### PR TITLE
Update Ingress path from Exact to ImplementationSpecific

### DIFF
--- a/actions/etcdsnapshot/creates.go
+++ b/actions/etcdsnapshot/creates.go
@@ -691,7 +691,7 @@ func createAndVerifyResources(steveclient *steveV1.Client, containerImage string
 		return nil, nil, nil, nil, nil, errors.New("service name doesn't match spec")
 	}
 
-	path := extensionsingress.NewIngressPathTemplate(networking.PathTypeExact, ingressPath, serviceAppendName+initialWorkloadName, 80)
+	path := extensionsingress.NewIngressPathTemplate(networking.PathTypeImplementationSpecific, ingressPath, serviceAppendName+initialWorkloadName, 80)
 	ingressTemplate := extensionsingress.NewIngressTemplate(initialIngressName, defaultNamespace, "", []networking.HTTPIngressPath{path})
 
 	ingressResp, err := extensionsingress.CreateIngress(steveclient, initialIngressName, ingressTemplate)


### PR DESCRIPTION
### Issue: N/A

### PR Description
In the snapshot tests, occassionally there have been reports of the following error message: `ingress contains invalid paths: path /index.html cannot be used with pathType Exact`. Looking closer into it, we should be using `ImplementationSpecific` as the path and not `Exact`.