### PR TITLE
QOL PR for relevant provisioning release tests

### DIFF
--- a/actions/clusters/clusters.go
+++ b/actions/clusters/clusters.go
@@ -837,7 +837,7 @@ func HardenRKE2ClusterConfig(clusterName, namespace string, clustersConfig *Clus
 	v1Cluster.Spec.RKEConfig.MachineSelectorConfig = []rkev1.RKESystemConfig{
 		{
 			Config: rkev1.GenericMap{
-				Data: map[string]interface{}{
+				Data: map[string]any{
 					"profile":             "cis",
 					protectKernelDefaults: true,
 				},

--- a/validation/certificates/README.md
+++ b/validation/certificates/README.md
@@ -18,8 +18,7 @@ The certificate functional tests validate core certificate functionality in Kube
 Note: RBAC tests for certificates are covered in `rbac/certificates`
 
 ## Certificate Rotation Tests
-
-For certificate rotation, the test has only been tested on RKE2. That does not mean RKE1 or K3S are unsupported, they just have not been tested. These tests are designed to accept an existing cluster that the user has access to. If you do not have a downstream cluster in Rancher, you should create one first before running these tests.
+These tests are designed to accept an existing cluster that the user has access to. If you do not have a downstream cluster in Rancher, you should create one first before running these tests.
 
 Please see below for more details for your config. Please note that the config can be in either JSON or YAML (all examples are illustrated in YAML).
 

--- a/validation/provisioning/hostnametruncation/hostname_truncation_test.go
+++ b/validation/provisioning/hostnametruncation/hostname_truncation_test.go
@@ -44,9 +44,6 @@ func (r *HostnameTruncationTestSuite) SetupSuite() {
 	r.client = client
 }
 
-// TestProvisioningRKE2ClusterTruncation consist of several test that loop through three limits
-// for hostnames. The test starts at a minimum length limit of 10 characters, then a maximum length
-// limit of 63 characters and finally a middle length limit of 31 characters
 func (r *HostnameTruncationTestSuite) TestProvisioningRKE2ClusterTruncation() {
 	tests := []struct {
 		name                        string
@@ -54,50 +51,30 @@ func (r *HostnameTruncationTestSuite) TestProvisioningRKE2ClusterTruncation() {
 		hostnameLengthLimits        []int
 		defaultHostnameLengthLimits []int
 	}{
-		{
-			name:                        "Cluster level truncation",
-			machinePoolNameLengths:      []int{10, 31, 63},
-			defaultHostnameLengthLimits: []int{10, 31, 63},
-		},
-		{
-			name:                        "Machine pool level truncation - 10 characters",
-			machinePoolNameLengths:      []int{10, 10, 10},
-			hostnameLengthLimits:        []int{10, 31, 63},
-			defaultHostnameLengthLimits: []int{10, 16, 63},
-		},
-		{
-			name:                        "Machine pool level truncation - 31 characters",
-			machinePoolNameLengths:      []int{10, 31, 63},
-			hostnameLengthLimits:        []int{31, 31, 31},
-			defaultHostnameLengthLimits: []int{10, 31, 63},
-		},
-		{
-			name:                        "Machine pool level truncation - 63 characters",
-			machinePoolNameLengths:      []int{10, 31, 63},
-			hostnameLengthLimits:        []int{63, 63, 63},
-			defaultHostnameLengthLimits: []int{10, 31, 63},
-		},
-		{
-			name:                        "Cluster and machine pool level truncation - 31 characters",
-			machinePoolNameLengths:      []int{10, 31, 63},
-			hostnameLengthLimits:        []int{31, 31, 31},
-			defaultHostnameLengthLimits: []int{10, 63, 31},
-		},
+		{"Cluster level truncation", []int{10, 31, 63}, []int{10, 31, 63}, []int{10, 31, 63}},
+		{"Machine pool level truncation - 10 characters", []int{10, 10, 10}, []int{10, 31, 63}, []int{10, 16, 63}},
+		{"Machine pool level truncation - 31 characters", []int{10, 31, 63}, []int{31, 31, 31}, []int{10, 31, 63}},
+		{"Machine pool level truncation - 63 characters", []int{10, 31, 63}, []int{63, 63, 63}, []int{10, 31, 63}},
+		{"Cluster and machine pool level truncation - 31 characters", []int{10, 31, 63}, []int{31, 31, 31}, []int{10, 63, 31}},
 	}
 	for _, tt := range tests {
 		for _, defaultLength := range tt.defaultHostnameLengthLimits {
 			r.Run(tt.name+fmt.Sprintf("_defaultHostnameLimit:%d", defaultLength), func() {
 				var hostnamePools []machinepools.HostnameTruncation
+
 				for i, nameLength := range tt.machinePoolNameLengths {
 					currentTruncationPool := machinepools.HostnameTruncation{
 						Name:                   namegen.RandStringLower(nameLength),
 						ClusterNameLengthLimit: defaultLength,
 					}
+
 					if len(tt.hostnameLengthLimits) >= i && len(tt.hostnameLengthLimits) > 0 {
 						currentTruncationPool.PoolNameLengthLimit = tt.hostnameLengthLimits[i]
 					}
+
 					hostnamePools = append(hostnamePools, currentTruncationPool)
 				}
+
 				testConfig := clusters.ConvertConfigToClusterConfig(r.clustersConfig)
 				testConfig.KubernetesVersion = r.clustersConfig.RKE2KubernetesVersions[0]
 				testConfig.CNI = r.clustersConfig.CNIs[0]

--- a/validation/provisioning/import/import_cluster_test.go
+++ b/validation/provisioning/import/import_cluster_test.go
@@ -189,5 +189,6 @@ func (r *ImportProvisioningTestSuite) TestProvisioningImportK3SCluster() {
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestImportProvisioningTestSuite(t *testing.T) {
+	t.Skip("This test has been deprecated; check https://github.com/rancher/tfp-automation for updated tests")
 	suite.Run(t, new(ImportProvisioningTestSuite))
 }

--- a/validation/provisioning/k3s/custom_cluster_test.go
+++ b/validation/provisioning/k3s/custom_cluster_test.go
@@ -82,6 +82,11 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomCluster() 
 	nodeRolesAll := []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
 	nodeRolesShared := []provisioninginput.MachinePools{provisioninginput.EtcdControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
 	nodeRolesDedicated := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
 
 	tests := []struct {
 		name         string
@@ -92,6 +97,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomCluster() 
 		{"1 Node all roles " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesAll, c.client.Flags.GetValue(environmentflag.Short) || c.client.Flags.GetValue(environmentflag.Long)},
 		{"2 nodes - etcd|cp roles per 1 node " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesShared, c.client.Flags.GetValue(environmentflag.Short) || c.client.Flags.GetValue(environmentflag.Long)},
 		{"3 nodes - 1 role per node " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesDedicated, c.client.Flags.GetValue(environmentflag.Long)},
+		{"8 nodes - 3 etcd, 2 cp, 3 worker " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesStandard, c.client.Flags.GetValue(environmentflag.Long)},
 	}
 	for _, tt := range tests {
 		if !tt.runFlag {
@@ -101,6 +107,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningK3SCustomCluster() 
 
 		provisioningConfig := *c.provisioningConfig
 		provisioningConfig.MachinePools = tt.machinePools
+
 		permutations.RunTestPermutations(&c.Suite, tt.name, tt.client, &provisioningConfig, permutations.K3SCustomCluster, nil, nil)
 	}
 }

--- a/validation/provisioning/k3s/hardened_cluster_test.go
+++ b/validation/provisioning/k3s/hardened_cluster_test.go
@@ -1,5 +1,3 @@
-//go:build (validation || sanity) && !infra.any && !infra.aks && !infra.eks && !infra.rke2k3s && !infra.gke && !infra.rke1 && !cluster.any && !cluster.custom && !cluster.nodedriver && !extended && !stress
-
 package k3s
 
 import (
@@ -87,7 +85,11 @@ func (c *HardenedK3SClusterProvisioningTestSuite) SetupSuite() {
 }
 
 func (c *HardenedK3SClusterProvisioningTestSuite) TestProvisioningK3SHardenedCluster() {
-	nodeRolesDedicated := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
 
 	tests := []struct {
 		name            string
@@ -95,8 +97,7 @@ func (c *HardenedK3SClusterProvisioningTestSuite) TestProvisioningK3SHardenedClu
 		machinePools    []provisioninginput.MachinePools
 		scanProfileName string
 	}{
-		{"K3S CIS 1.8 Profile Hardened " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesDedicated, "k3s-cis-1.8-profile-hardened"},
-		{"K3S CIS 1.8 Profile Permissive " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesDedicated, "k3s-cis-1.8-profile-permissive"},
+		{"CIS 1.9 Profile " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesStandard, "k3s-cis-1.9-profile"},
 	}
 	for _, tt := range tests {
 		c.Run(tt.name, func() {

--- a/validation/provisioning/k3s/provisioning_node_driver_test.go
+++ b/validation/provisioning/k3s/provisioning_node_driver_test.go
@@ -82,6 +82,11 @@ func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SCluster() {
 	nodeRolesAll := []provisioninginput.MachinePools{provisioninginput.AllRolesMachinePool}
 	nodeRolesShared := []provisioninginput.MachinePools{provisioninginput.EtcdControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
 	nodeRolesDedicated := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
 
 	tests := []struct {
 		name         string
@@ -92,6 +97,7 @@ func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SCluster() {
 		{"1 Node all roles " + provisioninginput.StandardClientName.String(), nodeRolesAll, k.standardUserClient, k.client.Flags.GetValue(environmentflag.Short) || k.client.Flags.GetValue(environmentflag.Long)},
 		{"2 nodes - etcd|cp roles per 1 node " + provisioninginput.StandardClientName.String(), nodeRolesShared, k.standardUserClient, k.client.Flags.GetValue(environmentflag.Short) || k.client.Flags.GetValue(environmentflag.Long)},
 		{"3 nodes - 1 role per node " + provisioninginput.StandardClientName.String(), nodeRolesDedicated, k.standardUserClient, k.client.Flags.GetValue(environmentflag.Long)},
+		{"8 nodes - 3 etcd, 2 cp, 3 worker " + provisioninginput.StandardClientName.String(), nodeRolesStandard, k.standardUserClient, k.client.Flags.GetValue(environmentflag.Long)},
 	}
 
 	for _, tt := range tests {
@@ -99,8 +105,10 @@ func (k *K3SNodeDriverProvisioningTestSuite) TestProvisioningK3SCluster() {
 			k.T().Logf("SKIPPED")
 			continue
 		}
+
 		provisioningConfig := *k.provisioningConfig
 		provisioningConfig.MachinePools = tt.machinePools
+
 		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
 	}
 }

--- a/validation/provisioning/k3s/psact_test.go
+++ b/validation/provisioning/k3s/psact_test.go
@@ -78,11 +78,11 @@ func (k *K3SPSACTTestSuite) SetupSuite() {
 }
 
 func (k *K3SPSACTTestSuite) TestK3SPSACTNodeDriverCluster() {
-	nodeRolesDedicated := []provisioninginput.MachinePools{
-		provisioninginput.EtcdMachinePool,
-		provisioninginput.ControlPlaneMachinePool,
-		provisioninginput.WorkerMachinePool,
-	}
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
 
 	tests := []struct {
 		name         string
@@ -90,32 +90,17 @@ func (k *K3SPSACTTestSuite) TestK3SPSACTNodeDriverCluster() {
 		psact        provisioninginput.PSACT
 		client       *rancher.Client
 	}{
-		{
-			name:         "Rancher Privileged " + provisioninginput.StandardClientName.String(),
-			machinePools: nodeRolesDedicated,
-			psact:        "rancher-privileged",
-			client:       k.standardUserClient,
-		},
-		{
-			name:         "Rancher Restricted " + provisioninginput.StandardClientName.String(),
-			machinePools: nodeRolesDedicated,
-			psact:        "rancher-restricted",
-			client:       k.standardUserClient,
-		},
-		{
-			name:         "Rancher Baseline " + provisioninginput.AdminClientName.String(),
-			machinePools: nodeRolesDedicated,
-			psact:        "rancher-baseline",
-			client:       k.client,
-		},
+		{"Rancher Privileged " + provisioninginput.AdminClientName.String(), nodeRolesStandard, "rancher-privileged", k.client},
+		{"Rancher Restricted " + provisioninginput.AdminClientName.String(), nodeRolesStandard, "rancher-restricted", k.client},
+		{"Rancher Baseline " + provisioninginput.AdminClientName.String(), nodeRolesStandard, "rancher-baseline", k.client},
 	}
 
 	for _, tt := range tests {
 		provisioningConfig := *k.provisioningConfig
 		provisioningConfig.MachinePools = tt.machinePools
 		provisioningConfig.PSACT = string(tt.psact)
-		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, &provisioningConfig,
-			permutations.K3SProvisionCluster, nil, nil)
+
+		permutations.RunTestPermutations(&k.Suite, tt.name, tt.client, &provisioningConfig, permutations.K3SProvisionCluster, nil, nil)
 	}
 }
 

--- a/validation/provisioning/registries/registry_test.go
+++ b/validation/provisioning/registries/registry_test.go
@@ -465,5 +465,6 @@ func (rt *RegistryTestSuite) configureRKE2K3SRegistry(registryName string, testC
 }
 
 func TestRegistryTestSuite(t *testing.T) {
+	t.Skip("This test has been deprecated; check https://github.com/rancher/tfp-automation for updated tests")
 	suite.Run(t, new(RegistryTestSuite))
 }

--- a/validation/provisioning/resources/cisbenchmark/cisbenchmark.go
+++ b/validation/provisioning/resources/cisbenchmark/cisbenchmark.go
@@ -94,7 +94,5 @@ func RunCISScan(client *rancher.Client, projectClusterID, scanProfileName string
 		return err
 	}
 
-	logrus.Infof("CIS Benchmark scan passed!")
-
 	return nil
 }

--- a/validation/provisioning/rke1/custom_cluster_test.go
+++ b/validation/provisioning/rke1/custom_cluster_test.go
@@ -82,6 +82,11 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 	nodeRolesAll := []provisioninginput.NodePools{provisioninginput.AllRolesNodePool}
 	nodeRolesShared := []provisioninginput.NodePools{provisioninginput.EtcdControlPlaneNodePool, provisioninginput.WorkerNodePool}
 	nodeRolesDedicated := []provisioninginput.NodePools{provisioninginput.EtcdNodePool, provisioninginput.ControlPlaneNodePool, provisioninginput.WorkerNodePool}
+	nodeRolesStandard := []provisioninginput.NodePools{provisioninginput.EtcdNodePool, provisioninginput.ControlPlaneNodePool, provisioninginput.WorkerNodePool}
+
+	nodeRolesStandard[0].NodeRoles.Quantity = 3
+	nodeRolesStandard[1].NodeRoles.Quantity = 2
+	nodeRolesStandard[2].NodeRoles.Quantity = 3
 
 	require.GreaterOrEqual(c.T(), len(c.provisioningConfig.CNIs), 1)
 
@@ -94,6 +99,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 		{"1 Node all roles " + provisioninginput.StandardClientName.String(), nodeRolesAll, c.standardUserClient, c.client.Flags.GetValue(environmentflag.Short) || c.client.Flags.GetValue(environmentflag.Long)},
 		{"2 nodes - etcd|cp roles per 1 node " + provisioninginput.StandardClientName.String(), nodeRolesShared, c.standardUserClient, c.client.Flags.GetValue(environmentflag.Short) || c.client.Flags.GetValue(environmentflag.Long)},
 		{"3 nodes - 1 role per node " + provisioninginput.StandardClientName.String(), nodeRolesDedicated, c.standardUserClient, c.client.Flags.GetValue(environmentflag.Long)},
+		{"8 nodes - 3 etcd, 2 cp, 3 worker " + provisioninginput.StandardClientName.String(), nodeRolesStandard, c.standardUserClient, c.client.Flags.GetValue(environmentflag.Long)},
 	}
 	for _, tt := range tests {
 		if !tt.runFlag {
@@ -104,6 +110,7 @@ func (c *CustomClusterProvisioningTestSuite) TestProvisioningRKE1CustomCluster()
 		provisioningConfig := *c.provisioningConfig
 		provisioningConfig.NodePools = tt.nodePools
 		provisioningConfig.NodePools[0].SpecifyCustomPublicIP = true
+
 		permutations.RunTestPermutations(&c.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE1CustomCluster, nil, nil)
 	}
 }

--- a/validation/provisioning/rke1/hardened_cluster_test.go
+++ b/validation/provisioning/rke1/hardened_cluster_test.go
@@ -34,7 +34,6 @@ type HardenedRKE1ClusterProvisioningTestSuite struct {
 	provisioningConfig  *provisioninginput.Config
 	project             *management.Project
 	chartInstallOptions *charts.InstallOptions
-	chartFeatureOptions *charts.RancherMonitoringOpts
 }
 
 func (c *HardenedRKE1ClusterProvisioningTestSuite) TearDownSuite() {

--- a/validation/provisioning/rke1/provisioning_node_driver_test.go
+++ b/validation/provisioning/rke1/provisioning_node_driver_test.go
@@ -82,6 +82,11 @@ func (r *RKE1NodeDriverProvisioningTestSuite) TestProvisioningRKE1Cluster() {
 	nodeRolesAll := []provisioninginput.NodePools{provisioninginput.AllRolesNodePool}
 	nodeRolesShared := []provisioninginput.NodePools{provisioninginput.EtcdControlPlaneNodePool, provisioninginput.WorkerNodePool}
 	nodeRolesDedicated := []provisioninginput.NodePools{provisioninginput.EtcdNodePool, provisioninginput.ControlPlaneNodePool, provisioninginput.WorkerNodePool}
+	nodeRolesStandard := []provisioninginput.NodePools{provisioninginput.EtcdNodePool, provisioninginput.ControlPlaneNodePool, provisioninginput.WorkerNodePool}
+
+	nodeRolesStandard[0].NodeRoles.Quantity = 3
+	nodeRolesStandard[1].NodeRoles.Quantity = 2
+	nodeRolesStandard[2].NodeRoles.Quantity = 3
 
 	tests := []struct {
 		name      string
@@ -92,14 +97,17 @@ func (r *RKE1NodeDriverProvisioningTestSuite) TestProvisioningRKE1Cluster() {
 		{"1 Node all roles " + provisioninginput.StandardClientName.String(), nodeRolesAll, r.standardUserClient, r.client.Flags.GetValue(environmentflag.Short) || r.client.Flags.GetValue(environmentflag.Long)},
 		{"2 nodes - etcd|cp roles per 1 node " + provisioninginput.StandardClientName.String(), nodeRolesShared, r.standardUserClient, r.client.Flags.GetValue(environmentflag.Short) || r.client.Flags.GetValue(environmentflag.Long)},
 		{"3 nodes - 1 role per node " + provisioninginput.StandardClientName.String(), nodeRolesDedicated, r.standardUserClient, r.client.Flags.GetValue(environmentflag.Long)},
+		{"8 nodes - 3 etcd, 2 cp, 3 worker " + provisioninginput.StandardClientName.String(), nodeRolesStandard, r.standardUserClient, r.client.Flags.GetValue(environmentflag.Long)},
 	}
 	for _, tt := range tests {
 		if !tt.runFlag {
 			r.T().Logf("SKIPPED")
 			continue
 		}
+
 		provisioningConfig := *r.provisioningConfig
 		provisioningConfig.NodePools = tt.nodePools
+
 		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
 	}
 }

--- a/validation/provisioning/rke1/psact_test.go
+++ b/validation/provisioning/rke1/psact_test.go
@@ -78,11 +78,11 @@ func (r *RKE1PSACTTestSuite) SetupSuite() {
 }
 
 func (r *RKE1PSACTTestSuite) TestRKE1PSACTNodeDriverCluster() {
-	nodeRolesDedicated := []provisioninginput.NodePools{
-		provisioninginput.EtcdNodePool,
-		provisioninginput.ControlPlaneNodePool,
-		provisioninginput.WorkerNodePool,
-	}
+	nodeRolesStandard := []provisioninginput.NodePools{provisioninginput.EtcdNodePool, provisioninginput.ControlPlaneNodePool, provisioninginput.WorkerNodePool}
+
+	nodeRolesStandard[0].NodeRoles.Quantity = 3
+	nodeRolesStandard[1].NodeRoles.Quantity = 2
+	nodeRolesStandard[2].NodeRoles.Quantity = 3
 
 	tests := []struct {
 		name      string
@@ -90,32 +90,17 @@ func (r *RKE1PSACTTestSuite) TestRKE1PSACTNodeDriverCluster() {
 		psact     provisioninginput.PSACT
 		client    *rancher.Client
 	}{
-		{
-			name:      "Rancher Privileged " + provisioninginput.StandardClientName.String(),
-			nodePools: nodeRolesDedicated,
-			psact:     "rancher-privileged",
-			client:    r.standardUserClient,
-		},
-		{
-			name:      "Rancher Restricted " + provisioninginput.StandardClientName.String(),
-			nodePools: nodeRolesDedicated,
-			psact:     "rancher-restricted",
-			client:    r.standardUserClient,
-		},
-		{
-			name:      "Rancher Baseline " + provisioninginput.AdminClientName.String(),
-			nodePools: nodeRolesDedicated,
-			psact:     "rancher-baseline",
-			client:    r.client,
-		},
+		{"Rancher Privileged " + provisioninginput.AdminClientName.String(), nodeRolesStandard, "rancher-privileged", r.client},
+		{"Rancher Restricted " + provisioninginput.AdminClientName.String(), nodeRolesStandard, "rancher-restricted", r.client},
+		{"Rancher Baseline " + provisioninginput.AdminClientName.String(), nodeRolesStandard, "rancher-baseline", r.client},
 	}
 
 	for _, tt := range tests {
 		provisioningConfig := *r.provisioningConfig
 		provisioningConfig.NodePools = tt.nodePools
 		provisioningConfig.PSACT = string(tt.psact)
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig,
-			permutations.RKE1ProvisionCluster, nil, nil)
+
+		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE1ProvisionCluster, nil, nil)
 	}
 }
 

--- a/validation/provisioning/rke2/hardened_cluster_test.go
+++ b/validation/provisioning/rke2/hardened_cluster_test.go
@@ -86,7 +86,11 @@ func (c *HardenedRKE2ClusterProvisioningTestSuite) SetupSuite() {
 }
 
 func (c *HardenedRKE2ClusterProvisioningTestSuite) TestProvisioningRKE2HardenedCluster() {
-	nodeRolesDedicated := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
 
 	tests := []struct {
 		name            string
@@ -94,8 +98,7 @@ func (c *HardenedRKE2ClusterProvisioningTestSuite) TestProvisioningRKE2HardenedC
 		machinePools    []provisioninginput.MachinePools
 		scanProfileName string
 	}{
-		{"RKE2 CIS 1.8 Profile Hardened " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesDedicated, "rke2-cis-1.8-profile-hardened"},
-		{"RKE2 CIS 1.8 Profile Permissive " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesDedicated, "rke2-cis-1.8-profile-permissive"},
+		{"CIS 1.9 Profile " + provisioninginput.StandardClientName.String(), c.standardUserClient, nodeRolesStandard, "rke2-cis-1.9-profile"},
 	}
 	for _, tt := range tests {
 		c.Run(tt.name, func() {

--- a/validation/provisioning/rke2/provisioning_node_driver_test.go
+++ b/validation/provisioning/rke2/provisioning_node_driver_test.go
@@ -82,6 +82,11 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2Cluster() {
 	nodeRolesShared := []provisioninginput.MachinePools{provisioninginput.EtcdControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
 	nodeRolesDedicated := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
 	nodeRolesWindows := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool, provisioninginput.WindowsMachinePool}
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
 
 	tests := []struct {
 		name         string
@@ -94,6 +99,7 @@ func (r *RKE2NodeDriverProvisioningTestSuite) TestProvisioningRKE2Cluster() {
 		{"2 nodes - etcd|cp roles per 1 node " + provisioninginput.StandardClientName.String(), nodeRolesShared, r.standardUserClient, false, r.client.Flags.GetValue(environmentflag.Short) || r.client.Flags.GetValue(environmentflag.Long)},
 		{"3 nodes - 1 role per node " + provisioninginput.StandardClientName.String(), nodeRolesDedicated, r.standardUserClient, false, r.client.Flags.GetValue(environmentflag.Long)},
 		{"4 nodes - 1 role per node + 1 Windows worker " + provisioninginput.StandardClientName.String(), nodeRolesWindows, r.standardUserClient, true, r.client.Flags.GetValue(environmentflag.Long)},
+		{"8 nodes - 3 etcd, 2 cp, 3 worker " + provisioninginput.StandardClientName.String(), nodeRolesStandard, r.standardUserClient, false, r.client.Flags.GetValue(environmentflag.Long)},
 	}
 
 	for _, tt := range tests {

--- a/validation/provisioning/rke2/psact_test.go
+++ b/validation/provisioning/rke2/psact_test.go
@@ -78,11 +78,11 @@ func (r *RKE2PSACTTestSuite) SetupSuite() {
 }
 
 func (r *RKE2PSACTTestSuite) TestRKE2PSACTNodeDriverCluster() {
-	nodeRolesDedicated := []provisioninginput.MachinePools{
-		provisioninginput.EtcdMachinePool,
-		provisioninginput.ControlPlaneMachinePool,
-		provisioninginput.WorkerMachinePool,
-	}
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
 
 	tests := []struct {
 		name         string
@@ -90,32 +90,17 @@ func (r *RKE2PSACTTestSuite) TestRKE2PSACTNodeDriverCluster() {
 		psact        provisioninginput.PSACT
 		client       *rancher.Client
 	}{
-		{
-			name:         "Rancher Privileged " + provisioninginput.StandardClientName.String(),
-			machinePools: nodeRolesDedicated,
-			psact:        "rancher-privileged",
-			client:       r.standardUserClient,
-		},
-		{
-			name:         "Rancher Restricted " + provisioninginput.StandardClientName.String(),
-			machinePools: nodeRolesDedicated,
-			psact:        "rancher-restricted",
-			client:       r.standardUserClient,
-		},
-		{
-			name:         "Rancher Baseline " + provisioninginput.AdminClientName.String(),
-			machinePools: nodeRolesDedicated,
-			psact:        "rancher-baseline",
-			client:       r.client,
-		},
+		{"Rancher Privileged " + provisioninginput.AdminClientName.String(), nodeRolesStandard, "rancher-privileged", r.client},
+		{"Rancher Restricted " + provisioninginput.AdminClientName.String(), nodeRolesStandard, "rancher-restricted", r.client},
+		{"Rancher Baseline " + provisioninginput.AdminClientName.String(), nodeRolesStandard, "rancher-baseline", r.client},
 	}
 
 	for _, tt := range tests {
 		provisioningConfig := *r.provisioningConfig
 		provisioningConfig.MachinePools = tt.machinePools
 		provisioningConfig.PSACT = string(tt.psact)
-		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig,
-			permutations.RKE2ProvisionCluster, nil, nil)
+
+		permutations.RunTestPermutations(&r.Suite, tt.name, tt.client, &provisioningConfig, permutations.RKE2ProvisionCluster, nil, nil)
 	}
 }
 

--- a/validation/upgrade/kubernetes.go
+++ b/validation/upgrade/kubernetes.go
@@ -88,6 +88,7 @@ func upgradeDownstreamCluster(u *suite.Suite, testName string, client *rancher.C
 	if cluster.VersionToUpgrade == "" {
 		u.T().Skip(u.T(), cluster.VersionToUpgrade, "Kubernetes version to upgrade is not provided, skipping the test")
 	}
+
 	testConfig.KubernetesVersion = cluster.VersionToUpgrade
 
 	clusterObject, _, _ := extensionscluster.GetProvisioningClusterByName(client, clusterName, namespace)

--- a/validation/upgrade/workload.go
+++ b/validation/upgrade/workload.go
@@ -378,7 +378,7 @@ func createPostUpgradeWorkloads(t *testing.T, client *rancher.Client, clusterNam
 }
 
 func getSteveID(namespaceName, resourceName string) string {
-	return fmt.Sprintf(namespaceName + "/" + resourceName)
+	return fmt.Sprintf("%s/%s", namespaceName, resourceName)
 }
 
 func getProject(client *rancher.Client, clusterName, projectName string) (project *management.Project, err error) {


### PR DESCRIPTION
### Issue: N/A

### PR Description
This PR is a QOL to various provisioning release tests. The PR is doing the following:
- Deprecates registry and import tests as `tfp-automation` handles it
- Adds cluster configuration to 3 etcd, 2 cp and 3 workers to relevant provisioning tests
- General housekeeping