### PR TITLE
vai only sort case

### DIFF
--- a/validation/steve/vai/vai_only_secret_sort.go
+++ b/validation/steve/vai/vai_only_secret_sort.go
@@ -1,0 +1,69 @@
+package vai
+
+import (
+	"fmt"
+	"net/url"
+
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var vaiOnlySecretSortCases = []secretSortTestCase{
+	{
+		name: "Sort by label should include secrets without that label in results",
+		createSecrets: func(sortFunc func() url.Values) ([]v1.Secret, []string, []string) {
+			suffix := namegen.RandStringLower(randomStringLength)
+			ns := fmt.Sprintf("namespace-%s", suffix)
+
+			name1 := "secret-no-priority-1"
+			name2 := "secret-high-priority-2"
+			name3 := "secret-low-priority-3"
+			name4 := "secret-no-priority-4"
+
+			secrets := []v1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name1,
+						Namespace: ns,
+						// No labels
+					},
+					Type: v1.SecretTypeOpaque,
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name2,
+						Namespace: ns,
+						Labels:    map[string]string{"priority": "high"},
+					},
+					Type: v1.SecretTypeOpaque,
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name3,
+						Namespace: ns,
+						Labels:    map[string]string{"priority": "low"},
+					},
+					Type: v1.SecretTypeOpaque,
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name4,
+						Namespace: ns,
+						// No labels
+					},
+					Type: v1.SecretTypeOpaque,
+				},
+			}
+
+			// For ASC NULLS LAST: labeled secrets first (alphabetically), then unlabeled secrets last
+			expectedOrder := []string{name2, name3, name1, name4} // "high", "low", null, null
+
+			return secrets, expectedOrder, []string{ns}
+		},
+		sort: func() url.Values {
+			return url.Values{"sort": []string{"metadata.labels.priority"}}
+		},
+		supportedWithVai: true,
+	},
+}

--- a/validation/steve/vai/vai_test.go
+++ b/validation/steve/vai/vai_test.go
@@ -1010,6 +1010,11 @@ func (v *VaiTestSuite) TestVaiEnabled() {
 		v.runSecretSortTestCases(supportedWithVai)
 	})
 
+	v.Run("VaiOnlySecretSorting", func() {
+		supportedWithVai := filterTestCases(vaiOnlySecretSortCases, true)
+		v.runSecretSortTestCases(supportedWithVai)
+	})
+
 	v.Run("CheckVaiDescription", v.checkVaiDescription)
 
 	v.Run("TimestampCacheTests", func() {


### PR DESCRIPTION
```log
=== RUN   TestVaiTestSuite
time="2025-07-22T15:08:36-07:00" level=info msg="Feature: ui-sql-cache"
time="2025-07-22T15:08:36-07:00" level=info msg="  spec.value: <nil>"
time="2025-07-22T15:08:36-07:00" level=info msg="  status.default: true"
time="2025-07-22T15:08:36-07:00" level=info msg="  status.description: Improve performance by enabling SQLite-backed caching. This also enables server-side pagination and other scaling based performance improvements."
time="2025-07-22T15:08:36-07:00" level=info msg="  status.dynamic: false"
time="2025-07-22T15:08:36-07:00" level=info msg="  status.lockedValue: <nil>"
time="2025-07-22T15:08:36-07:00" level=info msg="  VAI enabled: true (spec.value is nil, using default)"
=== RUN   TestVaiTestSuite/TestVaiEnabled
=== RUN   TestVaiTestSuite/TestVaiEnabled/VaiOnlySecretSorting
=== RUN   TestVaiTestSuite/TestVaiEnabled/VaiOnlySecretSorting/Sort_by_label_should_include_secrets_without_that_label_in_results
time="2025-07-22T15:08:36-07:00" level=info msg="Starting case: Sort by label should include secrets without that label in results"
time="2025-07-22T15:08:36-07:00" level=info msg="Running with vai enabled: [true]"
--- PASS: TestVaiTestSuite/TestVaiEnabled/VaiOnlySecretSorting/Sort_by_label_should_include_secrets_without_that_label_in_results (1.80s)
--- PASS: TestVaiTestSuite/TestVaiEnabled/VaiOnlySecretSorting (1.80s)
--- PASS: TestVaiTestSuite/TestVaiEnabled (1.80s)
--- PASS: TestVaiTestSuite (15.63s)
PASS
```