### PR TITLE
Add check rancher tag workflow

### DIFF
--- a/.github/actions/compare-rancher-tag/action.yaml
+++ b/.github/actions/compare-rancher-tag/action.yaml
@@ -1,0 +1,66 @@
+---
+name: Compare Rancher tag
+description: "Compares the latest Rancher tag for specified release lines with cached values"
+inputs:
+  cached-tag-v212:
+    required: true
+  cached-tag-v211:
+    required: true
+  cached-tag-v210:
+    required: true
+  cached-tag-v29:
+    required: true
+  latest-tag-v212:
+    required: true
+  latest-tag-v211:
+    required: true
+  latest-tag-v210:
+    required: true
+  latest-tag-v29:
+    required: true
+outputs:
+  is_tag_new_v212:
+    value: ${{ steps.compare.outputs.is_tag_new_v212 }}
+  is_tag_new_v211:
+    value: ${{ steps.compare.outputs.is_tag_new_v211 }}
+  is_tag_new_v210:
+    value: ${{ steps.compare.outputs.is_tag_new_v210 }}
+  is_tag_new_v29:
+    value: ${{ steps.compare.outputs.is_tag_new_v29 }}
+runs:
+  using: composite
+  steps:
+    - id: compare
+      run: |
+        for RELEASE_LINE in v212 v211 v210 v29; do
+          if [[ "$RELEASE_LINE" = "v212" ]]; then
+            TAG_INPUT="${{ inputs.latest-tag-v212 }}"
+            CACHED_TAG="${{ inputs.cached-tag-v212 }}"
+          elif [[ "$RELEASE_LINE" = "v211" ]]; then
+            TAG_INPUT="${{ inputs.latest-tag-v211 }}"
+            CACHED_TAG="${{ inputs.cached-tag-v211 }}"
+          elif [[ "$RELEASE_LINE" = "v210" ]]; then
+            TAG_INPUT="${{ inputs.latest-tag-v210 }}"
+            CACHED_TAG="${{ inputs.cached-tag-v210 }}"
+          elif [[ "$RELEASE_LINE" = "v29" ]]; then
+            TAG_INPUT="${{ inputs.latest-tag-v29 }}"
+            CACHED_TAG="${{ inputs.cached-tag-v29 }}"
+          fi
+
+          echo "Cached Rancher tag for $RELEASE_LINE: $CACHED_TAG"
+          echo "Latest Rancher tag for $RELEASE_LINE: $TAG_INPUT"
+
+          if [ "$CACHED_TAG" != "$TAG_INPUT" ]; then
+            echo "New tag for $RELEASE_LINE: $TAG_INPUT"
+            eval "IS_TAG_NEW_$RELEASE_LINE=true"
+          else
+            echo "No new tag found yet for $RELEASE_LINE..."
+            eval "IS_TAG_NEW_$RELEASE_LINE=false"
+          fi
+        done
+
+        echo "is_tag_new_v212=$IS_TAG_NEW_v212" >> $GITHUB_OUTPUT
+        echo "is_tag_new_v211=$IS_TAG_NEW_v211" >> $GITHUB_OUTPUT
+        echo "is_tag_new_v210=$IS_TAG_NEW_v210" >> $GITHUB_OUTPUT
+        echo "is_tag_new_v29=$IS_TAG_NEW_v29" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/actions/get-latest-rancher-tag/action.yaml
+++ b/.github/actions/get-latest-rancher-tag/action.yaml
@@ -1,0 +1,67 @@
+---
+name: Get latest Rancher tag
+description: Gets the latest Rancher tag for the specified release lines
+inputs:
+  release_lines:
+    description: "List Rancher release lines"
+    required: true
+  prime_artifacts_path:
+    description: "Path to prime artifacts"
+    required: true
+outputs:
+  latest_tag_v212:
+    description: "Latest tag for v2.12"
+    value: ${{ steps.set-outputs.outputs.latest_tag_v212 }}
+  latest_tag_v211:
+    description: "Latest tag for v2.11"
+    value: ${{ steps.set-outputs.outputs.latest_tag_v211 }}
+  latest_tag_v210:
+    description: "Latest tag for v2.10"
+    value: ${{ steps.set-outputs.outputs.latest_tag_v210 }}
+  latest_tag_v29:
+    description: "Latest tag for v2.9"
+    value: ${{ steps.set-outputs.outputs.latest_tag_v29 }}
+runs:
+  using: composite
+  steps:
+    - id: get-tags
+      run: |
+        RELEASE_LINES="${{ inputs.release_lines }}"
+        TAGS=$(curl -s https://api.github.com/repos/rancher/rancher/releases | jq -r '.[].tag_name')
+
+        for RELEASE_LINE in $RELEASE_LINES; do
+          LATEST_VERSION=$(curl -s https://api.github.com/repos/rancher/rancher/releases | jq -r '.[].tag_name' | grep -E "^$RELEASE_LINE" | head -n 1)
+
+          echo "Latest tag for $RELEASE_LINE: $LATEST_VERSION"
+
+          if [[ "$RELEASE_LINE" == "v2.12" ]]; then
+            RELEASE_JSON=$(curl -s "https://api.github.com/repos/rancher/rancher/releases/tags/$LATEST_VERSION")
+            ASSET_COUNT=$(echo "$RELEASE_JSON" | jq '.assets | length')
+
+            echo "Asset count for $LATEST_VERSION: $ASSET_COUNT"
+
+            if [ "$ASSET_COUNT" -lt 17 ]; then
+              echo "Asset count: $ASSET_COUNT. Expected at least 17 assets..."
+              LATEST_VERSION=""
+            fi
+          else
+            RELEASE_JSON=$(curl -s ${{ inputs.prime_artifacts_path }}/$RELEASE_LINE/rancher-images.txt)
+
+            if [[ $? -ne 0 ]]; then
+              echo "Unable to reach: ${{ inputs.prime_artifacts_path }}/$RELEASE_LINE/rancher-images.txt"
+              LATEST_VERSION=""
+            fi
+          fi
+
+          SUFFIX=$(echo "$RELEASE_LINE" | tr -d '.')
+          eval "LATEST_TAG_${SUFFIX}=$LATEST_VERSION"
+          echo "LATEST_TAG_${SUFFIX}=$LATEST_VERSION" >> $GITHUB_ENV
+        done
+      shell: bash
+    - id: set-outputs
+      run: |
+        echo "latest_tag_v212=$LATEST_TAG_v212" >> $GITHUB_OUTPUT
+        echo "latest_tag_v211=$LATEST_TAG_v211" >> $GITHUB_OUTPUT
+        echo "latest_tag_v210=$LATEST_TAG_v210" >> $GITHUB_OUTPUT
+        echo "latest_tag_v29=$LATEST_TAG_v29" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/check-rancher-tag.yml
+++ b/.github/workflows/check-rancher-tag.yml
@@ -1,0 +1,153 @@
+---
+name: Check Rancher Tag
+
+on:
+  schedule:
+    - cron: "0 16,20 * * 1-5"
+    - cron: "0 0 * * 2-6"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  check-latest-rancher-tag:
+    if: github.ref == 'refs/heads/main' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    env:
+      RANCHER_RELEASE_LINES: "v2.12 v2.11 v2.10 v2.9"
+      SANITIZED_RELEASES: "v212 v211 v210 v29"
+    outputs:
+      latest_tag_v212: ${{ steps.get-latest-tag.outputs.latest_tag_v212 }}
+      latest_tag_v211: ${{ steps.get-latest-tag.outputs.latest_tag_v211 }}
+      latest_tag_v210: ${{ steps.get-latest-tag.outputs.latest_tag_v210 }}
+      latest_tag_v29: ${{ steps.get-latest-tag.outputs.latest_tag_v29 }}
+      is_tag_new_v212: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v212 }}
+      is_tag_new_v211: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v211 }}
+      is_tag_new_v210: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v210 }}
+      is_tag_new_v29: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v29 }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Fetch Rancher tags from S3
+        run: |
+          for release in $SANITIZED_RELEASES; do
+            if aws s3 ls "s3://${{ secrets.RANCHER_TAG_BUCKET }}/tag_${release}.txt" > /dev/null 2>&1; then
+              aws s3 cp "s3://${{ secrets.RANCHER_TAG_BUCKET }}/tag_${release}.txt" "tag/tag_${release}.txt"
+            else
+              echo "Skipping $release — no tag file found in bucket."
+            fi
+          done
+
+      - name: Get latest Rancher tag
+        id: get-latest-tag
+        uses: ./.github/actions/get-latest-rancher-tag
+        with:
+          release_lines: ${{ env.RANCHER_RELEASE_LINES }}
+          prime_artifacts_path: ${{ secrets.PRIME_ARTIFACTS_PATH }}
+
+      - name: Read cached Rancher tags
+        id: read-cached-tags
+        run: |
+          for release in $SANITIZED_RELEASES; do
+            cache_tag="CACHED_TAG_${release}"
+            file="tag/tag_${release}.txt"
+            version=$(cat "$file" 2>/dev/null || echo '')
+            echo "${cache_tag}=${version}" >> $GITHUB_ENV
+          done
+
+      - name: Compare latest Rancher tag against cached tag
+        id: compare-rancher-tag
+        uses: ./.github/actions/compare-rancher-tag
+        with:
+          cached-tag-v212: ${{ env.CACHED_TAG_v212 }}
+          cached-tag-v211: ${{ env.CACHED_TAG_v211 }}
+          cached-tag-v210: ${{ env.CACHED_TAG_v210 }}
+          cached-tag-v29: ${{ env.CACHED_TAG_v29 }}
+          latest-tag-v212: ${{ steps.get-latest-tag.outputs.latest_tag_v212 }}
+          latest-tag-v211: ${{ steps.get-latest-tag.outputs.latest_tag_v211 }}
+          latest-tag-v210: ${{ steps.get-latest-tag.outputs.latest_tag_v210 }}
+          latest-tag-v29: ${{ steps.get-latest-tag.outputs.latest_tag_v29 }}
+
+      - name: Write latest tags to files
+        env:
+          LATEST_TAG_V212: ${{ steps.get-latest-tag.outputs.latest_tag_v212 }}
+          LATEST_TAG_V211: ${{ steps.get-latest-tag.outputs.latest_tag_v211 }}
+          LATEST_TAG_V210: ${{ steps.get-latest-tag.outputs.latest_tag_v210 }}
+          LATEST_TAG_V29: ${{ steps.get-latest-tag.outputs.latest_tag_v29 }}
+        run: |
+          mkdir -p tag
+          for release in $SANITIZED_RELEASES; do
+            latest_tag="LATEST_TAG_${release^^}"
+            echo "${!latest_tag}" > tag/tag_${release}.txt
+          done
+
+      - name: Update Rancher tags to S3
+        run: |
+          for release in $SANITIZED_RELEASES; do
+            aws s3 cp "tag/tag_${release}.txt" "s3://${{ secrets.RANCHER_TAG_BUCKET }}/tag_${release}.txt"
+          done
+
+  set-latest-chart-version:
+    needs: check-latest-rancher-tag
+    runs-on: ubuntu-latest
+    outputs:
+      chart_version_v212: ${{ steps.set-latest-chart-version.outputs.chart_version_v212 }}
+      chart_version_v211: ${{ steps.set-latest-chart-version.outputs.chart_version_v211 }}
+      chart_version_v210: ${{ steps.set-latest-chart-version.outputs.chart_version_v210 }}
+      chart_version_v29: ${{ steps.set-latest-chart-version.outputs.chart_version_v29 }}
+
+    steps:
+      - name: Chart versions
+        id: set-latest-chart-version
+        run: |
+          CHART_V212="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v212 }}"
+          CHART_V211="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v211 }}"
+          CHART_V210="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v210 }}"
+          CHART_V29="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v29 }}"
+
+          echo "chart_version_v212=${CHART_V212#v}" >> $GITHUB_OUTPUT
+          echo "chart_version_v211=${CHART_V211#v}" >> $GITHUB_OUTPUT
+          echo "chart_version_v210=${CHART_V210#v}" >> $GITHUB_OUTPUT
+          echo "chart_version_v29=${CHART_V29#v}" >> $GITHUB_OUTPUT
+
+  trigger-tests-v212:
+    needs: [check-latest-rancher-tag, set-latest-chart-version]
+    if: ${{ needs.check-latest-rancher-tag.outputs.is_tag_new_v212 == 'true' }}
+    uses: ./.github/workflows/dispatch-workflows.yml
+    with:
+      rancher_version: ${{ needs.check-latest-rancher-tag.outputs.latest_tag_v212 }}
+      rancher_chart_version: ${{ needs.set-latest-chart-version.outputs.chart_version_v212 }}
+
+  trigger-tests-v211:
+    needs: [check-latest-rancher-tag, set-latest-chart-version]
+    if: ${{ needs.check-latest-rancher-tag.outputs.is_tag_new_v211 == 'true' }}
+    uses: ./.github/workflows/dispatch-workflows.yml
+    with:
+      rancher_version: ${{ needs.check-latest-rancher-tag.outputs.latest_tag_v211 }}
+      rancher_chart_version: ${{ needs.set-latest-chart-version.outputs.chart_version_v211 }}
+
+  trigger-tests-v210:
+    needs: [check-latest-rancher-tag, set-latest-chart-version]
+    if: ${{ needs.check-latest-rancher-tag.outputs.is_tag_new_v210 == 'true' }}
+    uses: ./.github/workflows/dispatch-workflows.yml
+    with:
+      rancher_version: ${{ needs.check-latest-rancher-tag.outputs.latest_tag_v210 }}
+      rancher_chart_version: ${{ needs.set-latest-chart-version.outputs.chart_version_v210 }}
+
+  trigger-tests-v29:
+    needs: [check-latest-rancher-tag, set-latest-chart-version]
+    if: ${{ needs.check-latest-rancher-tag.outputs.is_tag_new_v29 == 'true' }}
+    uses: ./.github/workflows/dispatch-workflows.yml
+    with:
+      rancher_version: ${{ needs.check-latest-rancher-tag.outputs.latest_tag_v29 }}
+      rancher_chart_version: ${{ needs.set-latest-chart-version.outputs.chart_version_v29 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
   verify-gomod:
     name: verify-gomod
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/dispatch-workflows.yml
+++ b/.github/workflows/dispatch-workflows.yml
@@ -1,0 +1,31 @@
+---
+name: Dispatch Workflows
+
+on:
+  workflow_call:
+    inputs:
+      rancher_version:
+        required: true
+        type: string
+      rancher_chart_version:
+        required: true
+        type: string
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        workflow:
+          - recurring-tests.yml
+
+    steps:
+      - name: Trigger test workflow ${{ matrix.workflow }}
+        run: |
+          echo "Rancher Version: ${{ inputs.rancher_version }}"
+          echo "Rancher Chart Version: ${{ inputs.rancher_chart_version }}"
+          curl -X POST https://api.github.com/repos/${{ github.repository }}/actions/workflows/${{ matrix.workflow }}/dispatches \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            -d '{"ref": "main", "inputs": {"rancher_version": "${{ inputs.rancher_version }}", "rancher_chart_version": "${{ inputs.rancher_chart_version }}"}}'

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -34,6 +34,16 @@ on:
       rancher-chart-version-2-9:
         description: Rancher chart version for v2.9.x
         default: "v2.9-head"
+  workflow_call:
+    inputs:
+      rancher_version:
+        description: "Rancher tag version provided from check-rancher-tag workflow"
+        required: true
+        type: string
+      rancher_chart_version:
+        description: "Rancher chart version provided from check-rancher-tag workflow"
+        required: true
+        type: string
 
 permissions:
   id-token: write


### PR DESCRIPTION
### Issue: N/A

### Description
Now that we have recurring runs ported over to `rancher/tests`, we should port over the `tfp-automation` solution for checking rancher tags. As this has been consistently working for some time now, not much changes need to happen as the pain points have been worked through.