### PR TITLE
add jenkinsfile for harvester e2e tests, and general mantainance 

### DIFF
--- a/scripts/custodian/azure.yaml
+++ b/scripts/custodian/azure.yaml
@@ -163,79 +163,7 @@ policies:
   actions:
     - type: delete
 
-
-# Networking
-- name: az-mark-unknown-nsg-for-deletion
-  resource: azure.networksecuritygroup
-  description: |
-    Mark unknown NSG for deletion in 1 day
-  filters:
-    # instance name not in accepted user keys
-    - type: value
-      key: name
-      op: regex
-      #doesNOTcontain
-      value:  "^((?!USERKEYS).)*$"
-    # instance is not doNotDelete
-    - 'tag:doNotDelete': absent
-    - 'tag:DoNotDelete': absent
-    - 'tag:known_user': absent
-    - 'tag:unknown_user': absent
-    - "tag:DeletesOnFriday": absent
-    - not: 
-      - type: value
-        key: name
-        op: regex
-        value:  "^.*DONOTDELETEKEYS.*$"
-  actions:
-    - type: mark-for-op
-      tag: unknown_user
-      op: delete
-      days: 1
-
-- name: az-mark-known-nsg-for-deletion
-  resource: azure.networksecuritygroup
-  description: |
-    Mark known NSG for deletion in 2 days
-  filters:
-    # instance is named with accepted user key
-    - type: value
-      key: name
-      op: regex
-      value:  "^.*USERKEYS.*$"
-    # instance is not doNotDelete
-    - 'tag:doNotDelete': absent
-    - 'tag:DoNotDelete': absent
-    - 'tag:unknown_user': absent
-    - 'tag:known_user': absent
-    - "tag:DeletesOnFriday": absent
-    - not: 
-      - type: value
-        key: name
-        op: regex
-        value:  "^.*DONOTDELETEKEYS.*$"
-  actions:
-    - type: mark-for-op
-      tag: known_user
-      op: delete
-      days: 2
-
-- name: azure-terminate-nsg
-  resource: azure.networksecuritygroup
-  description: |
-    Delete any marked NSG which have been 
-    marked for deletion for more than 1 day.
-  filters:
-    - or:
-      - type: marked-for-op
-        tag: unknown_user
-        op: delete
-      - type: marked-for-op
-        tag: known_user
-        op: delete
-  actions:
-    - type: delete
-
+# Network Interfaces
 - name: az-mark-unknown-ni-for-deletion
   resource: azure.networkinterface
   description: |
@@ -295,6 +223,79 @@ policies:
   resource: azure.networkinterface
   description: |
     Delete any marked network interface which have been 
+    marked for deletion for more than 1 day.
+  filters:
+    - or:
+      - type: marked-for-op
+        tag: unknown_user
+        op: delete
+      - type: marked-for-op
+        tag: known_user
+        op: delete
+  actions:
+    - type: delete
+
+# Network Security Groups
+
+- name: az-mark-unknown-nsg-for-deletion
+  resource: azure.networksecuritygroup
+  description: |
+    Mark unknown NSG for deletion in 1 day
+  filters:
+    # instance name not in accepted user keys
+    - type: value
+      key: name
+      op: regex
+      #doesNOTcontain
+      value:  "^((?!USERKEYS).)*$"
+    # instance is not doNotDelete
+    - 'tag:doNotDelete': absent
+    - 'tag:DoNotDelete': absent
+    - 'tag:known_user': absent
+    - 'tag:unknown_user': absent
+    - "tag:DeletesOnFriday": absent
+    - not: 
+      - type: value
+        key: name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: mark-for-op
+      tag: unknown_user
+      op: delete
+      days: 1
+
+- name: az-mark-known-nsg-for-deletion
+  resource: azure.networksecuritygroup
+  description: |
+    Mark known NSG for deletion in 2 days
+  filters:
+    # instance is named with accepted user key
+    - type: value
+      key: name
+      op: regex
+      value:  "^.*USERKEYS.*$"
+    # instance is not doNotDelete
+    - 'tag:doNotDelete': absent
+    - 'tag:DoNotDelete': absent
+    - 'tag:unknown_user': absent
+    - 'tag:known_user': absent
+    - "tag:DeletesOnFriday": absent
+    - not: 
+      - type: value
+        key: name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: mark-for-op
+      tag: known_user
+      op: delete
+      days: 2
+
+- name: azure-terminate-nsg
+  resource: azure.networksecuritygroup
+  description: |
+    Delete any marked NSG which have been 
     marked for deletion for more than 1 day.
   filters:
     - or:

