### PR TITLE
run Test bot from forks

### DIFF
--- a/.github/scripts/check-changed-tests.sh
+++ b/.github/scripts/check-changed-tests.sh
@@ -46,6 +46,10 @@ grep-for-suite-and-test-name() {
 git fetch --all -q
 git config user.name "github-actions"
 git config user.email "github-actions@github.com"
+
+git remote add forked-upstream "$2"
+git fetch forked-upstream
+
 git checkout "$1" -q
 git rebase "origin/$TARGET_BRANCH" --strategy-option=theirs -q
 

--- a/.github/scripts/check-changed-tests.sh
+++ b/.github/scripts/check-changed-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 error_handler() {
   local lineno=${BASH_LINENO[0]}
   local funcname=${FUNCNAME[1]} 
@@ -47,8 +49,8 @@ git fetch --all -q
 git config user.name "github-actions"
 git config user.email "github-actions@github.com"
 
-git remote add forked-upstream "$2"
-git fetch forked-upstream
+git remote add forked-upstream https://github.com/"$2".git
+git fetch forked-upstream -q
 
 git checkout "$1" -q
 git rebase "origin/$TARGET_BRANCH" --strategy-option=theirs -q
@@ -102,11 +104,15 @@ wait
 
 # curl needs non-escaped newlines to read properly into json
 curl_digestable_string=""
+count=0
 while IFS= read -r official_tests; do
     curl_digestable_string+=$"\n$official_tests"
+    ((count++))
 done < "$TEMP_DIR/diff.used-anywhere"
 
-echo "$curl_digestable_string"
+if [$count -gt 1 ]; then
+    echo "$curl_digestable_string"
+fi
 
 # Clean up
 rm -rf "$TEMP_DIR"

--- a/.github/workflows/test_recommendations.yml
+++ b/.github/workflows/test_recommendations.yml
@@ -15,16 +15,16 @@ jobs:
       pull-requests: write
       issues: write
 
-    if: $(git rev-parse origin/main) != ${{ github.event.workflow_run.head_commit.id }}
+    if: ${{github.repository != github.event.workflow_run.head_repository.full_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
- 
+        
       - name: Get Recommended Tests
         run: |
             {
                 echo 'tests_from_script<<EOF'
-                ./.github/scripts/check-changed-tests.sh "${{ github.event.workflow_run.head_commit.id }}" "${{ github.event.workflow_run.head_repository.url }}"
+                ./.github/scripts/check-changed-tests.sh "${{ github.event.workflow_run.head_commit.id }}" "${{ github.event.workflow_run.head_repository.full_name }}"
                 echo EOF
             } >> "$GITHUB_ENV"
             

--- a/.github/workflows/test_recommendations.yml
+++ b/.github/workflows/test_recommendations.yml
@@ -24,11 +24,10 @@ jobs:
         run: |
             {
                 echo 'tests_from_script<<EOF'
-                ./.github/scripts/check-changed-tests.sh "${{ github.event.workflow_run.head_commit.id }}"
+                ./.github/scripts/check-changed-tests.sh "${{ github.event.workflow_run.head_commit.id }}" "${{ github.event.workflow_run.head_repository.url }}"
                 echo EOF
             } >> "$GITHUB_ENV"
             
-            echo "rec_tests=Hi, I am a friendly algorithm to help determine which tests you brok.. erm, modified. I suggest you run these! \n" >> $GITHUB_ENV
       - name: Add comment to PR
         run: |
             PR_NUMBER=$(curl -s \
@@ -40,7 +39,7 @@ jobs:
               response=$(curl -s -o response.json -w "%{http_code}" -X POST \
                   -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }} " \
                   -H "Accept: application/vnd.github.v3+json" \
-                  --data-binary '{"body": "'"$rec_tests $tests_from_script"'"}' \
+                  --data-binary '{"body": "'"$tests_from_script"'"}' \
                   "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments")
 
               if [[ "$response" -lt 200 || "$response" -gt 300 ]]; then


### PR DESCRIPTION
after the initial PR merged, the action was failing on a few accounts that I couldn't really check for when running in my personal fork. Here are the changes:

* fail action if script fails
* rebase from fork (add for as remote)
* don't run action if not from a fork