### PR TITLE
Add action for uploading schema files

### DIFF
--- a/.github/workflows/qase.yml
+++ b/.github/workflows/qase.yml
@@ -10,15 +10,15 @@ jobs:
   run-script:
     name: update-qase
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
       
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: "./go.mod"
           cache-dependency-path: "**/*.sum"

--- a/.github/workflows/qase.yml
+++ b/.github/workflows/qase.yml
@@ -1,0 +1,29 @@
+name: Qase Test Upload
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '**/schemas/**'
+  
+jobs:
+  run-script:
+    name: update-qase
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+          cache-dependency-path: "**/*.sum"
+
+      - name: Update Qase Tests
+        env:
+          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
+        run: go run ./validation/pipeline/qase/schemaupload/main.go


### PR DESCRIPTION
This is just a simple GH Action that runs the schemaupload on merge to main. It requires a change to be made to a schema to run at all.

See https://github.com/rancher-max/rancher-tests/actions/runs/15501356038/job/43649494777#step:4:12 for a working run. I have since updated the step names and removed the edit to the schema file that caused this to trigger.