--- a/validation/Dockerfile.validation
+++ b/validation/Dockerfile.validation
@@ -1,10 +1,10 @@
 FROM registry.suse.com/bci/golang:1.24
 
 # Configure Go
-ENV GOPATH /root/go
-ENV PATH ${PATH}:/root/go/bin
+ENV GOPATH=/root/go
+ENV PATH=${PATH}:/root/go/bin
 
-ENV WORKSPACE ${GOPATH}/src/github.com/rancher/tests
+ENV WORKSPACE=${GOPATH}/src/github.com/rancher/tests
 
 WORKDIR $WORKSPACE/validation
 

--- a/validation/harvester/import_harvester_test.go
+++ b/validation/harvester/import_harvester_test.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/rancher/shepherd/clients/harvester"
 	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/cloudcredentials"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/sirupsen/logrus"
 
 	"github.com/rancher/shepherd/pkg/config"
+	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/session"
 	harvesteraction "github.com/rancher/tests/interoperability/harvester"
 	"github.com/stretchr/testify/require"
@@ -23,6 +25,7 @@ type HarvesterTestSuite struct {
 	session         *session.Session
 	clusterID       string
 	harvesterClient *harvester.Client
+	userConfig      *provisioninginput.Config
 }
 
 func (h *HarvesterTestSuite) TearDownSuite() {
@@ -52,6 +55,22 @@ func (h *HarvesterTestSuite) TestImport() {
 	harvesterInRancherID, err := harvesteraction.RegisterHarvesterWithRancher(h.client, h.harvesterClient)
 	require.NoError(h.T(), err)
 	logrus.Info(harvesterInRancherID)
+
+	// the below is useful for most cases where daisy-chaining this job to others.
+
+	cluster, err := h.client.Management.Cluster.ByID(harvesterInRancherID)
+	require.NoError(h.T(), err)
+
+	kubeConfig, err := h.client.Management.Cluster.ActionGenerateKubeconfig(cluster)
+	require.NoError(h.T(), err)
+
+	var harvesterCredentialConfig cloudcredentials.HarvesterCredentialConfig
+
+	harvesterCredentialConfig.ClusterID = harvesterInRancherID
+	harvesterCredentialConfig.ClusterType = "imported"
+	harvesterCredentialConfig.KubeconfigContent = kubeConfig.Config
+
+	shepherdConfig.UpdateConfig(cloudcredentials.HarvesterCredentialConfigurationFileKey, harvesterCredentialConfig)
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/validation/harvester/import_harvester_test.go
+++ b/validation/harvester/import_harvester_test.go
@@ -25,7 +25,6 @@ type HarvesterTestSuite struct {
 	session         *session.Session
 	clusterID       string
 	harvesterClient *harvester.Client
-	userConfig      *provisioninginput.Config
 }
 
 func (h *HarvesterTestSuite) TearDownSuite() {
@@ -55,8 +54,6 @@ func (h *HarvesterTestSuite) TestImport() {
 	harvesterInRancherID, err := harvesteraction.RegisterHarvesterWithRancher(h.client, h.harvesterClient)
 	require.NoError(h.T(), err)
 	logrus.Info(harvesterInRancherID)
-
-	// the below is useful for most cases where daisy-chaining this job to others.
 
 	cluster, err := h.client.Management.Cluster.ByID(harvesterInRancherID)
 	require.NoError(h.T(), err)

--- a/validation/pipeline/tfp/Jenkinsfile.harvester.e2e
+++ b/validation/pipeline/tfp/Jenkinsfile.harvester.e2e
@@ -5,6 +5,8 @@ node("harvester-vpn-1") {
   def testRootPath = "/root/go/src/github.com/rancher/tests/validation/"
   def testsDir = "github.com/rancher/tfp-automation/tests/${env.TEST_PACKAGE}"
   def golangTestDir = "github.com/rancher/tests/validation/${env.GO_TEST_PACKAGE}"
+  def golangHvstDir = "github.com/rancher/tests/validation/harvester"
+  def hvstTestCase = "-run ^TestHarvesterTestSuite\$"
   def filename = "config.yml"
   def job_name = "${JOB_NAME}"
   if (job_name.contains('/')) { 
@@ -94,7 +96,7 @@ node("harvester-vpn-1") {
                         sh "docker volume create --name ${validationVolume}"
                      }
 
-                    stage('Run Infrastructure Module Test') {
+                    stage('Run Infrastructure TFP Test') {
                         try {
                             sh """
                             docker run -v ${validationVolume}:/root --name ${testContainer} -t --env-file ${envFile} ${imageName} sh -c "
@@ -102,8 +104,8 @@ node("harvester-vpn-1") {
                             """
                             sh "docker cp ${testContainer}:${rootPath}${filename} ${filename}"
                             sh "mkdir harvester"
-                            sh "docker cp ${testContainer}:${rootPath}modules/sanity/harvester/ ./harvester/"
-                            sh "cat ${filename}"
+                            sh "docker cp ${testContainer}:${rootPath}modules/sanity/harvester/ ."
+                            sh "ls -la harvester/"
                           
                         } catch(err) {
                             echo "Test run had failures. Collecting results... ${err}"
@@ -140,15 +142,25 @@ node("harvester-vpn-1") {
                             sh "docker cp ${testContainer}:${rootPath}${filename} ${filename}"
                           }
                         }
+                        stage('Connect Rancher -> Harvester') {
+
+                          try {
+                            // this test also writes harvesterCloudCredentials to the config
+                            sh """
+                            docker run -v tests${validationVolume}:/root --name hvst${golangTestContainer} -t --env-file ${envFile} ${imageName} sh -c "/root/go/bin/gotestsum --format standard-verbose --packages=${golangHvstDir} --junitfile ${testResultsOut} -- -tags=${TAGS} ${hvstTestCase} -timeout=${timeout} -v "
+                            """
+                          } catch(err) {
+                            echo "${err} Unable to connect harvester to new rancher setup. Aborting"
+                          }
+                          
+                        }
                         stage('Run Validation Tests') {
 
                           try {
                             sh """
-                            docker run -v tests${validationVolume}:/root --name ${golangTestContainer} -t --env-file ${envFile} ${imageName} sh -c "/root/go/bin/gotestsum --format standard-verbose --packages=${golangTestDir} --junitfile ${testResultsOut} -- -tags=${TAGS} ${GO_TEST_CASE} -timeout=${timeout} -v "
-                            """
-                            // figure out how to pull imported cluster info from ^ and use it to make a cloud credential for the below job
-                            sh """
-                            docker run -v tests${validationVolume}:/root --name ${golangTestContainer} -t --env-file ${envFile} ${imageName} sh -c "/root/go/bin/gotestsum --format standard-verbose --packages=${golangTestDir} --junitfile ${testResultsOut} -- -tags=${TAGS} ${GO_TEST_CASE} -timeout=${timeout} -v "
+                            docker run -v tests${validationVolume}:/root --name ${golangTestContainer} -t --env-file ${envFile} ${imageName} sh -c "/root/go/bin/gotestsum --format standard-verbose --packages=${golangTestDir} --junitfile ${testResultsOut} -- -tags=${TAGS} ${GO_TEST_CASE} -timeout=${timeout} -v ;"
+                            ${testRootPath}pipeline/scripts/build_qase_reporter.sh;
+                            ${testRootPath}reporter;
                             """
                               
                           } catch(err) {
@@ -156,6 +168,7 @@ node("harvester-vpn-1") {
                           }
                           sh """
                           docker rm ${golangTestContainer} || true
+                          docker rm hvst${golangTestContainer} || true
                           
                           docker rmi ${imageName} || true
                           
@@ -165,16 +178,19 @@ node("harvester-vpn-1") {
                     }//dir
                     stage('Cleanup terraform resources'){
                       try {
+                          sh "ls -la \$(pwd)/harvester/"
+
                           sh """
-                          docker run --rm -v harvester:/terraform-files \
+                          docker run --rm -v \$(pwd)/harvester:/terraform-files \
                               -w /terraform-files hashicorp/terraform:latest \
-                              init && terraform destroy -auto-approve
+                              init && terraform destroy --auto-approve
                           """
                       }
                       catch(err) {
                         echo "${err} captured, there be dragons..."
                       }
                       sh "docker volume rm ${validationVolume} || true"
+                      sh "docker rm ${testContainer} || true"
                       } //cleanup
                 } //params
             } //credentials

--- a/validation/pipeline/tfp/Jenkinsfile.harvester.e2e
+++ b/validation/pipeline/tfp/Jenkinsfile.harvester.e2e
@@ -103,9 +103,7 @@ node("harvester-vpn-1") {
                             /root/go/bin/gotestsum --format standard-verbose --packages=${testsDir} --junitfile ${testResultsOut} --jsonfile ${testResultsJSON} -- -timeout=${timeout} -v ${params.TEST_CASE}"
                             """
                             sh "docker cp ${testContainer}:${rootPath}${filename} ${filename}"
-                            sh "mkdir harvester"
-                            sh "docker cp ${testContainer}:${rootPath}modules/sanity/harvester/ ."
-                            sh "ls -la harvester/"
+                            
                           
                         } catch(err) {
                             echo "Test run had failures. Collecting results... ${err}"
@@ -158,15 +156,21 @@ node("harvester-vpn-1") {
 
                           try {
                             sh """
+
+                            docker cp ${testContainer}:${rootPath}modules/sanity/harvester/ .;
+                            pwd;
+                            ls -la harvester/ ;
                             docker run -v tests${validationVolume}:/root --name ${golangTestContainer} -t --env-file ${envFile} ${imageName} sh -c "/root/go/bin/gotestsum --format standard-verbose --packages=${golangTestDir} --junitfile ${testResultsOut} -- -tags=${TAGS} ${GO_TEST_CASE} -timeout=${timeout} -v ;"
-                            ${testRootPath}pipeline/scripts/build_qase_reporter.sh;
-                            ${testRootPath}reporter;
                             """
+                            // ${testRootPath}pipeline/scripts/build_qase_reporter.sh;
+                            // ${testRootPath}reporter;
                               
                           } catch(err) {
                             echo "${err} Validation tests had failures. Aborting"
                           }
                           sh """
+                          docker stop ${golangTestContainer} || true
+                          docker stop hvst${golangTestContainer} || true
                           docker rm ${golangTestContainer} || true
                           docker rm hvst${golangTestContainer} || true
                           
@@ -178,17 +182,27 @@ node("harvester-vpn-1") {
                     }//dir
                     stage('Cleanup terraform resources'){
                       try {
-                          sh "ls -la \$(pwd)/harvester/"
 
+                        dir ("./") {
+                          if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
+                            dir("./harvester/.ssh") {
+                              def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
+                              writeFile file: AWS_SSH_KEY_NAME, text: decoded
+                            }
+                          }
+                          
                           sh """
                           docker run --rm -v \$(pwd)/harvester:/terraform-files \
+                              -v \$(pwd)/harvester/.ssh:/root/go/src/github.com/rancher/tfp-automation/.ssh \
                               -w /terraform-files hashicorp/terraform:latest \
-                              init && terraform destroy --auto-approve
+                              destroy --auto-approve
                           """
+                        }
                       }
                       catch(err) {
                         echo "${err} captured, there be dragons..."
                       }
+                      sh "docker stop ${testContainer}"
                       sh "docker volume rm ${validationVolume} || true"
                       sh "docker rm ${testContainer} || true"
                       } //cleanup

--- a/validation/pipeline/tfp/Jenkinsfile.harvester.e2e
+++ b/validation/pipeline/tfp/Jenkinsfile.harvester.e2e
@@ -1,0 +1,183 @@
+#!groovy
+node("harvester-vpn-1") {
+  def rootPath = "/root/go/src/github.com/rancher/tfp-automation/"
+  def modulesPath = "modules/sanity/harvester"
+  def testRootPath = "/root/go/src/github.com/rancher/tests/validation/"
+  def testsDir = "github.com/rancher/tfp-automation/tests/${env.TEST_PACKAGE}"
+  def golangTestDir = "github.com/rancher/tests/validation/${env.GO_TEST_PACKAGE}"
+  def filename = "config.yml"
+  def job_name = "${JOB_NAME}"
+  if (job_name.contains('/')) { 
+    job_names = job_name.split('/')
+    job_name = job_names[job_names.size() - 1] 
+  }
+  def golangTestContainer = "${job_name}${env.BUILD_NUMBER}_test2"
+  def testContainer = "${job_name}${env.BUILD_NUMBER}_test"
+  def imageName = "tfp-automation-validation-${job_name}${env.BUILD_NUMBER}"
+  def testResultsOut = "results.xml"
+  def testResultsJSON = "results.json"
+  def envFile = ".env"
+  def config = env.CONFIG
+  def adminToken = ""
+  def privateRegistry = ""
+  def validationVolume = "ValidationSharedVolume-${job_name}${env.BUILD_NUMBER}"
+
+  def infraBranch = "${env.INFRA_BRANCH}"
+  if ("${env.INFRA_BRANCH}" != "null" && "${env.INFRA_BRANCH}" != "") {
+        infraBranch = "${env.INFRA_BRANCH}"
+  }
+  def testBranch = "${env.TEST_BRANCH}"
+  if ("${env.TEST_BRANCH}" != "null" && "${env.TEST_BRANCH}" != "") {
+        testBranch = "${env.TEST_BRANCH}"
+  }
+  def infraRepo = scm.userRemoteConfigs
+  if ("${env.INFRA_REPO}" != "null" && "${env.INFRA_REPO}" != "") {
+    infraRepo = [[url: "${env.INFRA_REPO}"]]
+  }
+  def testRepo = scm.userRemoteConfigs
+  if ("${env.TEST_REPO}" != "null" && "${env.TEST_REPO}" != "") {
+    testRepo = [[url: "${env.TEST_REPO}"]]
+  }
+  def timeout = "${env.TIMEOUT}"
+  if ("${env.TIMEOUT}" != "null" && "${env.TIMEOUT}" != "") {
+        timeout = "${env.TIMEOUT}" 
+  }
+
+    wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm', 'defaultFg': 2, 'defaultBg':1]) {
+        withFolderProperties {
+            paramsMap = []
+            params.each {
+                if (it.value && it.value.trim() != "") {
+                    paramsMap << "$it.key=$it.value"
+                }
+            }
+            withCredentials([ string(credentialsId: 'AWS_ACCESS_KEY_ID', variable: 'AWS_ACCESS_KEY_ID'),
+                              string(credentialsId: 'AWS_SECRET_ACCESS_KEY', variable: 'AWS_SECRET_ACCESS_KEY'),
+                              string(credentialsId: 'AWS_SSH_PEM_KEY', variable: 'AWS_SSH_PEM_KEY'),
+                              string(credentialsId: 'AWS_SSH_RSA_KEY', variable: 'AWS_SSH_RSA_KEY'),
+                              string(credentialsId: 'AWS_RSA_KEY_NAME', variable: 'AWS_RSA_KEY_NAME'),
+                              string(credentialsId: 'AWS_SSH_KEY_NAME', variable: 'AWS_SSH_KEY_NAME'),
+                              string(credentialsId: 'ADMIN_PASSWORD', variable: 'ADMIN_PASSWORD')]) {
+          
+                withEnv(paramsMap) {
+
+
+                    stage('Checkout Infrastructure Repo') {
+                        deleteDir()
+                        checkout([
+                                    $class: 'GitSCM',
+                                    branches: [[name: "*/${infraBranch}"]],
+                                    extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                                    userRemoteConfigs: infraRepo
+                                ])
+                     }
+
+                    stage('Configure and Build') {
+                        config = config.replace('${AWS_SECRET_ACCESS_KEY}', env.AWS_SECRET_ACCESS_KEY)
+                        config = config.replace('${AWS_ACCESS_KEY_ID}', env.AWS_ACCESS_KEY_ID)
+                
+                        writeFile file: filename, text: config
+                
+                        dir(".ssh") {
+                            def decoded = new String(env.AWS_SSH_PEM_KEY.decodeBase64())
+                            writeFile file: AWS_SSH_KEY_NAME, text: decoded
+                    
+                            def decodedRsa = new String(AWS_SSH_RSA_KEY.decodeBase64())
+                            writeFile file: AWS_RSA_KEY_NAME, text: decodedRsa
+                        }
+                        
+                        env.CATTLE_TEST_CONFIG=rootPath+filename
+                
+                        sh "./configure.sh"
+                        sh "./build.sh"
+
+                        sh "docker volume create --name ${validationVolume}"
+                     }
+
+                    stage('Run Infrastructure Module Test') {
+                        try {
+                            sh """
+                            docker run -v ${validationVolume}:/root --name ${testContainer} -t --env-file ${envFile} ${imageName} sh -c "
+                            /root/go/bin/gotestsum --format standard-verbose --packages=${testsDir} --junitfile ${testResultsOut} --jsonfile ${testResultsJSON} -- -timeout=${timeout} -v ${params.TEST_CASE}"
+                            """
+                            sh "docker cp ${testContainer}:${rootPath}${filename} ${filename}"
+                            sh "mkdir harvester"
+                            sh "docker cp ${testContainer}:${rootPath}modules/sanity/harvester/ ./harvester/"
+                            sh "cat ${filename}"
+                          
+                        } catch(err) {
+                            echo "Test run had failures. Collecting results... ${err}"
+                            error err
+                        }
+                     } 
+
+                    stage('Checkout Test Repo') {
+                        checkout([  
+                                    $class: 'GitSCM',
+                                    branches: [[name: "*/${testBranch}"]],
+                                    extensions: scm.extensions + [[$class: 'CleanCheckout']],
+                                    userRemoteConfigs: testRepo
+                                ])
+                    }
+
+                    dir ("./") {
+                        stage('Configure and Build') {
+                          if (env.AWS_SSH_PEM_KEY && env.AWS_SSH_KEY_NAME) {
+                            dir("./validation/.ssh") {
+                              def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
+                              writeFile file: AWS_SSH_KEY_NAME, text: decoded
+                            }
+                          }               
+                          dir("./validation") {             
+                            sh "docker cp ${testContainer}:${rootPath}${filename} ${filename}"
+                            env.CATTLE_TEST_CONFIG = testRootPath+filename
+                          }
+                          dir("./") {     
+                            sh "./validation/configure.sh"
+                            sh "docker build . -f ./validation/Dockerfile.validation -t ${imageName}"
+                            sh "docker volume create --name tests${validationVolume}"
+
+                            sh "docker cp ${testContainer}:${rootPath}${filename} ${filename}"
+                          }
+                        }
+                        stage('Run Validation Tests') {
+
+                          try {
+                            sh """
+                            docker run -v tests${validationVolume}:/root --name ${golangTestContainer} -t --env-file ${envFile} ${imageName} sh -c "/root/go/bin/gotestsum --format standard-verbose --packages=${golangTestDir} --junitfile ${testResultsOut} -- -tags=${TAGS} ${GO_TEST_CASE} -timeout=${timeout} -v "
+                            """
+                            // figure out how to pull imported cluster info from ^ and use it to make a cloud credential for the below job
+                            sh """
+                            docker run -v tests${validationVolume}:/root --name ${golangTestContainer} -t --env-file ${envFile} ${imageName} sh -c "/root/go/bin/gotestsum --format standard-verbose --packages=${golangTestDir} --junitfile ${testResultsOut} -- -tags=${TAGS} ${GO_TEST_CASE} -timeout=${timeout} -v "
+                            """
+                              
+                          } catch(err) {
+                            echo "${err} Validation tests had failures. Aborting"
+                          }
+                          sh """
+                          docker rm ${golangTestContainer} || true
+                          
+                          docker rmi ${imageName} || true
+                          
+                          """
+                          
+                        }
+                    }//dir
+                    stage('Cleanup terraform resources'){
+                      try {
+                          sh """
+                          docker run --rm -v harvester:/terraform-files \
+                              -w /terraform-files hashicorp/terraform:latest \
+                              init && terraform destroy -auto-approve
+                          """
+                      }
+                      catch(err) {
+                        echo "${err} captured, there be dragons..."
+                      }
+                      sh "docker volume rm ${validationVolume} || true"
+                      } //cleanup
+                } //params
+            } //credentials
+        } //folder properties
+    } //wrap
+} // node


### PR DESCRIPTION
dockerfile changes: fixes warning about formatting

azure custodian: update order to fix timing issue network interfaces v. network security groups

import_harvester_test: add step that updates users config.yaml with cloud credential info from the added harvester cluster

jenkinsfile: new jenkinsfile to run e2e harvester tests