### PR TITLE
Add HA sizing values and tests for StackState server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ replace (
 	github.com/docker/docker => github.com/docker/docker v20.10.27+incompatible // rancher-machine requires a replace is set
 
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20191219222812-2987a591a72c
+	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20191219222812-2987a591a72c
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20250212213103-5c3550f55322
 	github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20250212213103-5c3550f55322
 

--- a/interoperability/charts/stackstate.go
+++ b/interoperability/charts/stackstate.go
@@ -61,7 +61,7 @@ func InstallStackStateServerChart(client *rancher.Client, installOptions *charts
 	stackstateChartInstallActionPayload := &charts.PayloadOpts{
 		InstallOptions: *installOptions,
 		Name:           StackStateServerChartRepo,
-		Namespace:      StackstateNamespace,
+		Namespace:      StackStateServerNamespace,
 		Host:           serverSetting.Value,
 	}
 
@@ -79,7 +79,7 @@ func InstallStackStateServerChart(client *rancher.Client, installOptions *charts
 		return err
 	}
 
-	watchAppInterface, err := catalogClient.Apps(StackstateNamespace).Watch(context.TODO(), metav1.ListOptions{
+	watchAppInterface, err := catalogClient.Apps(StackStateServerNamespace).Watch(context.TODO(), metav1.ListOptions{
 		FieldSelector:  "metadata.name=" + StackStateServerChartRepo,
 		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
 	})

--- a/interoperability/observability/config.go
+++ b/interoperability/observability/config.go
@@ -54,8 +54,8 @@ type PersistenceConfig struct {
 	Size string `json:"size" yaml:"size"`
 }
 
-// SizingConfig represents the sizing configuration values
-type SizingConfig struct {
+// SizingConfigNonHA represents the sizing configuration values
+type SizingConfigNonHA struct {
 	Clickhouse struct {
 		ReplicaCount int               `json:"replicaCount" yaml:"replicaCount"`
 		Persistence  PersistenceConfig `json:"persistence" yaml:"persistence"`
@@ -133,6 +133,392 @@ type SizingConfig struct {
 			} `json:"server" yaml:"server"`
 		} `json:"components" yaml:"components"`
 	} `json:"stackstate" yaml:"stackstate"`
+}
+
+type SizingConfigHA struct {
+	Clickhouse struct {
+		ReplicaCount int `yaml:"replicaCount"`
+		Persistence  struct {
+			Size string `yaml:"size"`
+		} `yaml:"persistence"`
+	} `yaml:"clickhouse"`
+	Elasticsearch struct {
+		VolumeClaimTemplate struct {
+			Resources struct {
+				Requests struct {
+					Storage string `yaml:"storage"`
+				} `yaml:"requests"`
+			} `yaml:"resources"`
+		} `yaml:"volumeClaimTemplate"`
+	} `yaml:"elasticsearch"`
+	Hbase struct {
+		Version    string `yaml:"version"`
+		Deployment struct {
+			Mode string `yaml:"mode"`
+		} `yaml:"deployment"`
+		Hbase struct {
+			Console struct {
+				Resources struct {
+					Requests struct {
+						CPU string `yaml:"cpu"`
+					} `yaml:"requests"`
+				} `yaml:"resources"`
+			} `yaml:"console"`
+			Master struct {
+				Resources struct {
+					Requests struct {
+						CPU string `yaml:"cpu"`
+					} `yaml:"requests"`
+					Limits struct {
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+						CPU              string `yaml:"cpu"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"master"`
+			Regionserver struct {
+				Resources struct {
+					Requests struct {
+						CPU string `yaml:"cpu"`
+					} `yaml:"requests"`
+					Limits struct {
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+						CPU              string `yaml:"cpu"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"regionserver"`
+		} `yaml:"hbase"`
+		Hdfs struct {
+			Datanode struct {
+				Resources struct {
+					Requests struct {
+						CPU string `yaml:"cpu"`
+					} `yaml:"requests"`
+					Limits struct {
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+						CPU              string `yaml:"cpu"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"datanode"`
+			Namenode struct {
+				Resources struct {
+					Requests struct {
+						CPU string `yaml:"cpu"`
+					} `yaml:"requests"`
+					Limits struct {
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+						CPU              string `yaml:"cpu"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"namenode"`
+			Secondarynamenode struct {
+				Enabled   bool `yaml:"enabled"`
+				Resources struct {
+					Requests struct {
+						CPU string `yaml:"cpu"`
+					} `yaml:"requests"`
+					Limits struct {
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"secondarynamenode"`
+		} `yaml:"hdfs"`
+		Tephra struct {
+			Resources struct {
+				Limits struct {
+					Memory string `yaml:"memory"`
+					CPU    string `yaml:"cpu"`
+				} `yaml:"limits"`
+				Requests struct {
+					Memory string `yaml:"memory"`
+					CPU    string `yaml:"cpu"`
+				} `yaml:"requests"`
+			} `yaml:"resources"`
+			ReplicaCount int `yaml:"replicaCount"`
+		} `yaml:"tephra"`
+	} `yaml:"hbase"`
+	Kafka struct {
+		TransactionStateLogReplicationFactor int `yaml:"transactionStateLogReplicationFactor"`
+		Resources                            struct {
+			Requests struct {
+				CPU    string `yaml:"cpu"`
+				Memory string `yaml:"memory"`
+			} `yaml:"requests"`
+			Limits struct {
+				CPU              string `yaml:"cpu"`
+				Memory           string `yaml:"memory"`
+				EphemeralStorage string `yaml:"ephemeral-storage"`
+			} `yaml:"limits"`
+		} `yaml:"resources"`
+	} `yaml:"kafka"`
+	Stackstate struct {
+		Experimental struct {
+			Server struct {
+				Split bool `yaml:"split"`
+			} `yaml:"server"`
+		} `yaml:"experimental"`
+		Components struct {
+			All struct {
+				ExtraEnv struct {
+					Open struct {
+						CONFIGFORCEStackstateAgentsAgentLimit string `yaml:"CONFIG_FORCE_stackstate_agents_agentLimit"`
+					} `yaml:"open"`
+				} `yaml:"extraEnv"`
+			} `yaml:"all"`
+			API struct {
+				Resources struct {
+					Requests struct {
+						CPU    string `yaml:"cpu"`
+						Memory string `yaml:"memory"`
+					} `yaml:"requests"`
+					Limits struct {
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+						CPU              string `yaml:"cpu"`
+						Memory           string `yaml:"memory"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"api"`
+			Checks struct {
+				Resources struct {
+					Requests struct {
+						CPU    string `yaml:"cpu"`
+						Memory string `yaml:"memory"`
+					} `yaml:"requests"`
+					Limits struct {
+						CPU              string `yaml:"cpu"`
+						Memory           string `yaml:"memory"`
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"checks"`
+			HealthSync struct {
+				Resources struct {
+					Limits struct {
+						Memory           string `yaml:"memory"`
+						CPU              string `yaml:"cpu"`
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+					} `yaml:"limits"`
+					Requests struct {
+						Memory string `yaml:"memory"`
+						CPU    string `yaml:"cpu"`
+					} `yaml:"requests"`
+				} `yaml:"resources"`
+				Sizing struct {
+					BaseMemoryConsumption string `yaml:"baseMemoryConsumption"`
+				} `yaml:"sizing"`
+			} `yaml:"healthSync"`
+			Initializer struct {
+				Resources struct {
+					Requests struct {
+						CPU string `yaml:"cpu"`
+					} `yaml:"requests"`
+					Limits struct {
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"initializer"`
+			Notification struct {
+				Resources struct {
+					Requests struct {
+						CPU    string `yaml:"cpu"`
+						Memory string `yaml:"memory"`
+					} `yaml:"requests"`
+					Limits struct {
+						CPU    string `yaml:"cpu"`
+						Memory string `yaml:"memory"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"notification"`
+			Router struct {
+				Resources struct {
+					Requests struct {
+						CPU string `yaml:"cpu"`
+					} `yaml:"requests"`
+					Limits struct {
+						CPU              string `yaml:"cpu"`
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"router"`
+			Slicing struct {
+				Resources struct {
+					Requests struct {
+						CPU string `yaml:"cpu"`
+					} `yaml:"requests"`
+					Limits struct {
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"slicing"`
+			State struct {
+				Resources struct {
+					Limits struct {
+						CPU              string `yaml:"cpu"`
+						Memory           string `yaml:"memory"`
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+					} `yaml:"limits"`
+					Requests struct {
+						CPU    string `yaml:"cpu"`
+						Memory string `yaml:"memory"`
+					} `yaml:"requests"`
+				} `yaml:"resources"`
+			} `yaml:"state"`
+			Sync struct {
+				TmpToPVC struct {
+					VolumeSize string `yaml:"volumeSize"`
+				} `yaml:"tmpToPVC"`
+				Resources struct {
+					Limits struct {
+						CPU              string `yaml:"cpu"`
+						Memory           string `yaml:"memory"`
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+					} `yaml:"limits"`
+					Requests struct {
+						CPU    string `yaml:"cpu"`
+						Memory string `yaml:"memory"`
+					} `yaml:"requests"`
+				} `yaml:"resources"`
+			} `yaml:"sync"`
+			E2Es struct {
+				Resources struct {
+					Requests struct {
+						Memory string `yaml:"memory"`
+						CPU    string `yaml:"cpu"`
+					} `yaml:"requests"`
+					Limits struct {
+						Memory string `yaml:"memory"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"e2es"`
+			Correlate struct {
+				ReplicaCount int `yaml:"replicaCount"`
+				Resources    struct {
+					Limits struct {
+						CPU    int    `yaml:"cpu"`
+						Memory string `yaml:"memory"`
+					} `yaml:"limits"`
+					Requests struct {
+						CPU              int    `yaml:"cpu"`
+						Memory           string `yaml:"memory"`
+						EphemeralStorage string `yaml:"ephemeral-storage"`
+					} `yaml:"requests"`
+				} `yaml:"resources"`
+			} `yaml:"correlate"`
+			Receiver struct {
+				Split struct {
+					Enabled bool `yaml:"enabled"`
+					Base    struct {
+						Resources struct {
+							Requests struct {
+								Memory string `yaml:"memory"`
+								CPU    string `yaml:"cpu"`
+							} `yaml:"requests"`
+							Limits struct {
+								Memory string `yaml:"memory"`
+								CPU    string `yaml:"cpu"`
+							} `yaml:"limits"`
+						} `yaml:"resources"`
+					} `yaml:"base"`
+					ProcessAgent struct {
+						Resources struct {
+							Requests struct {
+								Memory string `yaml:"memory"`
+								CPU    string `yaml:"cpu"`
+							} `yaml:"requests"`
+							Limits struct {
+								Memory string `yaml:"memory"`
+								CPU    string `yaml:"cpu"`
+							} `yaml:"limits"`
+						} `yaml:"resources"`
+					} `yaml:"processAgent"`
+					Logs struct {
+						Resources struct {
+							Requests struct {
+								Memory string `yaml:"memory"`
+								CPU    string `yaml:"cpu"`
+							} `yaml:"requests"`
+							Limits struct {
+								Memory string `yaml:"memory"`
+								CPU    string `yaml:"cpu"`
+							} `yaml:"limits"`
+						} `yaml:"resources"`
+					} `yaml:"logs"`
+				} `yaml:"split"`
+				ExtraEnv struct {
+					Open struct {
+						CONFIGFORCEAkkaHTTPHostConnectionPoolMaxOpenRequests string `yaml:"CONFIG_FORCE_akka_http_host__connection__pool_max__open__requests"`
+					} `yaml:"open"`
+				} `yaml:"extraEnv"`
+			} `yaml:"receiver"`
+			Vmagent struct {
+				Resources struct {
+					Limits struct {
+						CPU    string `yaml:"cpu"`
+						Memory string `yaml:"memory"`
+					} `yaml:"limits"`
+					Requests struct {
+						CPU    string `yaml:"cpu"`
+						Memory string `yaml:"memory"`
+					} `yaml:"requests"`
+				} `yaml:"resources"`
+			} `yaml:"vmagent"`
+			UI struct {
+				ReplicaCount int `yaml:"replicaCount"`
+			} `yaml:"ui"`
+		} `yaml:"components"`
+	} `yaml:"stackstate"`
+	VictoriaMetrics0 struct {
+		Server struct {
+			Resources struct {
+				Requests struct {
+					CPU    int    `yaml:"cpu"`
+					Memory string `yaml:"memory"`
+				} `yaml:"requests"`
+				Limits struct {
+					CPU    int    `yaml:"cpu"`
+					Memory string `yaml:"memory"`
+				} `yaml:"limits"`
+			} `yaml:"resources"`
+		} `yaml:"server"`
+		Backup struct {
+			Vmbackup struct {
+				Resources struct {
+					Requests struct {
+						Memory string `yaml:"memory"`
+					} `yaml:"requests"`
+					Limits struct {
+						Memory string `yaml:"memory"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"vmbackup"`
+		} `yaml:"backup"`
+	} `yaml:"victoria-metrics-0"`
+	VictoriaMetrics1 struct {
+		Enabled bool `yaml:"enabled"`
+		Server  struct {
+			Resources struct {
+				Requests struct {
+					CPU    int    `yaml:"cpu"`
+					Memory string `yaml:"memory"`
+				} `yaml:"requests"`
+				Limits struct {
+					CPU    int    `yaml:"cpu"`
+					Memory string `yaml:"memory"`
+				} `yaml:"limits"`
+			} `yaml:"resources"`
+		} `yaml:"server"`
+		Backup struct {
+			Vmbackup struct {
+				Resources struct {
+					Requests struct {
+						Memory string `yaml:"memory"`
+					} `yaml:"requests"`
+					Limits struct {
+						Memory string `yaml:"memory"`
+					} `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"vmbackup"`
+		} `yaml:"backup"`
+	} `yaml:"victoria-metrics-1"`
 }
 
 type IngressConfig struct {

--- a/validation/observability/resources/150-ha_sizing_values.yaml
+++ b/validation/observability/resources/150-ha_sizing_values.yaml
@@ -1,0 +1,255 @@
+---
+# Source: suse-observability-values/templates/sizing_values.yaml
+# profile 150-ha
+clickhouse:
+  replicaCount: 1
+  persistence:
+    size: 100Gi
+
+elasticsearch:
+  volumeClaimTemplate:
+    resources:
+      requests:
+        storage: 200Gi
+
+hbase:
+  version: "2.5"
+  deployment:
+    mode: "Distributed"
+  hbase:
+    console:
+      resources:
+        requests:
+          cpu: "20m"
+    master:
+      resources:
+        requests:
+          cpu: "500m"
+        limits:
+          ephemeral-storage: "20Mi"
+          cpu: "1000m"
+    regionserver:
+      resources:
+        requests:
+          cpu: "2000m"
+        limits:
+          ephemeral-storage: "100Mi"
+          cpu: "4000m"
+  hdfs:
+    datanode:
+      resources:
+        requests:
+          cpu: "600m"
+        limits:
+          ephemeral-storage: "70Mi"
+          cpu: "1200m"
+    namenode:
+      resources:
+        requests:
+          cpu: "200m"
+        limits:
+          ephemeral-storage: "70Mi"
+          cpu: "400m"
+    secondarynamenode:
+      enabled: true
+      resources:
+        requests:
+          cpu: "10m"
+        limits:
+          ephemeral-storage: "70Mi"
+  tephra:
+    resources:
+      limits:
+        memory: "1Gi"
+        cpu: "1000m"
+      requests:
+        memory: "1Gi"
+        cpu: "500m"
+    replicaCount: 2
+kafka:
+  transactionStateLogReplicationFactor: 1
+  resources:
+    requests:
+      cpu: "1"
+      memory: "3Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+      ephemeral-storage: "70Mi"
+
+stackstate:
+  experimental:
+    server:
+      split: true
+
+  components:
+    all:
+      extraEnv:
+        open:
+          CONFIG_FORCE_stackstate_agents_agentLimit: "150"
+    api:
+      resources:
+        requests:
+          cpu: "1500m"
+          memory: "4Gi"
+        limits:
+          ephemeral-storage: "800Mi"
+          cpu: "3000m"
+          memory: "4Gi"
+    checks:
+      resources:
+        requests:
+          cpu: "3000m"
+          memory: 5Gi
+        limits:
+          cpu: "6000m"
+          memory: 5Gi
+          ephemeral-storage: "700Mi"
+    healthSync:
+      resources:
+        limits:
+          memory: 5Gi
+          cpu: "2000m"
+          ephemeral-storage: "650Mi"
+        requests:
+          memory: 5Gi
+          cpu: "1000m"
+      sizing:
+        baseMemoryConsumption: "1200Mi"
+    initializer:
+      resources:
+        requests:
+          cpu: "50m"
+        limits:
+          ephemeral-storage: "60Mi"
+    notification:
+      resources:
+        requests:
+          cpu: 500m
+          memory: "3000Mi"
+        limits:
+          cpu: 1000m
+          memory: "3000Mi"
+    router:
+      resources:
+        requests:
+          cpu: "120m"
+        limits:
+          cpu: "240m"
+          ephemeral-storage: "60Mi"
+    slicing:
+      resources:
+        requests:
+          cpu: "300m"
+        limits:
+          ephemeral-storage: "60Mi"
+    state:
+      resources:
+        limits:
+          cpu: "4"
+          memory: "4000Mi"
+          ephemeral-storage: "700Mi"
+        requests:
+          cpu: "2"
+          memory: "4000Mi"
+    sync:
+      tmpToPVC:
+        volumeSize: 10Gi
+      resources:
+        limits:
+          cpu: "4000m"
+          memory: "6500Mi"
+          ephemeral-storage: "700Mi"
+        requests:
+          cpu: "2000m"
+          memory: "6500Mi"
+    e2es:
+      resources:
+        requests:
+          memory: "512Mi"
+          cpu: "50m"
+        limits:
+          memory: "512Mi"
+    correlate:
+      replicaCount: 3
+      resources:
+        limits:
+          cpu: 6
+          memory: 3500Mi
+        requests:
+          cpu: 3
+          memory: 3500Mi
+          ephemeral-storage: "60Mi"
+    receiver:
+      split:
+        enabled: true
+        base:
+          resources:
+            requests:
+              memory: "5500Mi"
+              cpu: "4000m"
+            limits:
+              memory: "5500Mi"
+              cpu: "8000m"
+        processAgent:
+          resources:
+            requests:
+              memory: "2500Mi"
+              cpu: "1000m"
+            limits:
+              memory: "2500Mi"
+              cpu: "2000m"
+        logs:
+          resources:
+            requests:
+              memory: "3Gi"
+              cpu: "1000m"
+            limits:
+              memory: "3Gi"
+              cpu: "2000m"
+      extraEnv:
+        open:
+          CONFIG_FORCE_akka_http_host__connection__pool_max__open__requests: "256"
+    vmagent:
+      resources:
+        limits:
+          cpu: 3000m
+          memory: "1500Mi"
+        requests:
+          cpu: 1500m
+          memory: "1500Mi"
+    ui:
+      replicaCount: 2
+victoria-metrics-0:
+  server:
+    resources:
+      requests:
+        cpu: 2
+        memory: 9Gi
+      limits:
+        cpu: 4
+        memory: 9Gi
+  backup:
+    vmbackup:
+      resources:
+        requests:
+          memory: 512Mi
+        limits:
+          memory: 512Mi
+victoria-metrics-1:
+  enabled: true
+  server:
+    resources:
+      requests:
+        cpu: 2
+        memory: 9Gi
+      limits:
+        cpu: 4
+        memory: 9Gi
+  backup:
+    vmbackup:
+      resources:
+        requests:
+          memory: 512Mi
+        limits:
+          memory: 512Mi

--- a/validation/observability/resources/150-ha_sizing_values.yaml
+++ b/validation/observability/resources/150-ha_sizing_values.yaml
@@ -1,4 +1,3 @@
----
 # Source: suse-observability-values/templates/sizing_values.yaml
 # profile 150-ha
 clickhouse:

--- a/validation/observability/stackstate_server_test.go
+++ b/validation/observability/stackstate_server_test.go
@@ -93,7 +93,7 @@ func (sss *StackStateServerTestSuite) SetupSuite() {
 	}
 	require.NoError(sss.T(), err)
 
-	latestSSVersion, err := sss.client.Catalog.GetLatestChartVersion(interoperablecharts.StackStateServerChartRepo, observabilityChartName)
+	latestSSVersion, err := sss.catalogClient.GetLatestChartVersion(interoperablecharts.StackStateServerChartRepo, observabilityChartName)
 	require.NoError(sss.T(), err)
 
 	sss.stackstateChartInstallOptions = &charts.InstallOptions{

--- a/validation/observability/stackstate_server_test.go
+++ b/validation/observability/stackstate_server_test.go
@@ -103,7 +103,7 @@ func (sss *StackStateServerTestSuite) SetupSuite() {
 	}
 }
 
-func (sss *StackStateServerTestSuite) TestInstallStackState() {
+func (sss *StackStateServerTestSuite) TestInstallStackStateServerNonHAValues() {
 	subsession := sss.session.NewSession()
 	defer subsession.Cleanup()
 
@@ -174,6 +174,105 @@ func (sss *StackStateServerTestSuite) TestInstallStackState() {
 	systemProjectID := strings.Split(systemProject.ID, ":")[1]
 
 	sss.Run("Install SUSE Observability Server Chart with non HA values", func() {
+		err = interoperablecharts.InstallStackStateServerChart(sss.client, sss.stackstateChartInstallOptions, systemProjectID, mergedValues)
+		require.NoError(sss.T(), err)
+		log.Info("Stackstate server chart installed successfully")
+
+		sss.T().Log("Verifying the deployments of stackstate server chart to have expected number of available replicas")
+		err = extencharts.WatchAndWaitDeployments(sss.client, sss.cluster.ID, interoperablecharts.StackStateServerNamespace, meta.ListOptions{})
+		require.NoError(sss.T(), err)
+
+		sss.T().Log("Verifying the daemonsets of stackstate server chart to have expected number of available replicas nodes")
+		err = extencharts.WatchAndWaitDaemonSets(sss.client, sss.cluster.ID, interoperablecharts.StackStateServerNamespace, meta.ListOptions{})
+		require.NoError(sss.T(), err)
+
+		clusterObject, _, _ := extensionscluster.GetProvisioningClusterByName(sss.client, sss.client.RancherConfig.ClusterName, fleet.Namespace)
+		var clusterName string
+		if clusterObject != nil {
+			status := &provv1.ClusterStatus{}
+			err := steveV1.ConvertToK8sType(clusterObject.Status, status)
+			require.NoError(sss.T(), err)
+			clusterName = status.ClusterName
+		} else {
+			clusterName, err = extensionscluster.GetClusterIDByName(sss.client, sss.client.RancherConfig.ClusterName)
+			require.NoError(sss.T(), err)
+		}
+		podErrors := pods.StatusPods(sss.client, clusterName)
+		require.Empty(sss.T(), podErrors)
+	})
+}
+
+func (sss *StackStateServerTestSuite) TestInstallStackStateServerHAValues() {
+	subsession := sss.session.NewSession()
+	defer subsession.Cleanup()
+
+	var stackstateConfigs observability.StackStateConfig
+	config.LoadConfig(stackStateConfigFileKey, &stackstateConfigs)
+
+	baseConfig := observability.BaseConfig{
+		Global: struct {
+			ImageRegistry string `json:"imageRegistry" yaml:"imageRegistry"`
+		}{
+			ImageRegistry: "registry.rancher.com",
+		},
+		Stackstate: observability.StackstateServerConfig{
+			BaseUrl: stackstateConfigs.Url,
+			Authentication: observability.AuthenticationConfig{
+				AdminPassword: stackstateConfigs.AdminPassword,
+			},
+			ApiKey: observability.ApiKeyConfig{
+				Key: stackstateConfigs.ClusterApiKey,
+			},
+			License: observability.LicenseConfig{
+				Key: stackstateConfigs.License,
+			},
+		},
+	}
+
+	ingressConfig := observability.IngressConfig{
+		Ingress: observability.Ingress{
+			Enabled: true,
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/proxy-body-size": "50m",
+			},
+			Hosts: []observability.Host{
+				{
+					Host: stackstateConfigs.Url,
+				},
+			},
+			TLS: []observability.TLSConfig{
+				{
+					Hosts:      []string{stackstateConfigs.Url},
+					SecretName: "tls-secret",
+				},
+			},
+		},
+	}
+
+	sizingConfigData, err := os.ReadFile("resources/150-ha_sizing_values.yaml")
+	require.NoError(sss.T(), err)
+
+	var sizingConfig observability.SizingConfig
+	err = yaml.Unmarshal(sizingConfigData, &sizingConfig)
+	require.NoError(sss.T(), err)
+
+	ingressConfigMap, err := interoperablecharts.StructToMap(ingressConfig)
+	require.NoError(sss.T(), err)
+
+	baseConfigMap, err := interoperablecharts.StructToMap(baseConfig)
+	require.NoError(sss.T(), err)
+
+	sizingConfigMap, err := interoperablecharts.StructToMap(sizingConfig)
+	require.NoError(sss.T(), err)
+
+	mergedValues := interoperablecharts.MergeValues(ingressConfigMap, baseConfigMap, sizingConfigMap)
+
+	systemProject, err := rancherProjects.GetProjectByName(sss.client, sss.cluster.ID, systemProject)
+	require.NoError(sss.T(), err)
+	require.NotNil(sss.T(), systemProject.ID, "System project is nil.")
+	systemProjectID := strings.Split(systemProject.ID, ":")[1]
+
+	sss.Run("Install SUSE Observability Server Chart with HA values", func() {
 		err = interoperablecharts.InstallStackStateServerChart(sss.client, sss.stackstateChartInstallOptions, systemProjectID, mergedValues)
 		require.NoError(sss.T(), err)
 		log.Info("Stackstate server chart installed successfully")

--- a/validation/observability/stackstate_server_test.go
+++ b/validation/observability/stackstate_server_test.go
@@ -103,7 +103,7 @@ func (sss *StackStateServerTestSuite) SetupSuite() {
 	}
 }
 
-func (sss *StackStateServerTestSuite) TestInstallStackStateServerNonHAValues() {
+func (sss *StackStateServerTestSuite) TestInstall() {
 	subsession := sss.session.NewSession()
 	defer subsession.Cleanup()
 
@@ -202,7 +202,7 @@ func (sss *StackStateServerTestSuite) TestInstallStackStateServerNonHAValues() {
 	})
 }
 
-func (sss *StackStateServerTestSuite) TestInstallStackStateServerHAValues() {
+func (sss *StackStateServerTestSuite) TestInstallHAValues() {
 	subsession := sss.session.NewSession()
 	defer subsession.Cleanup()
 

--- a/validation/observability/stackstate_server_test.go
+++ b/validation/observability/stackstate_server_test.go
@@ -93,7 +93,7 @@ func (sss *StackStateServerTestSuite) SetupSuite() {
 	}
 	require.NoError(sss.T(), err)
 
-	latestSSVersion, err := sss.catalogClient.GetLatestChartVersion(interoperablecharts.StackStateServerChartRepo, observabilityChartName)
+	latestSSVersion, err := sss.client.Catalog.GetLatestChartVersion(interoperablecharts.StackStateServerChartRepo, observabilityChartName)
 	require.NoError(sss.T(), err)
 
 	sss.stackstateChartInstallOptions = &charts.InstallOptions{

--- a/validation/observability/stackstate_server_test.go
+++ b/validation/observability/stackstate_server_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	// Third-party library imports
 	log "github.com/sirupsen/logrus"
@@ -93,6 +94,7 @@ func (sss *StackStateServerTestSuite) SetupSuite() {
 	}
 	require.NoError(sss.T(), err)
 
+	time.Sleep(10 * time.Second)
 	latestSSVersion, err := sss.catalogClient.GetLatestChartVersion(interoperablecharts.StackStateServerChartRepo, observabilityChartName)
 	require.NoError(sss.T(), err)
 
@@ -103,7 +105,7 @@ func (sss *StackStateServerTestSuite) SetupSuite() {
 	}
 }
 
-func (sss *StackStateServerTestSuite) TestInstall() {
+func (sss *StackStateServerTestSuite) TestInstallNonHA() {
 	subsession := sss.session.NewSession()
 	defer subsession.Cleanup()
 
@@ -153,7 +155,7 @@ func (sss *StackStateServerTestSuite) TestInstall() {
 	sizingConfigData, err := os.ReadFile("resources/10-nonha_sizing_values.yaml")
 	require.NoError(sss.T(), err)
 
-	var sizingConfig observability.SizingConfig
+	var sizingConfig observability.SizingConfigNonHA
 	err = yaml.Unmarshal(sizingConfigData, &sizingConfig)
 	require.NoError(sss.T(), err)
 
@@ -252,7 +254,7 @@ func (sss *StackStateServerTestSuite) TestInstallHAValues() {
 	sizingConfigData, err := os.ReadFile("resources/150-ha_sizing_values.yaml")
 	require.NoError(sss.T(), err)
 
-	var sizingConfig observability.SizingConfig
+	var sizingConfig observability.SizingConfigHA
 	err = yaml.Unmarshal(sizingConfigData, &sizingConfig)
 	require.NoError(sss.T(), err)
 

--- a/validation/observability/stackstate_server_test.go
+++ b/validation/observability/stackstate_server_test.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
-
 	// Third-party library imports
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -94,7 +92,6 @@ func (sss *StackStateServerTestSuite) SetupSuite() {
 	}
 	require.NoError(sss.T(), err)
 
-	time.Sleep(10 * time.Second)
 	latestSSVersion, err := sss.catalogClient.GetLatestChartVersion(interoperablecharts.StackStateServerChartRepo, observabilityChartName)
 	require.NoError(sss.T(), err)
 


### PR DESCRIPTION
Introduced a YAML configuration for HA sizing values and updated tests to validate StackState server deployments with both non-HA and HA configurations. Ensures proper resource allocation and functionality in high-availability scenarios.

Closes https://github.com/rancher/qa-tasks/issues/1665