### PR TITLE
Updating RA Replacment tests with changes

### DIFF
--- a/actions/rbac/rbac.go
+++ b/actions/rbac/rbac.go
@@ -26,6 +26,7 @@ type Role string
 
 const (
 	Admin                     Role = "admin"
+	BaseUser                  Role = "user-base"
 	StandardUser              Role = "user"
 	ClusterOwner              Role = "cluster-owner"
 	ClusterMember             Role = "cluster-member"
@@ -44,6 +45,12 @@ const (
 	LocalCluster                   = "local"
 	UserKind                       = "User"
 	ImageName                      = "nginx"
+	ManageUsersVerb                = "manage-users"
+	ManagementAPIGroup             = "management.cattle.io"
+	UsersResource                  = "users"
+	UserAttributeResource          = "userattribute"
+	GroupsResource                 = "groups"
+	GroupMembersResource           = "groupmembers"
 )
 
 func (r Role) String() string {

--- a/actions/users/users.go
+++ b/actions/users/users.go
@@ -1,0 +1,23 @@
+package users
+
+import (
+	"fmt"
+	
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+)
+
+// UpdateUserPassword is an action to update a specific user's password
+func UpdateUserPassword(client *rancher.Client, user *management.User, password string) (error) {
+	setPasswordInput := management.SetPasswordInput{
+		NewPassword: password,
+	}
+
+	_, err := client.Management.User.ActionSetpassword(user, &setPasswordInput)
+	if err != nil {
+		return fmt.Errorf("failed to update password for user %s: %w", user.Name, err)
+	}
+
+	return nil
+}
+

--- a/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
+++ b/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
@@ -3,10 +3,12 @@ package globalroles
 import (
 	"testing"
 
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	extensionscluster "github.com/rancher/shepherd/extensions/clusters"
 	extensionsettings "github.com/rancher/shepherd/extensions/settings"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
 	"github.com/rancher/shepherd/pkg/config"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
@@ -14,7 +16,9 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioning/permutations"
 	"github.com/rancher/tests/actions/provisioninginput"
+	rbac "github.com/rancher/tests/actions/rbac"
 	"github.com/rancher/tests/actions/settings"
+	"github.com/rancher/tests/actions/users"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -51,18 +55,29 @@ func (ra *RestrictedAdminReplacementTestSuite) SetupSuite() {
 	require.NoError(ra.T(), err)
 }
 
+func (ra *RestrictedAdminReplacementTestSuite) createRestrictedAdminRoleAndUser(addManageUsersRule bool) (*v3.GlobalRole, *management.User, *rancher.Client) {
+	restrictedAdminReplacementRoleName := namegen.AppendRandomString("restricted-admin-replacement")
+	restrictedAdminReplacementRole := newRestrictedAdminReplacementTemplate(restrictedAdminReplacementRoleName)
+
+	if addManageUsersRule {
+		restrictedAdminReplacementRole.Rules = append(restrictedAdminReplacementRole.Rules, manageUsersVerb)
+	}
+
+	globalRole, user, err := createCustomGlobalRoleAndUser(ra.client, &restrictedAdminReplacementRole)
+	require.NoError(ra.T(), err, "failed to create global role and user")
+
+	userClient, err := ra.client.AsUser(user)
+	require.NoError(ra.T(), err, "failed to create user client")
+
+	return globalRole, user, userClient
+}
+
 func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCreateCluster() {
 	subSession := ra.session.NewSession()
 	defer subSession.Cleanup()
 
 	log.Info("Creating the replacement restricted admin global role")
-	restrictedAdminReplacementRoleName := namegen.AppendRandomString("restricted-admin-replacement")
-	restrictedAdminReplacementRole := newRestrictedAdminReplacementTemplate(restrictedAdminReplacementRoleName)
-	createdRaReplacementRole, createdRaReplacementUser, err := createCustomGlobalRoleAndUser(ra.client, &restrictedAdminReplacementRole)
-	require.NoError(ra.T(), err, "failed to create global role and user")
-
-	createdRAReplacementUserClient, err := ra.client.AsUser(createdRaReplacementUser)
-	require.NoError(ra.T(), err)
+	createdRaReplacementRole, createdRaReplacementUser, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(false)
 
 	ra.T().Logf("Verifying user %s with role %s can create a downstream cluster", createdRaReplacementUser.Name, createdRaReplacementRole.Name)
 	nodeRolesAll := []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
@@ -73,7 +88,7 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCre
 	clusterConfig := clusters.ConvertConfigToClusterConfig(&provisioningConfig)
 	clusterConfig.KubernetesVersion = ra.provisioningConfig.K3SKubernetesVersions[0]
 	k3sprovider, _, _, _ := permutations.GetClusterProvider(permutations.K3SProvisionCluster, (*clusterConfig.Providers)[0], &provisioningConfig)
-	clusterObject, err := provisioning.CreateProvisioningCluster(createdRAReplacementUserClient, *k3sprovider, clusterConfig, nil)
+	clusterObject, err := provisioning.CreateProvisioningCluster(createdRaReplacementUserClient, *k3sprovider, clusterConfig, nil)
 	require.NoError(ra.T(), err)
 
 	provisioning.VerifyCluster(ra.T(), ra.client, clusterConfig, clusterObject)
@@ -84,16 +99,10 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementLis
 	defer subSession.Cleanup()
 
 	log.Info("Creating the replacement restricted admin global role")
-	restrictedAdminReplacementRoleName := namegen.AppendRandomString("restricted-admin-replacement")
-	restrictedAdminReplacementRole := newRestrictedAdminReplacementTemplate(restrictedAdminReplacementRoleName)
-	createdRaReplacementRole, createdRaReplacementUser, err := createCustomGlobalRoleAndUser(ra.client, &restrictedAdminReplacementRole)
-	require.NoError(ra.T(), err, "failed to create global role and user")
-
-	createdRAReplacementUserClient, err := ra.client.AsUser(createdRaReplacementUser)
-	require.NoError(ra.T(), err)
+	createdRaReplacementRole, createdRaReplacementUser, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(false)
 
 	log.Infof("Verifying user %s with role %s can list global settings", createdRaReplacementUser.Name, createdRaReplacementRole.Name)
-	raReplacementUserSettingsList, err := settings.GetGlobalSettingNames(createdRAReplacementUserClient, ra.cluster.ID)
+	raReplacementUserSettingsList, err := settings.GetGlobalSettingNames(createdRaReplacementUserClient, ra.cluster.ID)
 	require.NoError(ra.T(), err)
 	adminGlobalSettingsList, err := settings.GetGlobalSettingNames(ra.client, ra.cluster.ID)
 	require.NoError(ra.T(), err)
@@ -107,15 +116,9 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCan
 	defer subSession.Cleanup()
 
 	log.Info("Creating the replacement restricted admin global role")
-	restrictedAdminReplacementRoleName := namegen.AppendRandomString("restricted-admin-replacement")
-	restrictedAdminReplacementRole := newRestrictedAdminReplacementTemplate(restrictedAdminReplacementRoleName)
-	_, createdRaReplacementUser, err := createCustomGlobalRoleAndUser(ra.client, &restrictedAdminReplacementRole)
-	require.NoError(ra.T(), err, "failed to create global role and user")
+	_, createdRaReplacementUser, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(false)
 
-	createdRAReplacementUserClient, err := ra.client.AsUser(createdRaReplacementUser)
-	require.NoError(ra.T(), err)
-
-	steveRAReplacementClient := createdRAReplacementUserClient.Steve
+	steveRAReplacementClient := createdRaReplacementUserClient.Steve
 	steveAdminClient := ra.client.Steve
 
 	log.Info("Getting kubeconfig-default-token-ttl-minutes setting")
@@ -126,6 +129,70 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCan
 	_, err = extensionsettings.UpdateGlobalSettings(steveRAReplacementClient, kubeConfigTokenSetting, "3")
 	require.Error(ra.T(), err)
 	require.Contains(ra.T(), err.Error(), "Resource type [management.cattle.io.setting] is not updatable")
+}
+
+func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCantUpdateAdminPassword() {
+	subSession := ra.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Creating the replacement restricted admin global role")
+	_, _, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(false)
+
+	adminUser, err := createUserWithBuiltinRole(ra.client, rbac.Admin)
+	require.NoError(ra.T(), err)
+
+	log.Info("Verifying user with restricted admin replacement role cannot update admin user password")
+	testPass := password.GenerateUserPassword("testpass-")
+	err = users.UpdateUserPassword(createdRaReplacementUserClient, adminUser, testPass)
+	require.Error(ra.T(), err)
+	require.Contains(ra.T(), err.Error(), "denied the request: request is attempting to modify user with more permissions than requester user")
+}
+
+func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCantDeleteAdmin() {
+	subSession := ra.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Creating the replacement restricted admin global role")
+	_, _, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(false)
+
+	adminUser, err := createUserWithBuiltinRole(ra.client, rbac.Admin)
+	require.NoError(ra.T(), err)
+
+	log.Info("Verifying user with restricted admin replacement role cannot delete admin user")
+	err = createdRaReplacementUserClient.Management.User.Delete(adminUser)
+	require.Error(ra.T(), err)
+	require.Contains(ra.T(), err.Error(), "denied the request: request is attempting to modify user with more permissions than requester user")
+}
+
+func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementWithManageUsersCanUpdateAdminPassword() {
+	subSession := ra.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Creating the replacement restricted admin global role with the manage-users verb")
+	_, _, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(true)
+
+	adminUser, err := createUserWithBuiltinRole(ra.client, rbac.Admin)
+	require.NoError(ra.T(), err)
+
+	log.Info("Verifying user with restricted admin replacement role with manage-users verb can update admin user password")
+	testPass := password.GenerateUserPassword("testpass-")
+	err = users.UpdateUserPassword(createdRaReplacementUserClient, adminUser, testPass)
+	require.NoError(ra.T(), err)
+}
+
+func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementWithManageUsersCanDeleteAdmin() {
+	subSession := ra.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Creating the replacement restricted admin global role with the manage-users verb")
+	_, _, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(true)
+
+	adminUser, err := createUserWithBuiltinRole(ra.client, rbac.Admin)
+	require.NoError(ra.T(), err)
+
+	log.Info("Verifying user with restricted admin replacement role with manage users verb can delete admin user")
+	err = createdRaReplacementUserClient.Management.User.Delete(adminUser)
+	require.NoError(ra.T(), err)
 }
 
 func TestRestrictedAdminReplacementTestSuite(t *testing.T) {

--- a/validation/rbac/globalroles/restrictedadmin_replacement_template.go
+++ b/validation/rbac/globalroles/restrictedadmin_replacement_template.go
@@ -2,6 +2,7 @@ package globalroles
 
 import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/tests/actions/rbac"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -103,3 +104,11 @@ func newRestrictedAdminReplacementTemplate(globalRoleName string) v3.GlobalRole 
 		},
 	}
 }
+
+var (
+	manageUsersVerb = rbacv1.PolicyRule{
+		Verbs:     []string{rbac.ManageUsersVerb},
+		APIGroups: []string{rbac.ManagementAPIGroup},
+		Resources: []string{rbac.UsersResource, rbac.UserAttributeResource, rbac.GroupsResource, rbac.GroupMembersResource},
+	}
+)

--- a/validation/rbac/globalroles/standarduser_manage_users_template.go
+++ b/validation/rbac/globalroles/standarduser_manage_users_template.go
@@ -1,0 +1,31 @@
+package globalroles
+
+import (
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/tests/actions/rbac"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newCustomGlobalRole(verbs []string) v3.GlobalRole {
+	name := namegen.AppendRandomString("custom-global-role-")
+	return v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{rbac.ManagementAPIGroup},
+				Resources: []string{rbac.UsersResource},
+				Verbs:     verbs,
+			},
+		},
+	}
+}
+
+var (
+	customGlobalRoleDelete      = newCustomGlobalRole([]string{"delete", "get", "list"})
+	customGlobalRoleEdit        = newCustomGlobalRole([]string{"patch", "update", "get", "list"})
+	customGlobalRoleManageUsers = newCustomGlobalRole([]string{rbac.ManageUsersVerb, "patch", "update", "delete", "get", "list"})
+)

