### PR TITLE
RBAC tests for Workloads - CronJob

### DIFF
--- a/actions/workloads/cronjob/template.go
+++ b/actions/workloads/cronjob/template.go
@@ -1,0 +1,39 @@
+package cronjob
+
+import (
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// NewCronJobTemplate is a constructor that creates the template for cronjob
+func NewCronJobTemplate(namespaceName, schedule string, podTemplate corev1.PodTemplateSpec) *batchv1.CronJob {
+	cronJobName := namegen.AppendRandomString("testcronjob")
+	var limit int32 = 10
+
+	podTemplate.Spec.RestartPolicy = corev1.RestartPolicyNever
+
+	cronJobTemplate := &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cronJobName,
+			Namespace: namespaceName,
+		},
+		Spec: batchv1.CronJobSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespaceName,
+				},
+				Spec: batchv1.JobSpec{
+					Template: podTemplate,
+				},
+			},
+			Schedule:                   schedule,
+			ConcurrencyPolicy:          batchv1.ForbidConcurrent,
+			FailedJobsHistoryLimit:     &limit,
+			SuccessfulJobsHistoryLimit: &limit,
+		},
+	}
+
+	return cronJobTemplate
+}

--- a/actions/workloads/job/job.go
+++ b/actions/workloads/job/job.go
@@ -15,10 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-const (
-	nginxImageName = "public.ecr.aws/docker/library/nginx"
-)
-
 // CreateJob is a helper to create a job in a namespace using wrangler context
 func CreateJob(client *rancher.Client, clusterID, namespaceName string, podTemplate corev1.PodTemplateSpec, watchJob bool) (*batchv1.Job, error) {
 	wranglerContext, err := clusterapi.GetClusterWranglerContext(client, clusterID)

--- a/actions/workloads/job/template.go
+++ b/actions/workloads/job/template.go
@@ -1,7 +1,6 @@
 package job
 
 import (
-	"github.com/rancher/shepherd/extensions/workloads"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -23,30 +22,4 @@ func NewJobTemplate(namespaceName string, podTemplate corev1.PodTemplateSpec) ba
 			Template: podTemplate,
 		},
 	}
-}
-
-// CreateContainerAndPodTemplate creates both the container and pod templates
-func CreateContainerAndPodTemplate() corev1.PodTemplateSpec {
-	containerName := namegen.AppendRandomString("test-container")
-
-	containerTemplate := workloads.NewContainer(
-		containerName,
-		nginxImageName,
-		corev1.PullAlways,
-		[]corev1.VolumeMount{},
-		[]corev1.EnvFromSource{},
-		nil,
-		nil,
-		nil,
-	)
-
-	podTemplate := workloads.NewPodTemplate(
-		[]corev1.Container{containerTemplate},
-		[]corev1.Volume{},
-		[]corev1.LocalObjectReference{},
-		nil,
-		nil,
-	)
-
-	return podTemplate
 }

