### PR TITLE
Bump Go to 1.24 in Dockerfiles

### DIFF
--- a/validation/Dockerfile.e2e
+++ b/validation/Dockerfile.e2e
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.23
+FROM registry.suse.com/bci/golang:1.24
 
 # Configure Go
 ENV GOFLAGS=-buildvcs=false

--- a/validation/Dockerfile.validation
+++ b/validation/Dockerfile.validation
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.23
+FROM registry.suse.com/bci/golang:1.24
 
 # Configure Go
 ENV GOPATH /root/go


### PR DESCRIPTION
With https://github.com/rancher/tests/pull/86 we bumped the Go version from 1.23 to 1.24. Updating the Dockerfiles to use 1.24