### PR TITLE
Test-a-Bot init commit

### DIFF
--- a/.github/scripts/check-changed-tests.sh
+++ b/.github/scripts/check-changed-tests.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+error_handler() {
+  local lineno=${BASH_LINENO[0]}
+  local funcname=${FUNCNAME[1]} 
+  local command=${BASH_COMMAND}
+
+  # Print the error details. Please keep this for debugging purposes. 
+  # echo "Error occurred at line $lineno in function $funcname: '$command'"
+}
+
+trap error_handler ERR
+
+TARGET_BRANCH="main"
+TEMP_DIR=$(mktemp -d)
+
+touch $TEMP_DIR/diff.used-anywhere
+touch $TEMP_DIR/diff.test-functions
+
+# returns the name of a function, supplied as an argument
+grep-for-function-name() {
+    echo "$1" | grep func | \
+    sed -E 's/.*func[[:space:]]+([a-zA-Z0-9_]+).*/\1/' | \
+    grep -v "(" | \ 
+    grep -v "//" # omit comments and functions that are part of a suite ()
+}
+
+# modifies diff.test-functions, adding a line-by-line list of where each supplied function is used, if it is used anywhere in go files.
+find-all-functions-anywhere() {
+    for function_name in $1 ; do
+        contained_files=$(grep -n -r "$function_name" --exclude-dir=".git" --exclude-dir=".github" . | grep -v "//" | grep ".go" | grep -v "main.go" )
+        echo "$contained_files" >> $TEMP_DIR/diff.test-functions
+    done
+}
+
+grep-for-suite-and-test-name() {
+    suite_name=$(echo "$1" | grep func | grep -oP '\((.*?)\)' | grep -oP '\*\K\w+' | grep -v "testing" | grep -v "github.com")
+    test_name=$(echo "$1" | grep -oP 'func \(\w+\s\*\w+\) \K\w+')
+
+    if [[ -n "$suite_name" && -n "$test_name" ]]; then
+        echo "$suite_name $test_name"
+    fi
+}
+
+
+# prepare for git diff to compare with latest main branch from origin. 
+git fetch --all -q
+git config user.name "github-actions"
+git config user.email "github-actions@github.com"
+git checkout $1 -q
+git rebase origin/$TARGET_BRANCH --strategy-option=theirs -q
+
+# get all the modified test suites
+git diff origin/$TARGET_BRANCH -- . ':(exclude)*.sh' ':(exclude)*.yml' | while read line; do
+    grep-for-suite-and-test-name "$line" >> $TEMP_DIR/diff.used-anywhere
+done
+
+echo "\nTestSuites above were modified. TestSuites below use modified code from this PR.\n" >> $TEMP_DIR/diff.used-anywhere
+
+# get all functions that changed (that aren't suites)
+git diff origin/$TARGET_BRANCH -- . ':(exclude)*.sh' ':(exclude)*.yml' | while read line; do
+    next=$(grep-for-function-name "$line")
+    if [[ $next == *"Test"* ]]; then
+        echo $next >> $TEMP_DIR/diff.used-anywhere
+    else
+        find-all-functions-anywhere $next 
+    fi
+done
+
+# given changed functions, find tests that use said functions in any capacity and add them to diff.used-anywhere list
+while IFS= read -r lines_not_tests; do
+    if [[ "$lines_not_tests" != *"func"* && "$lines_not_tests" != *"TestSuite"* ]]; then
+        if [[ "$lines_not_tests" == *".go"* ]]; then
+        
+            line_number=$(echo "$lines_not_tests" | awk -F":" '{print $2}')
+            file=$(echo "$lines_not_tests" | awk -F":" '{print $1}')
+
+            # sometimes, git diff has an = sign at the beginning of the string..
+            if [[ ${file:0:1} == "=" ]]; then
+                file="${file:1}"
+            fi
+
+            function_line=$(head -n "$line_number" "$file" | tac | grep -m 1 '^func' | tac)
+            function_name_tmp=$(grep-for-function-name "$function_line")
+            
+            if [ -n "$function_name_tmp" ]; then
+                find-all-functions-anywhere "$function_name_tmp"
+            fi
+
+            test_name=$(grep-for-suite-and-test-name "$function_line")
+            if ! grep -q "$test_name" $TEMP_DIR/diff.used-anywhere; then
+                echo $test_name >> $TEMP_DIR/diff.used-anywhere
+            fi
+        fi
+    fi
+done < $TEMP_DIR/diff.test-functions
+
+wait
+
+# curl needs non-escaped newlines to read properly into json
+curl_digestable_string=""
+while IFS= read -r official_tests; do
+    curl_digestable_string+=$"\n$official_tests"
+done < $TEMP_DIR/diff.used-anywhere
+
+echo "$curl_digestable_string"
+
+# Clean up
+rm -rf $TEMP_DIR

--- a/.github/workflows/test_recommendations.yml
+++ b/.github/workflows/test_recommendations.yml
@@ -1,0 +1,51 @@
+name: Determine Tests Bot
+on:
+  workflow_run:
+    workflows: 
+      - Verify Changes
+    types:
+      - requested
+
+ 
+jobs:
+  add-comment-to-pr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    permissions: 
+      pull-requests: write
+      issues: write
+
+    if: $(git rev-parse origin/main) != ${{ github.event.workflow_run.head_commit.id }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+ 
+      - name: Get Recommended Tests
+        run: |
+            {
+                echo 'tests_from_script<<EOF'
+                ./.github/scripts/check-changed-tests.sh "${{ github.event.workflow_run.head_commit.id }}"
+                echo EOF
+            } >> "$GITHUB_ENV"
+            
+            echo "rec_tests=Hi, I am a friendly algorithm to help determine which tests you brok.. erm, modified. I suggest you run these! \n" >> $GITHUB_ENV
+      - name: Add comment to PR
+        run: |
+            PR_NUMBER=$(curl -s \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls?state=all" \
+              | jq '.[] | select(.head.sha == "${{ github.event.workflow_run.head_commit.id }}") | .number' | head -n 1)
+
+            if [[ -n "$tests_from_script" ]]; then
+              response=$(curl -s -o response.json -w "%{http_code}" -X POST \
+                  -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }} " \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  --data-binary '{"body": "'"$rec_tests $tests_from_script"'"}' \
+                  "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments")
+
+              if [[ "$response" -lt 200 || "$response" -gt 300 ]]; then
+                  echo "Failed to post the comment. HTTP response code: $response"
+                  cat response.json
+                  exit 1  
+              fi
+            fi

--- a/.github/workflows/test_recommendations.yml
+++ b/.github/workflows/test_recommendations.yml
@@ -18,7 +18,7 @@ jobs:
     if: $(git rev-parse origin/main) != ${{ github.event.workflow_run.head_commit.id }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
  
       - name: Get Recommended Tests
         run: |


### PR DESCRIPTION
addresses this exploratory issue: https://github.com/rancher/qa-tasks/issues/1754

Some notes for future works:
* doesn't look at structs / consts?
* doesn't work for non-go files i.e. yaml
* not tested on removed or added functions, probably won't work well with the current lookups
* WILL run every time there's a new push to the PR

[click here to see an example](https://github.com/slickwarren/tests/pull/2#issuecomment-2744195337) of what the comment looks like when modifying actions/clusters/clusters.go


notes about the file organization:
* creating a new file that is `workflow_run`, triggered when the `Verify Changes` action is received in Github
  * this gets around some permissions issues when PRs are opened from forks, as secrets aren't shared between the parent repo and any forks for security purposes. 