--- a/actions/workloads/job/verify.go
+++ b/actions/workloads/job/verify.go
@@ -3,6 +3,7 @@ package job
 import (
 	"github.com/rancher/shepherd/clients/rancher"
 	projects "github.com/rancher/tests/actions/projects"
+	"github.com/rancher/tests/actions/workloads/pods"
 )
 
 func VerifyCreateJob(client *rancher.Client, clusterID string) error {
@@ -11,7 +12,7 @@ func VerifyCreateJob(client *rancher.Client, clusterID string) error {
 		return err
 	}
 
-	podTemplate := CreateContainerAndPodTemplate()
+	podTemplate := pods.CreateContainerAndPodTemplate()
 
 	_, err = CreateJob(client, clusterID, namespace.Name, podTemplate, true)
 	if err != nil {

--- a/actions/workloads/pods/template.go
+++ b/actions/workloads/pods/template.go
@@ -1,0 +1,37 @@
+package pods
+
+import (
+	"github.com/rancher/shepherd/extensions/workloads"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	nginxImageName = "public.ecr.aws/docker/library/nginx"
+)
+
+// CreateContainerAndPodTemplate creates both the container and pod templates
+func CreateContainerAndPodTemplate() corev1.PodTemplateSpec {
+	containerName := namegen.AppendRandomString("test-container")
+
+	containerTemplate := workloads.NewContainer(
+		containerName,
+		nginxImageName,
+		corev1.PullAlways,
+		[]corev1.VolumeMount{},
+		[]corev1.EnvFromSource{},
+		nil,
+		nil,
+		nil,
+	)
+
+	podTemplate := workloads.NewPodTemplate(
+		[]corev1.Container{containerTemplate},
+		[]corev1.Volume{},
+		[]corev1.LocalObjectReference{},
+		nil,
+		nil,
+	)
+
+	return podTemplate
+}

--- a/validation/rbac/workloads/rbac_cronjob_test.go
+++ b/validation/rbac/workloads/rbac_cronjob_test.go
@@ -1,0 +1,300 @@
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress
+
+package workloads
+
+import (
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/pkg/session"
+	clusterapi "github.com/rancher/tests/actions/kubeapi/clusters"
+	projectsapi "github.com/rancher/tests/actions/kubeapi/projects"
+	"github.com/rancher/tests/actions/projects"
+	"github.com/rancher/tests/actions/rbac"
+	"github.com/rancher/tests/actions/workloads/cronjob"
+	"github.com/rancher/tests/actions/workloads/pods"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type RbacCronJobTestSuite struct {
+	suite.Suite
+	client  *rancher.Client
+	session *session.Session
+	cluster *management.Cluster
+}
+
+func (rcj *RbacCronJobTestSuite) TearDownSuite() {
+	rcj.session.Cleanup()
+}
+
+func (rcj *RbacCronJobTestSuite) SetupSuite() {
+	rcj.session = session.NewSession()
+
+	client, err := rancher.NewClient("", rcj.session)
+	require.NoError(rcj.T(), err)
+	rcj.client = client
+
+	log.Info("Getting cluster name from the config file and append cluster details in rcj")
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(rcj.T(), clusterName, "Cluster name to install should be set")
+	clusterID, err := clusters.GetClusterIDByName(rcj.client, clusterName)
+	require.NoError(rcj.T(), err, "Error getting cluster ID")
+	rcj.cluster, err = rcj.client.Management.Cluster.ByID(clusterID)
+	require.NoError(rcj.T(), err)
+}
+
+func (rcj *RbacCronJobTestSuite) TestCreateCronJob() {
+	subSession := rcj.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rcj.Run("Validate cronjob creation as user with role "+tt.role.String(), func() {
+			log.Info("Creating a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespaceUsingWrangler(rcj.client, rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("Creating a standard user and add the user to a cluster/project with role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rcj.client, tt.member, tt.role.String(), rcj.cluster, adminProject)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("As a %v, creating a cronjob", tt.role.String())
+			podTemplate := pods.CreateContainerAndPodTemplate()
+			_, err = cronjob.CreateCronJob(userClient, rcj.cluster.ID, namespace.Name, "*/1 * * * *", podTemplate, false)
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rcj.T(), err, "failed to create cronjob")
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rcj.T(), err)
+				assert.True(rcj.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rcj *RbacCronJobTestSuite) TestListCronJob() {
+	subSession := rcj.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rcj.Run("Validate listing cronjob as user with role "+tt.role.String(), func() {
+			log.Info("Creating a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespaceUsingWrangler(rcj.client, rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("Creating a standard user and add the user to a cluster/project with role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rcj.client, tt.member, tt.role.String(), rcj.cluster, adminProject)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("As a %v, creating a cronjob in the namespace %v", rbac.Admin, namespace.Name)
+			podTemplate := pods.CreateContainerAndPodTemplate()
+			createdCronJob, err := cronjob.CreateCronJob(rcj.client, rcj.cluster.ID, namespace.Name, "*/1 * * * *", podTemplate, true)
+			assert.NoError(rcj.T(), err, "failed to create cronjob")
+
+			log.Infof("As a %v, listing the cronjob", tt.role.String())
+			standardUserContext, err := clusterapi.GetClusterWranglerContext(userClient, rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+			cronJobList, err := standardUserContext.Batch.CronJob().List(namespace.Name, metav1.ListOptions{})
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String(), rbac.ReadOnly.String():
+				assert.NoError(rcj.T(), err, "failed to list cronjob")
+				assert.Equal(rcj.T(), len(cronJobList.Items), 1)
+				assert.Equal(rcj.T(), cronJobList.Items[0].Name, createdCronJob.Name)
+			case rbac.ClusterMember.String():
+				assert.Error(rcj.T(), err)
+				assert.True(rcj.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rcj *RbacCronJobTestSuite) TestUpdateCronJob() {
+	subSession := rcj.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rcj.Run("Validate updating cronjob as user with role "+tt.role.String(), func() {
+			log.Info("Creating a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespaceUsingWrangler(rcj.client, rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("Creating a standard user and add the user to a cluster/project with role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rcj.client, tt.member, tt.role.String(), rcj.cluster, adminProject)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("As a %v, creating a cronjob in the namespace %v", rbac.Admin, namespace.Name)
+			podTemplate := pods.CreateContainerAndPodTemplate()
+			createdCronJob, err := cronjob.CreateCronJob(rcj.client, rcj.cluster.ID, namespace.Name, "*/1 * * * *", podTemplate, true)
+			assert.NoError(rcj.T(), err, "failed to create cronjob")
+
+			log.Infof("As a %v, updating the cronjob %s with a new label.", tt.role.String(), createdCronJob.Name)
+			adminContext, err := clusterapi.GetClusterWranglerContext(rcj.client, rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+			standardUserContext, err := clusterapi.GetClusterWranglerContext(userClient, rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+
+			latestCronJob, err := adminContext.Batch.CronJob().Get(namespace.Name, createdCronJob.Name, metav1.GetOptions{})
+			assert.NoError(rcj.T(), err, "Failed to list cronjob.")
+
+			if latestCronJob.Labels == nil {
+				latestCronJob.Labels = make(map[string]string)
+			}
+			latestCronJob.Labels["updated"] = "true"
+
+			_, err = standardUserContext.Batch.CronJob().Update(latestCronJob)
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rcj.T(), err, "failed to update cronjob")
+				updatedCronJob, err := standardUserContext.Batch.CronJob().Get(namespace.Name, createdCronJob.Name, metav1.GetOptions{})
+				assert.NoError(rcj.T(), err, "Failed to list the cronjob after updating labels.")
+				assert.Equal(rcj.T(), "true", updatedCronJob.Labels["updated"], "job label update failed.")
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rcj.T(), err)
+				assert.True(rcj.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rcj *RbacCronJobTestSuite) TestDeleteCronJob() {
+	subSession := rcj.session.NewSession()
+	defer subSession.Cleanup()
+
+	tests := []struct {
+		role   rbac.Role
+		member string
+	}{
+		{rbac.ClusterOwner, rbac.StandardUser.String()},
+		{rbac.ClusterMember, rbac.StandardUser.String()},
+		{rbac.ProjectOwner, rbac.StandardUser.String()},
+		{rbac.ProjectMember, rbac.StandardUser.String()},
+		{rbac.ReadOnly, rbac.StandardUser.String()},
+	}
+
+	for _, tt := range tests {
+		rcj.Run("Validate deleting cronjob as user with role "+tt.role.String(), func() {
+			log.Info("Creating a project and a namespace in the project.")
+			adminProject, namespace, err := projects.CreateProjectAndNamespaceUsingWrangler(rcj.client, rcj.cluster.ID)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("Creating a standard user and add the user to a cluster/project with role %s", tt.role)
+			_, userClient, err := rbac.AddUserWithRoleToCluster(rcj.client, tt.member, tt.role.String(), rcj.cluster, adminProject)
+			assert.NoError(rcj.T(), err)
+
+			log.Infof("As a %v, creating a cronjob in the namespace %v", rbac.Admin, namespace.Name)
+			podTemplate := pods.CreateContainerAndPodTemplate()
+			createdCronJob, err := cronjob.CreateCronJob(rcj.client, rcj.cluster.ID, namespace.Name, "*/1 * * * *", podTemplate, true)
+			assert.NoError(rcj.T(), err, "failed to create cronjob")
+
+			log.Infof("As a %v, deleting the cronjob", tt.role.String())
+			err = cronjob.DeleteCronJob(userClient, rcj.cluster.ID, createdCronJob, false)
+			switch tt.role.String() {
+			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
+				assert.NoError(rcj.T(), err, "failed to delete cronjob")
+				err = cronjob.WaitForDeleteCronJob(userClient, rcj.cluster.ID, createdCronJob)
+				assert.NoError(rcj.T(), err)
+			case rbac.ClusterMember.String(), rbac.ReadOnly.String():
+				assert.Error(rcj.T(), err)
+				assert.True(rcj.T(), errors.IsForbidden(err))
+			}
+		})
+	}
+}
+
+func (rcj *RbacCronJobTestSuite) TestCrudCronJobAsClusterMember() {
+	subSession := rcj.session.NewSession()
+	defer subSession.Cleanup()
+
+	role := rbac.ClusterMember.String()
+	log.Info("Creating a standard user and adding them to cluster as a cluster member.")
+	user, userClient, err := rbac.AddUserWithRoleToCluster(rcj.client, rbac.StandardUser.String(), role, rcj.cluster, nil)
+	require.NoError(rcj.T(), err)
+
+	projectTemplate := projectsapi.NewProjectTemplate(rcj.cluster.ID)
+	projectTemplate.Annotations = map[string]string{
+		"field.cattle.io/creatorId": user.ID,
+	}
+	createdProject, err := userClient.WranglerContext.Mgmt.Project().Create(projectTemplate)
+	require.NoError(rcj.T(), err)
+
+	err = projects.WaitForProjectFinalizerToUpdate(userClient, createdProject.Name, createdProject.Namespace, 2)
+	require.NoError(rcj.T(), err)
+
+	namespace, err := projects.CreateNamespaceUsingWrangler(userClient, rcj.cluster.ID, createdProject.Name)
+	require.NoError(rcj.T(), err)
+
+	log.Infof("As a %v, creating a cronjob in the namespace %v", role, namespace.Name)
+	podTemplate := pods.CreateContainerAndPodTemplate()
+	createdCronJob, err := cronjob.CreateCronJob(userClient, rcj.cluster.ID, namespace.Name, "*/1 * * * *", podTemplate, true)
+	require.NoError(rcj.T(), err, "failed to create cronjob")
+
+	log.Infof("As a %v, listing the cronjob", role)
+	standardUserContext, err := clusterapi.GetClusterWranglerContext(userClient, rcj.cluster.ID)
+	assert.NoError(rcj.T(), err)
+	cronJobList, err := standardUserContext.Batch.CronJob().List(namespace.Name, metav1.ListOptions{})
+	require.NoError(rcj.T(), err, "failed to list cronjobs")
+	require.Equal(rcj.T(), len(cronJobList.Items), 1)
+	require.Equal(rcj.T(), cronJobList.Items[0].Name, createdCronJob.Name)
+
+	log.Infof("As a %v, updating the cronjob %s with a new label.", role, createdCronJob.Name)
+	latestCronJob, err := standardUserContext.Batch.CronJob().Get(namespace.Name, createdCronJob.Name, metav1.GetOptions{})
+	assert.NoError(rcj.T(), err, "Failed to get the latest cronjob.")
+
+	if latestCronJob.Labels == nil {
+		latestCronJob.Labels = make(map[string]string)
+	}
+	latestCronJob.Labels["updated"] = "true"
+
+	_, err = standardUserContext.Batch.CronJob().Update(latestCronJob)
+	require.NoError(rcj.T(), err, "failed to update cronjob")
+	updatedCronJobList, err := standardUserContext.Batch.CronJob().List(namespace.Name, metav1.ListOptions{})
+	require.NoError(rcj.T(), err, "Failed to list the cronjob after updating labels.")
+	require.Equal(rcj.T(), "true", updatedCronJobList.Items[0].Labels["updated"], "job label update failed.")
+
+	log.Infof("As a %v, deleting the cronjob", role)
+	err = cronjob.DeleteCronJob(userClient, rcj.cluster.ID, createdCronJob, true)
+	require.NoError(rcj.T(), err, "failed to delete cronjob")
+}
+
+func TestRbacCronJobTestSuite(t *testing.T) {
+	suite.Run(t, new(RbacCronJobTestSuite))
+}

--- a/validation/rbac/workloads/rbac_job_test.go
+++ b/validation/rbac/workloads/rbac_job_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/rbac"
 	"github.com/rancher/tests/actions/workloads/job"
+	"github.com/rancher/tests/actions/workloads/pods"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -75,7 +76,7 @@ func (rj *RbacJobTestSuite) TestCreateJob() {
 			assert.NoError(rj.T(), err)
 
 			log.Infof("As a %v, creating a job", tt.role.String())
-			podTemplate := job.CreateContainerAndPodTemplate()
+			podTemplate := pods.CreateContainerAndPodTemplate()
 			_, err = job.CreateJob(userClient, rj.cluster.ID, namespace.Name, podTemplate, false)
 			switch tt.role.String() {
 			case rbac.ClusterOwner.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String():
@@ -114,7 +115,7 @@ func (rj *RbacJobTestSuite) TestListJob() {
 			assert.NoError(rj.T(), err)
 
 			log.Infof("As a %v, creating a job in the namespace %v", rbac.Admin, namespace.Name)
-			podTemplate := job.CreateContainerAndPodTemplate()
+			podTemplate := pods.CreateContainerAndPodTemplate()
 			createdJob, err := job.CreateJob(rj.client, rj.cluster.ID, namespace.Name, podTemplate, true)
 			assert.NoError(rj.T(), err, "failed to create job")
 
@@ -161,7 +162,7 @@ func (rj *RbacJobTestSuite) TestUpdateJob() {
 			assert.NoError(rj.T(), err)
 
 			log.Infof("As a %v, creating a job in the namespace %v", rbac.Admin, namespace.Name)
-			podTemplate := job.CreateContainerAndPodTemplate()
+			podTemplate := pods.CreateContainerAndPodTemplate()
 			createdJob, err := job.CreateJob(rj.client, rj.cluster.ID, namespace.Name, podTemplate, true)
 			assert.NoError(rj.T(), err, "failed to create job")
 
@@ -220,7 +221,7 @@ func (rj *RbacJobTestSuite) TestDeleteJob() {
 			assert.NoError(rj.T(), err)
 
 			log.Infof("As a %v, creating a job in the namespace %v", rbac.Admin, namespace.Name)
-			podTemplate := job.CreateContainerAndPodTemplate()
+			podTemplate := pods.CreateContainerAndPodTemplate()
 			createdJob, err := job.CreateJob(rj.client, rj.cluster.ID, namespace.Name, podTemplate, true)
 			assert.NoError(rj.T(), err, "failed to create job")
 
@@ -262,7 +263,7 @@ func (rj *RbacJobTestSuite) TestCrudJobAsClusterMember() {
 	require.NoError(rj.T(), err)
 
 	log.Infof("As a %v, creating a job in the namespace %v", role, namespace.Name)
-	podTemplate := job.CreateContainerAndPodTemplate()
+	podTemplate := pods.CreateContainerAndPodTemplate()
 	createdJob, err := job.CreateJob(userClient, rj.cluster.ID, namespace.Name, podTemplate, true)
 	require.NoError(rj.T(), err, "failed to create job")
 


### PR DESCRIPTION
**Issue**: https://github.com/rancher/qa-tasks/issues/1342

This is one of the several upcoming PRs aimed at migrating the RBAC workload tests from Python to Go. **This PR specifically includes tests for CronJob only.**
