### PR TITLE
updating azure to remove unused public IPs every 2 days.

### DIFF
--- a/scripts/custodian/azure.yaml
+++ b/scripts/custodian/azure.yaml
@@ -307,3 +307,41 @@ policies:
         op: delete
   actions:
     - type: delete
+
+# Public IP Address
+
+
+- name: az-mark-ip-for-deletion
+  resource: azure.publicip
+  description: |
+    Mark IP Addresses for deletion in 2 days
+  filters:
+    - type: resource-lock
+      lock-type: Absent
+    - not: 
+      - type: value
+        key: "tags.known_user"
+        op: regex
+        value: ".*delete.*"
+    - not: 
+      - type: value
+        key: name
+        op: regex
+        value:  "^.*DONOTDELETEKEYS.*$"
+  actions:
+    - type: mark-for-op
+      tag: known_user
+      op: delete
+      days: 2
+
+- name: azure-terminate-ip
+  resource: azure.publicip
+  description: |
+    Delete any marked IP address which have been 
+    marked for deletion for more than 1 day.
+  filters:
+    - type: marked-for-op
+      tag: known_user
+      op: delete
+  actions:
+    - type: delete


### PR DESCRIPTION
tested locally, correctly marks and removes all public IPs not tagged as 'locked' and not used currently. 

note the normal `tag` and `name` filters don't exist for this resource. Since these are protected resources, in the sense that if they are used elsewhere, then you can't remove them, not having these filters shouldn't limit us as the API won't delete them. i.e. 
```
Microsoft.Network/publicIPAddresses/maybeidk2-ip can not be deleted since it is still allocated to resource

```