### PR TITLE
added to exceptionMap

### DIFF
--- a/validation/schemas/schemas.go
+++ b/validation/schemas/schemas.go
@@ -47,6 +47,7 @@ var exceptionMap = map[string]bool{
 	"schemaDefinition":         true,
 	"subscribe":                true,
 	"userpreference":           true,
+	"gateway.networking.k8s.io.referencegrant": true,
 }
 
 func getSchemaByID(client *rancher.Client, clusterID, existingSchemaID string) (map[string]interface{}, error) {


### PR DESCRIPTION
### Add gateway.networking.k8s.io.referencegrant to Exception Map

### Problem
`TestPreferredVersionCheckDownstreamCluster` is failing with

Schema ID: gateway.networking.k8s.io.referencegrant, Schema Version: v1beta1; API Group Name: gateway.networking.k8s.io, API Group Version: v1

### What's going on
referenceGrant is stuck at v1beta1 while the Gateway API group prefers v1. This is actually intentional - from the Gateway API docs

> ReferenceGrant is a special case since it's transitioning to upstream Kubernetes API owned by sig-auth. Until resolved, ReferenceGrant will be effectively frozen as beta in Gateway API

So basically:
- gateway API group prefers v1 
- most resources (Gateway, HTTPRoute) support v1  
- referenceGrant only supports v1beta1 by design

our test caught this version mismatch, which is working as expected.

### Fix
just add it to the exception map since this is documented behavior that won't change anytime soon

```go
var exceptionMap = map[string]bool{
    // ... existing exceptions
    "gateway.networking.k8s.io.referencegrant": true,
}
```

## Links to docs
- https://gateway-api.sigs.k8s.io/concepts/versioning/ 
  > "ReferenceGrant is a special case since it is in the process of transitioning into an upstream Kubernetes API that is owned by sig-auth. Until that is resolved, it is likely that ReferenceGrant will be effectively frozen as beta in Gateway API."

- https://gateway-api.sigs.k8s.io/api-types/referencegrant/
  > "The ReferenceGrant resource is Beta and part of the Standard Channel since v0.6.0."
