### PR TITLE
Update Qase reporter path

### DIFF
--- a/validation/pipeline/scripts/build_qase_reporter.sh
+++ b/validation/pipeline/scripts/build_qase_reporter.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-cd $(dirname $0)/../../../../../
+cd $(dirname $0)/../../../
 if [[ -z "${QASE_TEST_RUN_ID}" ]]; then
   echo "no test run ID is provided"
 else


### PR DESCRIPTION
### PR Description
When the tests were migrated over to the new repo, the Qase reporter was not updated to the new paths. This is causing results to not be properly reported. This small PR fixes that issue.