### PR TITLE
Migrate RBAC Daemonset Tests

### DIFF
--- a/actions/workloads/daemonset/daemonset.go
+++ b/actions/workloads/daemonset/daemonset.go
@@ -1,63 +1,50 @@
 package daemonset
 
 import (
-	"context"
-
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/extensions/unstructured"
+	"github.com/rancher/shepherd/extensions/charts"
 	"github.com/rancher/shepherd/extensions/workloads"
-	"github.com/rancher/shepherd/pkg/wrangler"
+	"github.com/rancher/tests/actions/kubeapi/clusters"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	appv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var DaemonsetGroupVersionResource = schema.GroupVersionResource{
-	Group:    "apps",
-	Version:  "v1",
-	Resource: "daemonsets",
-}
+// CreateDaemonset is a helper to create a daemonset using wrangler context
+func CreateDaemonset(client *rancher.Client, clusterID, namespaceName string, replicaCount int, secretName, configMapName string, useEnvVars, useVolumes, watchDaemonset bool) (*appv1.DaemonSet, error) {
+	wranglerContext, err := clusters.GetClusterWranglerContext(client, clusterID)
+	if err != nil {
+		return nil, err
+	}
 
-const (
-	DaemonsetSteveType = "apps.daemonset"
-)
-
-// CreateDaemonset is a helper to create a daemonset
-func CreateDaemonset(client *rancher.Client, clusterID, namespaceName string, replicaCount int, secretName, configMapName string, useEnvVars, useVolumes bool) (*appv1.DaemonSet, error) {
 	deploymentTemplate, err := deployment.CreateDeployment(client, clusterID, namespaceName, replicaCount, secretName, configMapName, useEnvVars, useVolumes, false, true)
 	if err != nil {
 		return nil, err
 	}
 
-	createdDaemonset := workloads.NewDaemonSetTemplate(deploymentTemplate.Name, namespaceName, deploymentTemplate.Spec.Template, true, nil)
-
-	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	daemonsetTemplate := workloads.NewDaemonSetTemplate(deploymentTemplate.Name, namespaceName, deploymentTemplate.Spec.Template, true, nil)
+	createdDaemonset, err := wranglerContext.Apps.DaemonSet().Create(daemonsetTemplate)
 	if err != nil {
 		return nil, err
 	}
 
-	daemonsetResource := dynamicClient.Resource(DaemonsetGroupVersionResource).Namespace(namespaceName)
-
-	_, err = daemonsetResource.Create(context.TODO(), unstructured.MustToUnstructured(createdDaemonset), metav1.CreateOptions{})
-	if err != nil {
-		return nil, err
+	if watchDaemonset {
+		err = charts.WatchAndWaitDaemonSets(client, clusterID, namespaceName, metav1.ListOptions{
+			FieldSelector: "metadata.name=" + createdDaemonset.Name,
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return createdDaemonset, nil
 }
 
-// UpdateDaemonset is a helper to update daemonsets
-func UpdateDaemonset(client *rancher.Client, clusterID, namespaceName string, daemonset *appv1.DaemonSet) (*appv1.DaemonSet, error) {
-	var wranglerContext *wrangler.Context
-	var err error
-
-	wranglerContext = client.WranglerContext
-	if clusterID != "local" {
-		wranglerContext, err = client.WranglerContext.DownStreamClusterWranglerContext(clusterID)
-		if err != nil {
-			return nil, err
-		}
+// UpdateDaemonset is a helper to update daemonsets using wrangler context
+func UpdateDaemonset(client *rancher.Client, clusterID, namespaceName string, daemonset *appv1.DaemonSet, watchDaemonset bool) (*appv1.DaemonSet, error) {
+	wranglerContext, err := clusters.GetClusterWranglerContext(client, clusterID)
+	if err != nil {
+		return nil, err
 	}
 
 	latestDaemonset, err := wranglerContext.Apps.DaemonSet().Get(namespaceName, daemonset.Name, metav1.GetOptions{})
@@ -72,23 +59,26 @@ func UpdateDaemonset(client *rancher.Client, clusterID, namespaceName string, da
 		return nil, err
 	}
 
-	return updatedDaemonset, err
+	if watchDaemonset {
+		err = charts.WatchAndWaitDaemonSets(client, clusterID, namespaceName, metav1.ListOptions{
+			FieldSelector: "metadata.name=" + updatedDaemonset.Name,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return updatedDaemonset, nil
 }
 
-// DeleteDaemonset is a helper to delete a daemonset
+// DeleteDaemonset is a helper to delete a daemonset using wrangler context
 func DeleteDaemonset(client *rancher.Client, clusterID string, daemonset *appv1.DaemonSet) error {
-	steveClient, err := client.Steve.ProxyDownstream(clusterID)
+	wranglerContext, err := clusters.GetClusterWranglerContext(client, clusterID)
 	if err != nil {
 		return err
 	}
 
-	daemonsetID := daemonset.Namespace + "/" + daemonset.Name
-	daemonsetResp, err := steveClient.SteveType(DaemonsetSteveType).ByID(daemonsetID)
-	if err != nil {
-		return err
-	}
-
-	err = steveClient.SteveType(DaemonsetSteveType).Delete(daemonsetResp)
+	err = wranglerContext.Apps.DaemonSet().Delete(daemonset.Namespace, daemonset.Name, &metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}

--- a/actions/workloads/daemonset/verify.go
+++ b/actions/workloads/daemonset/verify.go
@@ -2,10 +2,8 @@ package daemonset
 
 import (
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/extensions/charts"
 	projectsapi "github.com/rancher/tests/actions/projects"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func VerifyCreateDaemonSet(client *rancher.Client, clusterID string) error {
@@ -15,15 +13,10 @@ func VerifyCreateDaemonSet(client *rancher.Client, clusterID string) error {
 	}
 
 	logrus.Info("Creating new daemonset")
-	createdDaemonset, err := CreateDaemonset(client, clusterID, namespace.Name, 1, "", "", false, false)
+	_, err = CreateDaemonset(client, clusterID, namespace.Name, 1, "", "", false, false, true)
 	if err != nil {
 		return err
 	}
-
-	logrus.Infof("Waiting for daemonset %s to become active", createdDaemonset.Name)
-	err = charts.WatchAndWaitDaemonSets(client, clusterID, namespace.Name, metav1.ListOptions{
-		FieldSelector: "metadata.name=" + createdDaemonset.Name,
-	})
 
 	return err
 }

--- a/validation/projects/projects.go
+++ b/validation/projects/projects.go
@@ -13,7 +13,7 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
-	"github.com/rancher/shepherd/pkg/wrangler"
+	clusterapi "github.com/rancher/tests/actions/kubeapi/clusters"
 	"github.com/rancher/tests/actions/kubeapi/namespaces"
 	"github.com/rancher/tests/actions/kubeapi/projects"
 	rbacapi "github.com/rancher/tests/actions/kubeapi/rbac"
@@ -359,16 +359,9 @@ func checkContainerResources(client *rancher.Client, clusterID, namespaceName, d
 }
 
 func checkLimitRange(client *rancher.Client, clusterID, namespaceName string, expectedCPULimit, expectedCPURequest, expectedMemoryLimit, expectedMemoryRequest string) error {
-	var ctx *wrangler.Context
-	var err error
-
-	if clusterID != "local" {
-		ctx, err = client.WranglerContext.DownStreamClusterWranglerContext(clusterID)
-		if err != nil {
-			return fmt.Errorf("failed to get downstream context: %w", err)
-		}
-	} else {
-		ctx = client.WranglerContext
+	ctx, err := clusterapi.GetClusterWranglerContext(client, clusterID)
+	if err != nil {
+		return err
 	}
 
 	limitRanges, err := ctx.Core.LimitRange().List(namespaceName, metav1.ListOptions{})

--- a/validation/projects/projects_container_default_resource_limit_test.go
+++ b/validation/projects/projects_container_default_resource_limit_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/shepherd/extensions/users"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/shepherd/pkg/wrangler"
+	clusterapi "github.com/rancher/tests/actions/kubeapi/clusters"
 	"github.com/rancher/tests/actions/kubeapi/namespaces"
 	"github.com/rancher/tests/actions/kubeapi/projects"
 	project "github.com/rancher/tests/actions/projects"
@@ -63,7 +64,7 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) setupUserForProject() (*ran
 	err = users.AddClusterRoleToUser(pcrl.client, pcrl.cluster, standardUser, rbac.ClusterOwner.String(), nil)
 	require.NoError(pcrl.T(), err, "Failed to add the user as a cluster owner to the downstream cluster")
 
-	standardUserContext, err := standardUserClient.WranglerContext.DownStreamClusterWranglerContext(pcrl.cluster.ID)
+	standardUserContext, err := clusterapi.GetClusterWranglerContext(standardUserClient, pcrl.cluster.ID)
 	require.NoError(pcrl.T(), err)
 
 	return standardUserClient, standardUserContext
@@ -376,7 +377,7 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestLimitDeletionPropagatio
 	require.Equal(pcrl.T(), memoryReservation, projectSpec.RequestsMemory, "Memory reservation mismatch")
 
 	log.Info("Verify that the limit range in the existing namespace is deleted.")
-	ctx, err := standardUserClient.WranglerContext.DownStreamClusterWranglerContext(pcrl.cluster.ID)
+	ctx, err := clusterapi.GetClusterWranglerContext(standardUserClient, pcrl.cluster.ID)
 	require.NoError(pcrl.T(), err)
 	err = kwait.Poll(defaults.FiveHundredMillisecondTimeout, defaults.TenSecondTimeout, func() (done bool, pollErr error) {
 		limitRanges, err := ctx.Core.LimitRange().List(createdNamespace.Name, metav1.ListOptions{})

--- a/validation/projects/projects_resource_quota_test.go
+++ b/validation/projects/projects_resource_quota_test.go
@@ -15,6 +15,7 @@ import (
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/shepherd/pkg/wrangler"
+	clusterapi "github.com/rancher/tests/actions/kubeapi/clusters"
 	"github.com/rancher/tests/actions/kubeapi/namespaces"
 	"github.com/rancher/tests/actions/kubeapi/projects"
 	quotas "github.com/rancher/tests/actions/kubeapi/resourcequotas"
@@ -65,7 +66,7 @@ func (prq *ProjectsResourceQuotaTestSuite) setupUserForProject() (*rancher.Clien
 	err = users.AddClusterRoleToUser(prq.client, prq.cluster, standardUser, rbac.ClusterOwner.String(), nil)
 	require.NoError(prq.T(), err, "Failed to add the user as a cluster owner to the downstream cluster")
 
-	standardUserContext, err := standardUserClient.WranglerContext.DownStreamClusterWranglerContext(prq.cluster.ID)
+	standardUserContext, err := clusterapi.GetClusterWranglerContext(standardUserClient, prq.cluster.ID)
 	require.NoError(prq.T(), err)
 
 	return standardUserClient, standardUserContext
@@ -363,7 +364,7 @@ func (prq *ProjectsResourceQuotaTestSuite) TestOverrideQuotaInNamespace() {
 
 	log.Info("Override the pod limit for the namespace and increase it from 2 to 3.")
 	namespacePodLimit = "3"
-	downstreamContext, err := prq.client.WranglerContext.DownStreamClusterWranglerContext(prq.cluster.ID)
+	downstreamContext, err := clusterapi.GetClusterWranglerContext(prq.client, prq.cluster.ID)
 	require.NoError(prq.T(), err)
 	currentNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
 	require.NoError(prq.T(), err)
@@ -441,7 +442,7 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceFromNoQuotaToQuotaPr
 	require.Equal(prq.T(), projectPodLimit, createdProject2.Spec.ResourceQuota.Limit.Pods, "Project pod limit mismatch")
 
 	log.Info("Move the namespace to the project with resource quota set.")
-	downstreamContext, err := prq.client.WranglerContext.DownStreamClusterWranglerContext(prq.cluster.ID)
+	downstreamContext, err := clusterapi.GetClusterWranglerContext(prq.client, prq.cluster.ID)
 	require.NoError(prq.T(), err)
 
 	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
@@ -526,7 +527,7 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceFromQuotaToNoQuotaPr
 	require.NoError(prq.T(), err, "Failed to create project")
 
 	log.Info("Move the namespace to the project that has no resource quota set.")
-	downstreamContext, err := prq.client.WranglerContext.DownStreamClusterWranglerContext(prq.cluster.ID)
+	downstreamContext, err := clusterapi.GetClusterWranglerContext(prq.client, prq.cluster.ID)
 	require.NoError(prq.T(), err)
 
 	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
@@ -608,7 +609,7 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceWithDeploymentTransi
 	require.NoError(prq.T(), err, "Failed to create project")
 
 	log.Info("Move the namespace to the project that has no resource quota set.")
-	downstreamContext, err := prq.client.WranglerContext.DownStreamClusterWranglerContext(prq.cluster.ID)
+	downstreamContext, err := clusterapi.GetClusterWranglerContext(prq.client, prq.cluster.ID)
 	require.NoError(prq.T(), err)
 
 	updatedNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, createdNamespace.Name)
@@ -675,7 +676,7 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceBetweenProjectsWithN
 	log.Info("Move the namespace from the first project to the second project.")
 	currentNamespace, err := namespaces.GetNamespaceByName(standardUserClient, prq.cluster.ID, updatedNamespace.Name)
 	require.NoError(prq.T(), err)
-	downstreamContext, err := prq.client.WranglerContext.DownStreamClusterWranglerContext(prq.cluster.ID)
+	downstreamContext, err := clusterapi.GetClusterWranglerContext(prq.client, prq.cluster.ID)
 	require.NoError(prq.T(), err)
 
 	updatedNamespace.Annotations[projects.ProjectIDAnnotation] = createdProject2.Namespace + ":" + createdProject2.Name

--- a/validation/projects/projects_test.go
+++ b/validation/projects/projects_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/users"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterapi "github.com/rancher/tests/actions/kubeapi/clusters"
 	"github.com/rancher/tests/actions/kubeapi/namespaces"
 	"github.com/rancher/tests/actions/kubeapi/projects"
 	project "github.com/rancher/tests/actions/projects"
@@ -198,7 +199,7 @@ func (pr *ProjectsTestSuite) TestMoveNamespaceOutOfProject() {
 	delete(updatedNamespace.Labels, projects.ProjectIDAnnotation)
 	delete(updatedNamespace.Annotations, projects.ProjectIDAnnotation)
 
-	downstreamContext, err := pr.client.WranglerContext.DownStreamClusterWranglerContext(pr.cluster.ID)
+	downstreamContext, err := clusterapi.GetClusterWranglerContext(pr.client, pr.cluster.ID)
 	require.NoError(pr.T(), err)
 
 	currentNamespace, err := namespaces.GetNamespaceByName(standardUserClient, pr.cluster.ID, updatedNamespace.Name)

--- a/validation/rbac/secrets/rbac_opaque_secrets_test.go
+++ b/validation/rbac/secrets/rbac_opaque_secrets_test.go
@@ -9,6 +9,7 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterapi "github.com/rancher/tests/actions/kubeapi/clusters"
 	projectsapi "github.com/rancher/tests/actions/kubeapi/projects"
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/rbac"
@@ -174,7 +175,7 @@ func (rbos *RbacOpaqueSecretTestSuite) TestListSecret() {
 			assert.NoError(rbos.T(), err, "failed to create secret")
 
 			log.Infof("As a %v, list the secrets.", tt.role.String())
-			standardUserContext, err := standardUserClient.WranglerContext.DownStreamClusterWranglerContext(rbos.cluster.ID)
+			standardUserContext, err := clusterapi.GetClusterWranglerContext(standardUserClient, rbos.cluster.ID)
 			assert.NoError(rbos.T(), err)
 			secretList, err := standardUserContext.Core.Secret().List(namespace.Name, metav1.ListOptions{})
 			switch tt.role.String() {
@@ -224,7 +225,7 @@ func (rbos *RbacOpaqueSecretTestSuite) TestUpdateSecret() {
 			assert.NoError(rbos.T(), err, "failed to create secret")
 
 			log.Infof("As a %v, update the secrets.", tt.role.String())
-			standardUserContext, err := standardUserClient.WranglerContext.DownStreamClusterWranglerContext(rbos.cluster.ID)
+			standardUserContext, err := clusterapi.GetClusterWranglerContext(standardUserClient, rbos.cluster.ID)
 			assert.NoError(rbos.T(), err)
 
 			newData := map[string][]byte{
@@ -284,7 +285,7 @@ func (rbos *RbacOpaqueSecretTestSuite) TestDeleteSecret() {
 			assert.NoError(rbos.T(), err, "failed to create secret")
 
 			log.Infof("As a %v, delete the secrets.", tt.role.String())
-			standardUserContext, err := standardUserClient.WranglerContext.DownStreamClusterWranglerContext(rbos.cluster.ID)
+			standardUserContext, err := clusterapi.GetClusterWranglerContext(standardUserClient, rbos.cluster.ID)
 			assert.NoError(rbos.T(), err)
 
 			err = standardUserContext.Core.Secret().Delete(namespace.Name, createdSecret.Name, &metav1.DeleteOptions{})
@@ -336,7 +337,7 @@ func (rbos *RbacOpaqueSecretTestSuite) TestCrudSecretAsClusterMember() {
 	require.NoError(rbos.T(), err, "failed to create deployment with secret")
 
 	log.Infof("As a %v, list the secrets.", role)
-	standardUserContext, err := standardUserClient.WranglerContext.DownStreamClusterWranglerContext(rbos.cluster.ID)
+	standardUserContext, err := clusterapi.GetClusterWranglerContext(standardUserClient, rbos.cluster.ID)
 	assert.NoError(rbos.T(), err)
 	secretList, err := standardUserContext.Core.Secret().List(namespace.Name, metav1.ListOptions{})
 	require.NoError(rbos.T(), err, "failed to list secret")

--- a/validation/rbac/secrets/rbac_registry_secrets_test.go
+++ b/validation/rbac/secrets/rbac_registry_secrets_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
+	clusterapi "github.com/rancher/tests/actions/kubeapi/clusters"
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/rbac"
 	"github.com/rancher/tests/actions/secrets"
@@ -139,7 +140,7 @@ func (rbrs *RbacRegistrySecretTestSuite) TestListRegistrySecret() {
 			assert.NoError(rbrs.T(), err, "failed to create a registry secret")
 
 			log.Infof("As a %v, list the registry secrets.", tt.role.String())
-			standardUserContext, err := standardUserClient.WranglerContext.DownStreamClusterWranglerContext(rbrs.cluster.ID)
+			standardUserContext, err := clusterapi.GetClusterWranglerContext(standardUserClient, rbrs.cluster.ID)
 			assert.NoError(rbrs.T(), err)
 			secretList, err := standardUserContext.Core.Secret().List(namespace.Name, metav1.ListOptions{})
 			switch tt.role.String() {
@@ -192,7 +193,7 @@ func (rbrs *RbacRegistrySecretTestSuite) TestUpdateRegistrySecret() {
 			assert.NoError(rbrs.T(), err, "failed to create a registry secret")
 
 			log.Infof("As a %v, update the registry secret with a new label.", tt.role.String())
-			standardUserContext, err := standardUserClient.WranglerContext.DownStreamClusterWranglerContext(rbrs.cluster.ID)
+			standardUserContext, err := clusterapi.GetClusterWranglerContext(standardUserClient, rbrs.cluster.ID)
 			assert.NoError(rbrs.T(), err)
 
 			if createdRegistrySecret.Labels == nil {
@@ -250,7 +251,7 @@ func (rbrs *RbacRegistrySecretTestSuite) TestDeleteRegistrySecret() {
 			assert.NoError(rbrs.T(), err, "failed to create a registry secret")
 
 			log.Infof("As a %v, delete the registry secrets.", tt.role.String())
-			standardUserContext, err := standardUserClient.WranglerContext.DownStreamClusterWranglerContext(rbrs.cluster.ID)
+			standardUserContext, err := clusterapi.GetClusterWranglerContext(standardUserClient, rbrs.cluster.ID)
 			assert.NoError(rbrs.T(), err)
 
 			err = standardUserContext.Core.Secret().Delete(namespace.Name, createdRegistrySecret.Name, &metav1.DeleteOptions{})

--- a/validation/rbac/workloads/README.md
+++ b/validation/rbac/workloads/README.md
@@ -1,0 +1,26 @@
+# RBAC Workloads
+
+## Pre-requisites
+
+- Ensure you have an existing cluster that the user has access to. If you do not have a downstream cluster in Rancher, create one first before running this test.
+
+## Test Setup
+
+Your GO suite should be set to `-run ^Test<TestSuite>$`
+
+- To run the rbac_daemonset_test.go, set the GO suite to `-run ^TestRbacDaemonsetTestSuite$`
+- To run the rbac_deployment_test.go, set the GO suite to `-run ^TestRbacDeploymentTestSuite$`
+- To run the rbac_statefulset_test.go, set the GO suite to `-run ^TestRbacStatefulSetTestSuite$`
+- To run the rbac_cronjob_test.go, set the GO suite to `-run ^TestRbacCronJobTestSuite$`
+- To run the rbac_job_test.go, set the GO suite to `-run ^TestRbacJobTestSuite$`
+
+In your config file, set the following:
+
+```yaml
+rancher: 
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  insecure: True #optional
+  cleanup: True #optional
+  clusterName: "cluster_name"
+```

--- a/validation/rbac/workloads/rbac_daemonset_test.go
+++ b/validation/rbac/workloads/rbac_daemonset_test.go
@@ -1,0 +1,289 @@
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress
+
+package workloads
+
+import (
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/pkg/session"
+	clusterapi "github.com/rancher/tests/actions/kubeapi/clusters"
+	projectsapi "github.com/rancher/tests/actions/kubeapi/projects"
+	"github.com/rancher/tests/actions/projects"
+	"github.com/rancher/tests/actions/rbac"
+	"github.com/rancher/tests/actions/workloads/daemonset"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type RbacDaemonsetTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+	cluster *management.Cluster
+}
+
+func (rds *RbacDaemonsetTestSuite) TearDownSuite() {
+	rds.session.Cleanup()
+}
+
+func (rds *RbacDaemonsetTestSuite) SetupSuite() {
+	rds.session = session.NewSession()
+
+	client, err := rancher.NewClient("", rds.session)
+	require.NoError(rds.T(), err)
+	rds.client = client
+
+	log.Info("Getting cluster name from the config file and append cluster details in rds")
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(rds.T(), clusterName, "Cluster name to install should be set")
+	clusterID, err := clusters.GetClusterIDByName(rds.client, clusterName)
+	require.NoError(rds.T(), err, "Error getting cluster ID")
+	rds.cluster, err = rds.client.Management.Cluster.ByID(clusterID)
+	require.NoError(rds.T(), err)
+}
+
+func (rds *RbacDaemonsetTestSuite) TestCreateDaemonset() {
+	subSession := rds.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rds.Run("Validate daemonset creation as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespaceUsingWrangler(rds.client, rds.cluster.ID)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rds.client, tt.member, tt.role.String(), rds.cluster, adminProject)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("As a %v, create a daemonset", tt.role.String())
+			_, err = daemonset.CreateDaemonset(userClient, rds.cluster.ID, namespace.Name, 1, "", "", false, false, false)
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rds.T(), err, "failed to create daemonset")
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rds.T(), err)
+				assert.True(rds.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rds *RbacDaemonsetTestSuite) TestListDaemonset() {
+	subSession := rds.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rds.Run("Validate listing daemonset as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespaceUsingWrangler(rds.client, rds.cluster.ID)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rds.client, tt.member, tt.role.String(), rds.cluster, adminProject)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("As a %v, create a daemonset in the namespace %v", rbac.Admin, namespace.Name)
+			createdDaemonset, err := daemonset.CreateDaemonset(rds.client, rds.cluster.ID, namespace.Name, 1, "", "", false, false, true)
+			assert.NoError(rds.T(), err, "failed to create daemonset")
+
+			log.Infof("As a %v, list the daemonset", tt.role.String())
+			standardUserContext, err := clusterapi.GetClusterWranglerContext(userClient, rds.cluster.ID)
+			assert.NoError(rds.T(), err)
+			daemonsetList, err := standardUserContext.Apps.DaemonSet().List(namespace.Name, metav1.ListOptions{})
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String(), rbac.ReadOnly.String():
+				assert.NoError(rds.T(), err, "failed to list daemonset")
+				assert.Equal(rds.T(), len(daemonsetList.Items), 1)
+				assert.Equal(rds.T(), daemonsetList.Items[0].Name, createdDaemonset.Name)
+			case rbac.ClusterMember.String():
+				assert.Error(rds.T(), err)
+				assert.True(rds.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rds *RbacDaemonsetTestSuite) TestUpdateDaemonset() {
+	subSession := rds.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rds.Run("Validate updating daemonset as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespaceUsingWrangler(rds.client, rds.cluster.ID)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rds.client, tt.member, tt.role.String(), rds.cluster, adminProject)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("As a %v, create a daemonset in the namespace %v", rbac.Admin, namespace.Name)
+			createdDaemonset, err := daemonset.CreateDaemonset(rds.client, rds.cluster.ID, namespace.Name, 1, "", "", false, false, true)
+			assert.NoError(rds.T(), err, "failed to create daemonset")
+
+			log.Infof("As a %v, update the daemonSet %s with a new label.", tt.role.String(), createdDaemonset.Name)
+			if createdDaemonset.Labels == nil {
+				createdDaemonset.Labels = make(map[string]string)
+			}
+			createdDaemonset.Labels["updated"] = "true"
+			updatedDaemonSet, err := daemonset.UpdateDaemonset(userClient, rds.cluster.ID, namespace.Name, createdDaemonset, false)
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rds.T(), err, "failed to update daemonset")
+				standardUserContext, err := clusterapi.GetClusterWranglerContext(userClient, rds.cluster.ID)
+				assert.NoError(rds.T(), err)
+				updatedDaemonSet, err = standardUserContext.Apps.DaemonSet().Get(namespace.Name, updatedDaemonSet.Name, metav1.GetOptions{})
+				assert.NoError(rds.T(), err, "Failed to get the updated daemonSet after updating labels.")
+				assert.Equal(rds.T(), "true", updatedDaemonSet.Labels["updated"], "DaemonSet label update failed.")
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rds.T(), err)
+				assert.True(rds.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rds *RbacDaemonsetTestSuite) TestDeleteDaemonset() {
+	subSession := rds.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rds.Run("Validate deleting daemonset as user with role "+tt.role.String(), func() {
+			log.Info("Create a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespaceUsingWrangler(rds.client, rds.cluster.ID)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("Create a standard user and add the user to a cluster/project role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rds.client, tt.member, tt.role.String(), rds.cluster, adminProject)
+			assert.NoError(rds.T(), err)
+
+			log.Infof("As a %v, create a daemonset in the namespace %v", rbac.Admin, namespace.Name)
+			createdDaemonset, err := daemonset.CreateDaemonset(rds.client, rds.cluster.ID, namespace.Name, 1, "", "", false, false, true)
+			assert.NoError(rds.T(), err, "failed to create daemonset")
+
+			log.Infof("As a %v, delete the daemonset", tt.role.String())
+			standardUserContext, err := clusterapi.GetClusterWranglerContext(userClient, rds.cluster.ID)
+			assert.NoError(rds.T(), err)
+			err = standardUserContext.Apps.DaemonSet().Delete(namespace.Name, createdDaemonset.Name, &metav1.DeleteOptions{})
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rds.T(), err, "failed to delete daemonset")
+				daemonsetList, err := standardUserContext.Apps.DaemonSet().List(namespace.Name, metav1.ListOptions{})
+				assert.NoError(rds.T(), err)
+				assert.Equal(rds.T(), len(daemonsetList.Items), 0)
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rds.T(), err)
+				assert.True(rds.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rds *RbacDaemonsetTestSuite) TestCrudDaemonsetAsClusterMember() {
+	subSession := rds.session.NewSession()
+	defer subSession.Cleanup()
+
+	role := rbac.ClusterMember.String()
+	log.Info("Creating a standard user and adding them to cluster as a cluster member.")
+	user, userClient, err := rbac.AddUserWithRoleToCluster(rds.client, rbac.StandardUser.String(), role, rds.cluster, nil)
+	require.NoError(rds.T(), err)
+
+	projectTemplate := projectsapi.NewProjectTemplate(rds.cluster.ID)
+	projectTemplate.Annotations = map[string]string{
+		"field.cattle.io/creatorId": user.ID,
+	}
+	createdProject, err := userClient.WranglerContext.Mgmt.Project().Create(projectTemplate)
+	require.NoError(rds.T(), err)
+
+	err = projects.WaitForProjectFinalizerToUpdate(userClient, createdProject.Name, createdProject.Namespace, 2)
+	require.NoError(rds.T(), err)
+
+	namespace, err := projects.CreateNamespaceUsingWrangler(userClient, rds.cluster.ID, createdProject.Name)
+	require.NoError(rds.T(), err)
+
+	log.Infof("As a %v, create a daemonset in the namespace %v", role, namespace.Name)
+	createdDaemonset, err := daemonset.CreateDaemonset(userClient, rds.cluster.ID, namespace.Name, 1, "", "", false, false, true)
+	require.NoError(rds.T(), err, "failed to create daemonset")
+
+	log.Infof("As a %v, list the daemonset", role)
+	standardUserContext, err := clusterapi.GetClusterWranglerContext(userClient, rds.cluster.ID)
+	require.NoError(rds.T(), err)
+	daemonsetList, err := standardUserContext.Apps.DaemonSet().List(namespace.Name, metav1.ListOptions{})
+	require.NoError(rds.T(), err, "failed to list daemonset")
+	require.Equal(rds.T(), len(daemonsetList.Items), 1)
+	require.Equal(rds.T(), daemonsetList.Items[0].Name, createdDaemonset.Name)
+
+	log.Infof("As a %v, update the daemonSet %s with a new label.", role, createdDaemonset.Name)
+	if createdDaemonset.Labels == nil {
+		createdDaemonset.Labels = make(map[string]string)
+	}
+	createdDaemonset.Labels["updated"] = "true"
+	updatedDaemonSet, err := daemonset.UpdateDaemonset(userClient, rds.cluster.ID, namespace.Name, createdDaemonset, true)
+	require.NoError(rds.T(), err, "failed to update daemonset")
+	updatedDaemonSet, err = standardUserContext.Apps.DaemonSet().Get(namespace.Name, updatedDaemonSet.Name, metav1.GetOptions{})
+	require.NoError(rds.T(), err, "Failed to get the updated daemonSet after updating labels.")
+	require.Equal(rds.T(), "true", updatedDaemonSet.Labels["updated"], "DaemonSet label update failed.")
+
+	log.Infof("As a %v, delete the daemonset", role)
+	err = standardUserContext.Apps.DaemonSet().Delete(namespace.Name, createdDaemonset.Name, &metav1.DeleteOptions{})
+	require.NoError(rds.T(), err, "failed to delete daemonset")
+	daemonsetList, err = standardUserContext.Apps.DaemonSet().List(namespace.Name, metav1.ListOptions{})
+	require.NoError(rds.T(), err)
+	require.Equal(rds.T(), len(daemonsetList.Items), 0)
+}
+
+func TestRbacDaemonsetTestSuite(t *testing.T) {
+	suite.Run(t, new(RbacDaemonsetTestSuite))
+}


### PR DESCRIPTION
**Issue**: https://github.com/rancher/qa-tasks/issues/1342

This is one of the several upcoming PRs aimed at migrating the RBAC workload tests from Python to Go. **This PR specifically includes tests for DaemonSet only.**
