### PR TITLE
fix terminate labels for marked-for-op

### DIFF
--- a/scripts/custodian/gcp.yaml
+++ b/scripts/custodian/gcp.yaml
@@ -78,10 +78,8 @@ policies:
   filters:
     - or:
       - type: marked-for-op
-        label: unknown_user
         op: delete
       - type: marked-for-op
-        label: known_user
         op: delete
   actions:
     - type: delete
@@ -161,10 +159,8 @@ policies:
   filters:
     - or:
       - type: marked-for-op
-        label: unknown_user
         op: delete
       - type: marked-for-op
-        label: known_user
         op: delete
   actions:
     - type: delete


### PR DESCRIPTION
terminates weren't working because gcp doesn't support the label I copied from the other cloud config files. 