--- a/validation/rbac/globalroles/standarduser_manage_users_test.go
+++ b/validation/rbac/globalroles/standarduser_manage_users_test.go
@@ -1,0 +1,156 @@
+package globalroles
+
+import (
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	extensionscluster "github.com/rancher/shepherd/extensions/clusters"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/rbac"
+	"github.com/rancher/tests/actions/users"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type StandardUserManageUsersTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+	cluster *management.Cluster
+}
+
+func (su *StandardUserManageUsersTestSuite) TearDownSuite() {
+	su.session.Cleanup()
+}
+
+func (su *StandardUserManageUsersTestSuite) SetupSuite() {
+	su.session = session.NewSession()
+
+	client, err := rancher.NewClient("", su.session)
+	require.NoError(su.T(), err)
+	su.client = client
+
+	log.Info("Getting cluster name from the config file and append cluster details in the struct.")
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(su.T(), clusterName, "Cluster name to install should be set")
+	clusterID, err := extensionscluster.GetClusterIDByName(su.client, clusterName)
+	require.NoError(su.T(), err, "Error getting cluster ID")
+	su.cluster, err = su.client.Management.Cluster.ByID(clusterID)
+	require.NoError(su.T(), err)
+}
+
+func (su *StandardUserManageUsersTestSuite) TestStandardUserWithoutManageUsersDelete() {
+	subSession := su.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Creating a standard user with delete custom global role")
+	_, standardUser, err := createCustomGlobalRoleAndUser(su.client, &customGlobalRoleDelete)
+	require.NoError(su.T(), err, "failed to create global role and user")
+
+	standardUserClient, err := su.client.AsUser(standardUser)
+	require.NoError(su.T(), err)
+
+	adminUser, err := createUserWithBuiltinRole(su.client, rbac.Admin)
+	require.NoError(su.T(), err)
+
+	baseUser, err := createUserWithBuiltinRole(su.client, rbac.BaseUser)
+	require.NoError(su.T(), err)
+
+	log.Info("Verifying standard user with delete custom global role can delete a user with lower permissions")
+	err = standardUserClient.Management.User.Delete(baseUser)
+	require.NoError(su.T(), err)
+
+	log.Info("Verifying standard user with delete custom global role cannot delete a user with higher permissions")
+	err = standardUserClient.Management.User.Delete(adminUser)
+	require.Error(su.T(), err)
+	require.Contains(su.T(), err.Error(), "denied the request: request is attempting to modify user with more permissions than requester user")
+}
+
+func (su *StandardUserManageUsersTestSuite) TestStandardUserWithoutManageUsersEdit() {
+	subSession := su.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Creating a standard user with edit custom global role")
+	_, standardUser, err := createCustomGlobalRoleAndUser(su.client, &customGlobalRoleEdit)
+	require.NoError(su.T(), err, "failed to create global role and user")
+
+	standardUserClient, err := su.client.AsUser(standardUser)
+	require.NoError(su.T(), err)
+
+	adminUser, err := createUserWithBuiltinRole(su.client, rbac.Admin)
+	require.NoError(su.T(), err)
+
+	baseUser, err := createUserWithBuiltinRole(su.client, rbac.BaseUser)
+	require.NoError(su.T(), err)
+
+	log.Info("Verifying standard user with edit custom global role can update password of a user with lower permissions")
+	var testPass = password.GenerateUserPassword("testpass-")
+	err = users.UpdateUserPassword(standardUserClient, baseUser, testPass)
+	require.NoError(su.T(), err)
+
+	log.Info("Verifying standard user with edit custom global role cannot update password of a user with higher permissions")
+	err = users.UpdateUserPassword(standardUserClient, adminUser, testPass)
+	require.Error(su.T(), err)
+	require.Contains(su.T(), err.Error(), "denied the request: request is attempting to modify user with more permissions than requester user")
+}
+
+func (su *StandardUserManageUsersTestSuite) TestStandardUserWithManageUsersDelete() {
+	subSession := su.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Creating a standard user with manage-users verb on users resource")
+	_, standardUser, err := createCustomGlobalRoleAndUser(su.client, &customGlobalRoleManageUsers)
+	require.NoError(su.T(), err, "failed to create global role and user")
+
+	standardUserClient, err := su.client.AsUser(standardUser)
+	require.NoError(su.T(), err)
+
+	adminUser, err := createUserWithBuiltinRole(su.client, rbac.Admin)
+	require.NoError(su.T(), err)
+
+	baseUser, err := createUserWithBuiltinRole(su.client, rbac.BaseUser)
+	require.NoError(su.T(), err)
+
+	log.Info("Verifying standard user with custom global role including manage-users verb can delete a user with lower permissions")
+	err = standardUserClient.Management.User.Delete(baseUser)
+
+	require.NoError(su.T(), err)
+
+	log.Info("Verifying standard user with custom global role including manage-users verb can delete a user with higher permissions")
+	err = standardUserClient.Management.User.Delete(adminUser)
+	require.NoError(su.T(), err)
+}
+
+func (su *StandardUserManageUsersTestSuite) TestStandardUserWithManageUsersEdit() {
+	subSession := su.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Creating a standard user with manage-users verb on users resource")
+	_, standardUser, err := createCustomGlobalRoleAndUser(su.client, &customGlobalRoleManageUsers)
+	require.NoError(su.T(), err, "failed to create global role and user")
+
+	standardUserClient, err := su.client.AsUser(standardUser)
+	require.NoError(su.T(), err)
+
+	adminUser, err := createUserWithBuiltinRole(su.client, rbac.Admin)
+	require.NoError(su.T(), err)
+
+	baseUser, err := createUserWithBuiltinRole(su.client, rbac.BaseUser)
+	require.NoError(su.T(), err)
+
+	log.Info("Verifying standard user with custom global role including manage-users verb can update password of a user with lower permissions")
+	var testPass = password.GenerateUserPassword("testpass-")
+	err = users.UpdateUserPassword(standardUserClient, baseUser, testPass)
+	require.NoError(su.T(), err)
+
+	log.Info("Verifying standard user with custom global role including manage-users verb can update password of a user with higher permissions")
+	err = users.UpdateUserPassword(standardUserClient, adminUser, testPass)
+	require.NoError(su.T(), err)
+}
+
+func TestStandardUserManageUsersTestSuite(t *testing.T) {
+	suite.Run(t, new(StandardUserManageUsersTestSuite))
+}


### PR DESCRIPTION
Updating restrictedadmin_replacement_role_test wrt changes to restricted admin replacement role and adding tests to cover the new manage-users verb for users resource. 