### PR TITLE
Add back removed Go build tag

### DIFF
--- a/validation/provisioning/k3s/hardened_cluster_test.go
+++ b/validation/provisioning/k3s/hardened_cluster_test.go
@@ -1,3 +1,5 @@
+//go:build (validation || sanity) && !infra.any && !infra.aks && !infra.eks && !infra.rke2k3s && !infra.gke && !infra.rke1 && !cluster.any && !cluster.custom && !cluster.nodedriver && !extended && !stress
+
 package k3s
 
 import (
@@ -32,7 +34,6 @@ type HardenedK3SClusterProvisioningTestSuite struct {
 	provisioningConfig  *provisioninginput.Config
 	project             *management.Project
 	chartInstallOptions *charts.InstallOptions
-	chartFeatureOptions *charts.RancherMonitoringOpts
 }
 
 func (c *HardenedK3SClusterProvisioningTestSuite) TearDownSuite() {


### PR DESCRIPTION
### Issue: N/A

### PR Description
As part of the last PR, accidentally removed the go tag from the test for hardening K3s clusters. This is adding it back.