### PR TITLE
Increase deployment verification timeout to 15 minutes for Windows compatibility

### DIFF
--- a/actions/workloads/deployment/verify.go
+++ b/actions/workloads/deployment/verify.go
@@ -28,7 +28,7 @@ const (
 
 // VerifyDeployment waits for a deployment to be ready in the downstream cluster
 func VerifyDeployment(steveClient *steveV1.Client, deployment *steveV1.SteveAPIObject) error {
-	err := kwait.PollUntilContextTimeout(context.TODO(), 500*time.Millisecond, defaults.FiveMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
+	err := kwait.PollUntilContextTimeout(context.TODO(), 500*time.Millisecond, defaults.FifteenMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
 		deploymentResp, err := steveClient.SteveType(DeploymentSteveType).ByID(deployment.Namespace + "/" + deployment.Name)
 		if err != nil {
 			return false, nil


### PR DESCRIPTION
This PR updates the VerifyDeployment function to use a 15-minute timeout instead of 5 minutes.

Windows nodes take longer to pull container images, and this change ensures that deployment verification has enough time to succeed during snapshot restore tests and similar flows.

This avoids test failures caused by premature timeouts when running on Windows clusters.