### PR TITLE
Update Resync interval from 60minutes to 1minute

### DIFF
--- a/validation/rbac/grb/grb_status_field_test.go
+++ b/validation/rbac/grb/grb_status_field_test.go
@@ -98,8 +98,8 @@ func (grbs *GlobalRoleBindingStatusFieldTestSuite) TestGlobalRoleBindingStatusFi
 	require.NoError(grbs.T(), err)
 	require.NotEmpty(grbs.T(), grb, "Global Role Binding not found for the user")
 
-	log.Info("Add environment variable CATTLE_RESYNC_DEFAULT and set it to 60 seconds")
-	err = deployment.UpdateOrRemoveEnvVarForDeployment(grbs.client, deploymentNamespace, deploymentName, deploymentEnvVarName, "60")
+	log.Info("Add environment variable CATTLE_RESYNC_DEFAULT and set it to 1 minute")
+	err = deployment.UpdateOrRemoveEnvVarForDeployment(grbs.client, deploymentNamespace, deploymentName, deploymentEnvVarName, "1")
 	require.NoError(grbs.T(), err, "Failed to add environment variable")
 
 	log.Info("Verify that global role binding resourceVersion and generation have not been updated upon reconciliation")


### PR DESCRIPTION
CATTLE_RESYNC_DEFAULT accepts values in minutes, but it was mistakenly assumed to be in seconds. Updating the resync interval from 60 minutes to 1 minute.