### PR TITLE
omit jenkinsfiles from commenteng bot

### DIFF
--- a/.github/scripts/check-changed-tests.sh
+++ b/.github/scripts/check-changed-tests.sh
@@ -55,14 +55,14 @@ git checkout "$1" -q
 git rebase "origin/$TARGET_BRANCH" --strategy-option=theirs -q
 
 # get all the modified test suites
-git diff "origin/$TARGET_BRANCH" --ignore-space-change --unified=0 -- . ':(exclude)*.sh' ':(exclude)*.yml' | while read -r line; do
+git diff "origin/$TARGET_BRANCH" --ignore-space-change --unified=0 -- . ':(exclude)*.sh' ':(exclude)*.yml' ':(exclude)*Jenkinsfile*' | while read -r line; do
     grep-for-suite-and-test-name "$line" >> "$TEMP_DIR/diff.used-anywhere"
 done
 
 echo "\nTestSuites above were modified. TestSuites below use modified code from this PR.\n" >> "$TEMP_DIR/diff.used-anywhere"
 
 # get all functions that changed (that aren't suites)
-git diff "origin/$TARGET_BRANCH" --ignore-space-change --unified=0 -- . ':(exclude)*.sh' ':(exclude)*.yml' | while read -r line; do
+git diff "origin/$TARGET_BRANCH" --ignore-space-change --unified=0 -- . ':(exclude)*.sh' ':(exclude)*.yml' ':(exclude)*Jenkinsfile*' | while read -r line; do
     next=$(grep-for-function-name "$line")
     if [[ "$next" == *"Test"* ]]; then
         echo "$next" >> "$TEMP_DIR/diff.used-anywhere"


### PR DESCRIPTION
should fix this: https://github.com/rancher/tests/pull/60
local output:
```

AirGapRKE1CustomClusterTestSuite TearDownSuite
AirGapRKE1CustomClusterTestSuite SetupSuite
AirGapRKE1CustomClusterTestSuite TestProvisioningAirGapRKE1CustomCluster
AirGapRKE1CustomClusterTestSuite TestProvisioningUpgradeAirGapRKE1CustomCluster
AirGapRKE2CustomClusterTestSuite TearDownSuite
AirGapRKE2CustomClusterTestSuite SetupSuite
AirGapRKE2CustomClusterTestSuite TestProvisioningAirGapRKE2CustomCluster
AirGapRKE2CustomClusterTestSuite TestProvisioningAirGapUpgradeRKE2CustomCluster

TestSuites above were modified. TestSuites below use modified code from this PR.

TestAirGapCustomClusterRKE1ProvisioningTestSuite
TestAirGapCustomClusterRKE2ProvisioningTestSuite


```
