### PR TITLE
Updating Deprecated RA test with changes

### DIFF
--- a/validation/rbac/globalroles/deprecated_restrictedadmin_role_test.go
+++ b/validation/rbac/globalroles/deprecated_restrictedadmin_role_test.go
@@ -1,4 +1,4 @@
-//go:build 2.8 || 2.9 || 2.10
+//go:build (validation || infra.any || cluster.any || extended) && !stress && !sanity && (2.8 || 2.9 || 2.10)
 
 package globalroles
 
@@ -8,14 +8,16 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	extensionscluster "github.com/rancher/shepherd/extensions/clusters"
-	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
 	"github.com/rancher/shepherd/extensions/settings"
+	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/provisioning/permutations"
 	"github.com/rancher/tests/actions/provisioninginput"
 	rbac "github.com/rancher/tests/actions/rbac"
+	"github.com/rancher/tests/actions/users"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,13 +26,15 @@ import (
 
 type RestrictedAdminTestSuite struct {
 	suite.Suite
-	client  *rancher.Client
-	session *session.Session
-	cluster *management.Cluster
+	client             *rancher.Client
+	session            *session.Session
+	cluster            *management.Cluster
+	provisioningConfig *provisioninginput.Config
 }
 
 const (
 	restrictedAdmin rbac.Role = "restricted-admin"
+	manageUsers     rbac.Role = "users-manage"
 )
 
 func (ra *RestrictedAdminTestSuite) TearDownSuite() {
@@ -45,6 +49,9 @@ func (ra *RestrictedAdminTestSuite) SetupSuite() {
 
 	ra.client = client
 
+	ra.provisioningConfig = new(provisioninginput.Config)
+	config.LoadConfig(provisioninginput.ConfigurationFileKey, ra.provisioningConfig)
+
 	log.Info("Getting cluster name from the config file and append cluster details in the struct.")
 	clusterName := client.RancherConfig.ClusterName
 	require.NotEmptyf(ra.T(), clusterName, "Cluster name to install should be set")
@@ -54,34 +61,51 @@ func (ra *RestrictedAdminTestSuite) SetupSuite() {
 	require.NoError(ra.T(), err)
 }
 
-func (ra *RestrictedAdminTestSuite) TestRestrictedAdminCreateCluster() {
+func (ra *RestrictedAdminTestSuite) createRestrictedAdminAndAdminUser(addManageUsersRole bool) (*management.User, *management.User, *rancher.Client) {
+	var restrictedAdminUser *management.User
+	var restrictedAdminClient *rancher.Client
+	var err error
+
+	if addManageUsersRole {
+		log.Info("Creating the restricted admin user with manage users")
+		restrictedAdminUser, restrictedAdminClient, err = rbac.SetupUser(ra.client, restrictedAdmin.String(), manageUsers.String())
+	} else {
+		log.Info("Creating the restricted admin user")
+		restrictedAdminUser, restrictedAdminClient, err = rbac.SetupUser(ra.client, restrictedAdmin.String())
+	}
+	require.NoError(ra.T(), err)
+
+	log.Info("Creating the admin user")
+	adminUser, err := createUserWithBuiltinRole(ra.client, rbac.Admin)
+	require.NoError(ra.T(), err)
+
+	return restrictedAdminUser, adminUser, restrictedAdminClient
+}
+
+func (ra *RestrictedAdminTestSuite) TestRestrictedAdminCreateK3sCluster() {
 	subSession := ra.session.NewSession()
 	defer subSession.Cleanup()
 
+	log.Info("Creating the restricted admin global role")
 	_, restrictedAdminClient, err := rbac.SetupUser(ra.client, restrictedAdmin.String())
 	require.NoError(ra.T(), err)
-	ra.T().Logf("Validating restricted admin can create a downstream cluster")
-	userConfig := new(provisioninginput.Config)
-	config.LoadConfig(provisioninginput.ConfigurationFileKey, userConfig)
-	nodeProviders := userConfig.NodeProviders[0]
-	nodeAndRoles := []provisioninginput.NodePools{
-		provisioninginput.AllRolesNodePool,
-	}
-	externalNodeProvider := provisioning.ExternalNodeProviderSetup(nodeProviders)
-	clusterConfig := clusters.ConvertConfigToClusterConfig(userConfig)
-	clusterConfig.NodePools = nodeAndRoles
-	kubernetesVersion, err := kubernetesversions.Default(restrictedAdminClient, extensionscluster.RKE1ClusterType.String(), []string{})
+
+	ra.T().Logf("Verifying restricted admin can create a downstream cluster")
+	nodeRolesAll := []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
+	provisioningConfig := *ra.provisioningConfig
+	provisioningConfig.MachinePools = nodeRolesAll
+
+	log.Info("Setting up cluster config and provider for downstream k3s cluster")
+	clusterConfig := clusters.ConvertConfigToClusterConfig(&provisioningConfig)
+	clusterConfig.KubernetesVersion = ra.provisioningConfig.K3SKubernetesVersions[0]
+	k3sprovider, _, _, _ := permutations.GetClusterProvider(permutations.K3SProvisionCluster, (*clusterConfig.Providers)[0], &provisioningConfig)
+	clusterObject, err := provisioning.CreateProvisioningCluster(restrictedAdminClient, *k3sprovider, clusterConfig, nil)
 	require.NoError(ra.T(), err)
 
-	clusterConfig.KubernetesVersion = kubernetesVersion[0]
-	clusterConfig.CNI = userConfig.CNIs[0]
-	clusterObject, _, err := provisioning.CreateProvisioningRKE1CustomCluster(restrictedAdminClient, &externalNodeProvider, clusterConfig)
-	require.NoError(ra.T(), err)
-	provisioning.VerifyRKE1Cluster(ra.T(), restrictedAdminClient, clusterConfig, clusterObject)
+	provisioning.VerifyCluster(ra.T(), ra.client, clusterConfig, clusterObject)
 }
 
 func (ra *RestrictedAdminTestSuite) TestRestrictedAdminGlobalSettings() {
-
 	subSession := ra.session.NewSession()
 	defer subSession.Cleanup()
 
@@ -104,6 +128,9 @@ func (ra *RestrictedAdminTestSuite) TestRestrictedAdminGlobalSettings() {
 }
 
 func (ra *RestrictedAdminTestSuite) TestRestrictedAdminCantUpdateGlobalSettings() {
+	subSession := ra.session.NewSession()
+	defer subSession.Cleanup()
+
 	ra.T().Logf("Validating restrictedAdmin cannot edit global settings")
 
 	_, restrictedAdminClient, err := rbac.SetupUser(ra.client, restrictedAdmin.String())
@@ -118,6 +145,53 @@ func (ra *RestrictedAdminTestSuite) TestRestrictedAdminCantUpdateGlobalSettings(
 	_, err = settings.UpdateGlobalSettings(steveRestrictedAdminclient, kubeConfigTokenSetting, "3")
 	require.Error(ra.T(), err)
 	assert.Contains(ra.T(), err.Error(), "Resource type [management.cattle.io.setting] is not updatable")
+}
+
+func (ra *RestrictedAdminTestSuite) TestRestrictedAdminCantUpdateAdminPassword() {
+	subSession := ra.session.NewSession()
+	defer subSession.Cleanup()
+
+	_, adminUser, restrictedAdminClient := ra.createRestrictedAdminAndAdminUser(false)
+
+	log.Info("Verifying user with restricted admin replacement role cannot update admin user password")
+	testPass := password.GenerateUserPassword("testpass-")
+	err := users.UpdateUserPassword(restrictedAdminClient, adminUser, testPass)
+	require.Error(ra.T(), err)
+	require.Contains(ra.T(), err.Error(), "denied the request: request is attempting to modify user with more permissions than requester user")
+}
+
+func (ra *RestrictedAdminTestSuite) TestRestrictedAdminCantDeleteAdmin() {
+	subSession := ra.session.NewSession()
+	defer subSession.Cleanup()
+
+	_, adminUser, restrictedAdminClient := ra.createRestrictedAdminAndAdminUser(false)
+
+	log.Info("Verifying restricted admin cannot delete admin user")
+	err := restrictedAdminClient.Management.User.Delete(adminUser)
+	require.Error(ra.T(), err)
+	require.Contains(ra.T(), err.Error(), "denied the request: request is attempting to modify user with more permissions than requester user")
+}
+
+func (ra *RestrictedAdminTestSuite) TestRestrictedAdminWithManageUsersCanUpdateAdminPassword() {
+	subSession := ra.session.NewSession()
+	defer subSession.Cleanup()
+
+	_, adminUser, restrictedAdminClient := ra.createRestrictedAdminAndAdminUser(true)
+
+	log.Info("Verifying restricted admin with manage users can update admin user password")
+	testPass := password.GenerateUserPassword("testpass-")
+	err := users.UpdateUserPassword(restrictedAdminClient, adminUser, testPass)
+	require.NoError(ra.T(), err)
+}
+
+func (ra *RestrictedAdminTestSuite) TestRestrictedAdminWithManageUsersCanDeleteAdmin() {
+	subSession := ra.session.NewSession()
+	defer subSession.Cleanup()
+
+	_, adminUser, restrictedAdminClient := ra.createRestrictedAdminAndAdminUser(true)
+	log.Info("Verifying restricted admin with manage users can delete admin user")
+	err := restrictedAdminClient.Management.User.Delete(adminUser)
+	require.NoError(ra.T(), err)
 }
 
 func TestRestrictedAdminTestSuite(t *testing.T) {

--- a/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
+++ b/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
@@ -55,7 +55,7 @@ func (ra *RestrictedAdminReplacementTestSuite) SetupSuite() {
 	require.NoError(ra.T(), err)
 }
 
-func (ra *RestrictedAdminReplacementTestSuite) createRestrictedAdminRoleAndUser(addManageUsersRule bool) (*v3.GlobalRole, *management.User, *rancher.Client) {
+func (ra *RestrictedAdminReplacementTestSuite) createRestrictedAdminReplacementRoleAndUser(addManageUsersRule bool) (*v3.GlobalRole, *management.User, *rancher.Client) {
 	restrictedAdminReplacementRoleName := namegen.AppendRandomString("restricted-admin-replacement")
 	restrictedAdminReplacementRole := newRestrictedAdminReplacementTemplate(restrictedAdminReplacementRoleName)
 
@@ -77,7 +77,7 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCre
 	defer subSession.Cleanup()
 
 	log.Info("Creating the replacement restricted admin global role")
-	createdRaReplacementRole, createdRaReplacementUser, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(false)
+	createdRaReplacementRole, createdRaReplacementUser, createdRaReplacementUserClient := ra.createRestrictedAdminReplacementRoleAndUser(false)
 
 	ra.T().Logf("Verifying user %s with role %s can create a downstream cluster", createdRaReplacementUser.Name, createdRaReplacementRole.Name)
 	nodeRolesAll := []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
@@ -99,7 +99,7 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementLis
 	defer subSession.Cleanup()
 
 	log.Info("Creating the replacement restricted admin global role")
-	createdRaReplacementRole, createdRaReplacementUser, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(false)
+	createdRaReplacementRole, createdRaReplacementUser, createdRaReplacementUserClient := ra.createRestrictedAdminReplacementRoleAndUser(false)
 
 	log.Infof("Verifying user %s with role %s can list global settings", createdRaReplacementUser.Name, createdRaReplacementRole.Name)
 	raReplacementUserSettingsList, err := settings.GetGlobalSettingNames(createdRaReplacementUserClient, ra.cluster.ID)
@@ -116,7 +116,7 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCan
 	defer subSession.Cleanup()
 
 	log.Info("Creating the replacement restricted admin global role")
-	_, createdRaReplacementUser, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(false)
+	_, createdRaReplacementUser, createdRaReplacementUserClient := ra.createRestrictedAdminReplacementRoleAndUser(false)
 
 	steveRAReplacementClient := createdRaReplacementUserClient.Steve
 	steveAdminClient := ra.client.Steve
@@ -136,7 +136,7 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCan
 	defer subSession.Cleanup()
 
 	log.Info("Creating the replacement restricted admin global role")
-	_, _, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(false)
+	_, _, createdRaReplacementUserClient := ra.createRestrictedAdminReplacementRoleAndUser(false)
 
 	adminUser, err := createUserWithBuiltinRole(ra.client, rbac.Admin)
 	require.NoError(ra.T(), err)
@@ -153,7 +153,7 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCan
 	defer subSession.Cleanup()
 
 	log.Info("Creating the replacement restricted admin global role")
-	_, _, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(false)
+	_, _, createdRaReplacementUserClient := ra.createRestrictedAdminReplacementRoleAndUser(false)
 
 	adminUser, err := createUserWithBuiltinRole(ra.client, rbac.Admin)
 	require.NoError(ra.T(), err)
@@ -169,7 +169,7 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementWit
 	defer subSession.Cleanup()
 
 	log.Info("Creating the replacement restricted admin global role with the manage-users verb")
-	_, _, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(true)
+	_, _, createdRaReplacementUserClient := ra.createRestrictedAdminReplacementRoleAndUser(true)
 
 	adminUser, err := createUserWithBuiltinRole(ra.client, rbac.Admin)
 	require.NoError(ra.T(), err)
@@ -185,7 +185,7 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementWit
 	defer subSession.Cleanup()
 
 	log.Info("Creating the replacement restricted admin global role with the manage-users verb")
-	_, _, createdRaReplacementUserClient := ra.createRestrictedAdminRoleAndUser(true)
+	_, _, createdRaReplacementUserClient := ra.createRestrictedAdminReplacementRoleAndUser(true)
 
 	adminUser, err := createUserWithBuiltinRole(ra.client, rbac.Admin)
 	require.NoError(ra.T(), err)


### PR DESCRIPTION
Updating deprecated_restrictedadmin_role_test wrt backport changes to restricted admin role.

Also updates a function name in restrictedadmin_replacement_role_test. 