### PR TITLE
adding check for forked repos of shepherd, rancher. Speed up verify-changes action via parallelism

### DIFF
--- a/.github/scripts/check-forked-repos.sh
+++ b/.github/scripts/check-forked-repos.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+if grep -q "github.com/.*rancher/shepherd =>" go.mod; then
+    echo "Error: Forked version of rancher/shepherd detected in go.mod"
+    exit 1
+fi
+if grep -q "github.com/.*rancher/shepherd =>" actions/go.mod; then
+    echo "Error: Forked version of rancher/shepherd detected in actions/go.mod"
+    exit 1
+fi
+
+if grep -q "github.com/.*rancher/rancher =>" go.mod; then
+    echo "Error: Forked version of rancher/rancher detected in go.mod"
+    exit 1
+fi
+if grep -q "github.com/.*rancher/rancher =>" actions/go.mod; then
+    echo "Error: Forked version of rancher/rancher detected in actions/go.mod"
+    exit 1
+fi

--- a/.github/scripts/check-forked-repos.sh
+++ b/.github/scripts/check-forked-repos.sh
@@ -2,20 +2,20 @@
 
 set -e
 
-if grep -q "github.com/.*rancher/shepherd =>" go.mod; then
+if grep -q "github.com/rancher/shepherd =>" go.mod; then
     echo "Error: Forked version of rancher/shepherd detected in go.mod"
     exit 1
 fi
-if grep -q "github.com/.*rancher/shepherd =>" actions/go.mod; then
+if grep -q "github.com/rancher/shepherd =>" actions/go.mod; then
     echo "Error: Forked version of rancher/shepherd detected in actions/go.mod"
     exit 1
 fi
 
-if grep -q "github.com/.*rancher/rancher =>" go.mod; then
+if grep -q "github.com/rancher/rancher =>" go.mod; then
     echo "Error: Forked version of rancher/rancher detected in go.mod"
     exit 1
 fi
-if grep -q "github.com/.*rancher/rancher =>" actions/go.mod; then
+if grep -q "github.com/rancher/rancher =>" actions/go.mod; then
     echo "Error: Forked version of rancher/rancher detected in actions/go.mod"
     exit 1
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,9 @@ jobs:
         run: ./.github/scripts/go-build.sh
 
   verify-golangci-lint:
-    name: verify-golangci-lint
+    name: verify-changes
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,19 @@ on:
       - 'main'
 
 jobs:
+  check-forks:
+    name: check-forks
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: recursive
+
+      - name: Check for Forked Branches
+        run: ./.github/scripts/check-forked-repos.sh
+
   verify-changes:
     name: verify-changes
     runs-on: ubuntu-latest
@@ -31,11 +44,11 @@ jobs:
 
       - name: Go Version
         run: go version
-
+    
       - name: Generate Golang
         run: |
           export PATH=$PATH:/home/runner/go/bin/
-      
+
       - name: Verify Go Mod
         run: ./.github/scripts/check-gomod.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
       - name: Check for Forked Branches
         run: ./.github/scripts/check-forked-repos.sh
 
-  verify-changes:
-    name: verify-changes
+  verify-gomod:
+    name: verify-gomod
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -54,6 +54,16 @@ jobs:
 
       - name: Build Packages
         run: ./.github/scripts/go-build.sh
+
+  verify-golangci-lint:
+    name: verify-golangci-lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: recursive
 
       - name: Golangci Lint
         uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0


### PR DESCRIPTION
This is to protect from accidentally merging PRs that point to fork'd repos of rancher or shepherd (since we often point to these during testing)

please check the commit CI checks for examples. 
addresses: https://github.com/rancher/qa-tasks/issues/1723