### PR TITLE
Update GET prtb in the tests to use prtb namespace instead of project name

### DIFF
--- a/actions/rbac/rbac.go
+++ b/actions/rbac/rbac.go
@@ -452,7 +452,7 @@ func CreateProjectRoleTemplateBinding(client *rancher.Client, user *management.U
 
 	prtbNamespace := project.Name
 	if project.Status.BackingNamespace != "" {
-		prtbNamespace = fmt.Sprintf("%s-%s", project.Spec.ClusterName, project.Name)
+		prtbNamespace = fmt.Sprintf("%s:%s", project.Spec.ClusterName, project.Name)
 	}
 
 	prtbObj := &v3.ProjectRoleTemplateBinding{

--- a/validation/rbac/clusterandprojectroles/cluster_role_test.go
+++ b/validation/rbac/clusterandprojectroles/cluster_role_test.go
@@ -89,7 +89,7 @@ func (rb *ClusterRoleTestSuite) TestClusterOwnerAddsUserAsProjectOwner() {
 	additionalUser, additionalUserClient, err := rbac.SetupUser(rb.client, rbac.StandardUser.String())
 	require.NoError(rb.T(), err)
 
-	prtb, err := rbac.CreateProjectRoleTemplateBinding(standardUserClient, additionalUser, clusterOwnerProject, rbac.ProjectOwner.String())
+	createdPrtb, err := rbac.CreateProjectRoleTemplateBinding(standardUserClient, additionalUser, clusterOwnerProject, rbac.ProjectOwner.String())
 	require.NoError(rb.T(), err)
 	additionalUserClient, err = additionalUserClient.ReLogin()
 	require.NoError(rb.T(), err)
@@ -98,7 +98,7 @@ func (rb *ClusterRoleTestSuite) TestClusterOwnerAddsUserAsProjectOwner() {
 	require.NoError(rb.T(), err)
 	require.Equal(rb.T(), clusterOwnerProject.Name, projectAdditionalUser.Name)
 
-	err = standardUserClient.WranglerContext.Mgmt.ProjectRoleTemplateBinding().Delete(clusterOwnerProject.Name, prtb.Name, &metav1.DeleteOptions{})
+	err = standardUserClient.WranglerContext.Mgmt.ProjectRoleTemplateBinding().Delete(createdPrtb.Namespace, createdPrtb.Name, &metav1.DeleteOptions{})
 	require.NoError(rb.T(), err)
 	additionalUserClient, err = additionalUserClient.ReLogin()
 	require.NoError(rb.T(), err)
@@ -194,7 +194,7 @@ func (rb *ClusterRoleTestSuite) TestClusterMemberWithPrtbAccess() {
 
 	userContext, err := clusterapi.GetClusterWranglerContext(standardUserClient, rbac.LocalCluster)
 	require.NoError(rb.T(), err)
-	prtb, err = userContext.Mgmt.ProjectRoleTemplateBinding().Get(adminProject.Name, prtb.Name, metav1.GetOptions{})
+	prtb, err = userContext.Mgmt.ProjectRoleTemplateBinding().Get(prtb.Namespace, prtb.Name, metav1.GetOptions{})
 	require.NoError(rb.T(), err)
 
 	if prtb.Labels == nil {
@@ -204,7 +204,7 @@ func (rb *ClusterRoleTestSuite) TestClusterMemberWithPrtbAccess() {
 	updatedPrtb, err := userContext.Mgmt.ProjectRoleTemplateBinding().Update(prtb)
 	require.NoError(rb.T(), err)
 
-	err = userContext.Mgmt.ProjectRoleTemplateBinding().Delete(adminProject.Name, updatedPrtb.Name, &metav1.DeleteOptions{})
+	err = userContext.Mgmt.ProjectRoleTemplateBinding().Delete(updatedPrtb.Namespace, updatedPrtb.Name, &metav1.DeleteOptions{})
 	require.NoError(rb.T(), err)
 }
 

--- a/validation/rbac/clusterandprojectroles/project_role_test.go
+++ b/validation/rbac/clusterandprojectroles/project_role_test.go
@@ -72,7 +72,7 @@ func (pr *ProjectRolesTestSuite) TestProjectOwnerAddsAndRemovesOtherProjectOwner
 	additionalUser, additionalUserClient, err := rbac.SetupUser(pr.client, rbac.StandardUser.String())
 	require.NoError(pr.T(), err)
 
-	prtb, errUserRole := rbac.CreateProjectRoleTemplateBinding(standardUserClient, additionalUser, adminProject, rbac.ProjectOwner.String())
+	createdPrtb, errUserRole := rbac.CreateProjectRoleTemplateBinding(standardUserClient, additionalUser, adminProject, rbac.ProjectOwner.String())
 	require.NoError(pr.T(), errUserRole)
 	additionalUserClient, err = additionalUserClient.ReLogin()
 	require.NoError(pr.T(), err)
@@ -81,7 +81,7 @@ func (pr *ProjectRolesTestSuite) TestProjectOwnerAddsAndRemovesOtherProjectOwner
 	require.NoError(pr.T(), err)
 	require.Equal(pr.T(), userGetProject.Name, adminProject.Name)
 
-	errRemoveMember := standardUserClient.WranglerContext.Mgmt.ProjectRoleTemplateBinding().Delete(adminProject.Name, prtb.Name, &metav1.DeleteOptions{})
+	errRemoveMember := standardUserClient.WranglerContext.Mgmt.ProjectRoleTemplateBinding().Delete(createdPrtb.Namespace, createdPrtb.Name, &metav1.DeleteOptions{})
 	require.NoError(pr.T(), errRemoveMember)
 	additionalUserClient, err = additionalUserClient.ReLogin()
 	require.NoError(pr.T(), err)


### PR DESCRIPTION
A new field was added to projects to specify the namespace for storing PRTBs. So, the PRTB namespace is now a combination of the cluster name and the project name, rather than just the project name. GET PRTB method has been updated in this PR to use the PRTB namespace instead of the project name as the namespace to ensure backward compatibility.