### PR TITLE
Add daily provisioning workflow

### DIFF
--- a/.github/workflows/daily-cluster-provisioning.yml
+++ b/.github/workflows/daily-cluster-provisioning.yml
@@ -1,9 +1,9 @@
 ---
-name: Hostbusters QA Recurring Runs
+name: Hostbusters Daily Cluster Provisioning
 
 on:
   schedule:
-    - cron: "0 11 * * 1"
+    - cron: "0 10 * * 1-5"
   workflow_dispatch:
     inputs:
       rancher_version:
@@ -34,16 +34,6 @@ on:
       rancher-chart-version-2-9:
         description: Rancher chart version for v2.9.x
         default: "v2.9-head"
-  workflow_call:
-    inputs:
-      rancher_version:
-        description: "Rancher tag version provided from check-rancher-tag workflow"
-        required: true
-        type: string
-      rancher_chart_version:
-        description: "Rancher chart version provided from check-rancher-tag workflow"
-        required: true
-        type: string
 
 permissions:
   id-token: write
@@ -51,7 +41,7 @@ permissions:
 
 env:
   CLOUD_PROVIDER_VERSION: "5.95.0"
-  HOSTNAME_PREFIX: "gha-recur"
+  HOSTNAME_PREFIX: "gha-prov"
   TIMEOUT: "5h"
 
 jobs:
@@ -176,6 +166,12 @@ jobs:
               awsUser: "${{ secrets.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
+              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
+              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
+              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
               loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
               targetType: "${{ vars.TARGET_TYPE }}"
@@ -195,9 +191,6 @@ jobs:
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          scalingInput:
-            nodeProvider: "ec2"
 
           clusterConfig:
             cni: "${{ secrets.CNI }}"
@@ -232,7 +225,7 @@ jobs:
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
-                awsCICDInstanceTag: "hb-recurring-runs"
+                awsCICDInstanceTag: "hb-daily-provisioning"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ secrets.AWS_USER }}"
                 volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
@@ -242,7 +235,7 @@ jobs:
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
-                awsCICDInstanceTag: "hb-recurring-runs-wins"
+                awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
                 volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
                 roles: ["windows"]
@@ -274,8 +267,15 @@ jobs:
       - name: Creating Rancher server
         run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/createRancherServer.go
 
-      - name: Run Test Suites
-        uses: ./.github/actions/run-hostbusters-test-suites
+      - name: Run K3S Provisioning Tests
+        run: |
+          gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s \
+          --junitfile results.xml -- -timeout=3h -tags=recurring -v
+
+      - name: Run RKE2 Provisioning Tests
+        run: |
+          gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 \
+          --junitfile results.xml -- -timeout=3h -tags=recurring -v
 
       - name: Reporting Results to Qase
         if: always()
@@ -420,6 +420,12 @@ jobs:
               awsUser: "${{ secrets.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
+              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
+              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
+              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
               loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
               targetType: "${{ vars.TARGET_TYPE }}"
@@ -439,9 +445,6 @@ jobs:
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: "${{ vars.TERRAFORM_LOGGING }}"
-
-          scalingInput:
-            nodeProvider: "ec2"
 
           clusterConfig:
             cni: "${{ secrets.CNI }}"
@@ -476,7 +479,7 @@ jobs:
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
-                awsCICDInstanceTag: "hb-recurring-runs"
+                awsCICDInstanceTag: "hb-daily-provisioning"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ secrets.AWS_USER }}"
                 volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
@@ -486,7 +489,7 @@ jobs:
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
-                awsCICDInstanceTag: "hb-recurring-runs-wins"
+                awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
                 volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
                 roles: ["windows"]
@@ -518,8 +521,15 @@ jobs:
       - name: Creating Rancher server
         run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/createRancherServer.go
 
-      - name: Run Test Suites
-        uses: ./.github/actions/run-hostbusters-test-suites
+      - name: Run K3S Provisioning Tests
+        run: |
+          gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s \
+          --junitfile results.xml -- -timeout=3h -tags=recurring -v
+
+      - name: Run RKE2 Provisioning Tests
+        run: |
+          gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 \
+          --junitfile results.xml -- -timeout=3h -tags=recurring -v
 
       - name: Reporting Results to Qase
         if: always()
@@ -664,6 +674,12 @@ jobs:
               awsUser: "${{ secrets.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
+              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
+              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
+              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
               loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
               targetType: "${{ vars.TARGET_TYPE }}"
@@ -683,9 +699,6 @@ jobs:
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: "${{ vars.TERRAFORM_LOGGING }}"
-
-          scalingInput:
-            nodeProvider: "ec2"
 
           clusterConfig:
             cni: "${{ secrets.CNI }}"
@@ -720,7 +733,7 @@ jobs:
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
-                awsCICDInstanceTag: "hb-recurring-runs"
+                awsCICDInstanceTag: "hb-daily-provisioning"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ secrets.AWS_USER }}"
                 volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
@@ -730,7 +743,7 @@ jobs:
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
-                awsCICDInstanceTag: "hb-recurring-runs-wins"
+                awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
                 volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
                 roles: ["windows"]
@@ -762,8 +775,15 @@ jobs:
       - name: Creating Rancher server
         run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/createRancherServer.go
 
-      - name: Run Test Suites
-        uses: ./.github/actions/run-hostbusters-test-suites
+      - name: Run K3S Provisioning Tests
+        run: |
+          gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s \
+          --junitfile results.xml -- -timeout=3h -tags=recurring -v
+
+      - name: Run RKE2 Provisioning Tests
+        run: |
+          gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 \
+          --junitfile results.xml -- -timeout=3h -tags=recurring -v
 
       - name: Reporting Results to Qase
         if: always()
@@ -907,6 +927,12 @@ jobs:
               awsUser: "${{ secrets.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
+              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
+              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
+              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
               loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
               targetType: "${{ vars.TARGET_TYPE }}"
@@ -926,9 +952,6 @@ jobs:
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: "${{ vars.TERRAFORM_LOGGING }}"
-
-          scalingInput:
-            nodeProvider: "ec2"
 
           clusterConfig:
             cni: "${{ secrets.CNI }}"
@@ -963,7 +986,7 @@ jobs:
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
-                awsCICDInstanceTag: "hb-recurring-runs"
+                awsCICDInstanceTag: "hb-daily-provisioning-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ secrets.AWS_USER }}"
                 volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
@@ -973,7 +996,7 @@ jobs:
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
-                awsCICDInstanceTag: "hb-recurring-runs-wins"
+                awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
                 volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
                 roles: ["windows"]
@@ -1005,8 +1028,15 @@ jobs:
       - name: Creating Rancher server
         run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/createRancherServer.go
 
-      - name: Run Test Suites
-        uses: ./.github/actions/run-hostbusters-test-suites
+      - name: Run K3S Provisioning Tests
+        run: |
+          gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s \
+          --junitfile results.xml -- -timeout=3h -tags=recurring -v
+
+      - name: Run RKE2 Provisioning Tests
+        run: |
+          gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 \
+          --junitfile results.xml -- -timeout=3h -tags=recurring -v
 
       - name: Reporting Results to Qase
         if: always()

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/rancher/shepherd v0.0.0-20250806164026-f0b65006babd
 	github.com/rancher/tests/actions v0.0.0-20250806190403-cb1746eb0d9d
 	github.com/rancher/tests/interoperability v0.0.0-00010101000000-000000000000
-	github.com/rancher/tfp-automation v0.0.0-20250805185108-98f2e826d0a7
+	github.com/rancher/tfp-automation v0.0.0-20250808204141-19342d1b9adc
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2207,8 +2207,8 @@ github.com/rancher/shepherd v0.0.0-20250806164026-f0b65006babd h1:0M6xSIbWmbA2pz
 github.com/rancher/shepherd v0.0.0-20250806164026-f0b65006babd/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd h1:M3oVcVktMhNk8l3ZRW94kroqzWzE/VGbZfLw/F0rw5Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd/go.mod h1:VfRrgue4yl6O0GYakMGYgyByu7ySooPQWWRxTt2MIEI=
-github.com/rancher/tfp-automation v0.0.0-20250805185108-98f2e826d0a7 h1:KwMMUn8a7nPzq3deIbiA0xmnY7lvPU6sIGcJ3zH4POo=
-github.com/rancher/tfp-automation v0.0.0-20250805185108-98f2e826d0a7/go.mod h1:vPJ6Cw1ZekSdf0lMUZ7lqz6w4UUGNL5UMZBk3vmZBro=
+github.com/rancher/tfp-automation v0.0.0-20250808204141-19342d1b9adc h1:pqUcCz4CbnO53TO3Uy+M1ufhFOU+B9p0mphb9a1pNA4=
+github.com/rancher/tfp-automation v0.0.0-20250808204141-19342d1b9adc/go.mod h1:vPJ6Cw1ZekSdf0lMUZ7lqz6w4UUGNL5UMZBk3vmZBro=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/validation/recurring/infrastructure/setuprancher/createRancherServer.go
+++ b/validation/recurring/infrastructure/setuprancher/createRancherServer.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/tfp-automation/framework/cleanup"
 	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	resources "github.com/rancher/tfp-automation/framework/set/resources/sanity"
+	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/rancher/tfp-automation/tests/infrastructure"
 	"github.com/sirupsen/logrus"
 )
@@ -40,7 +41,7 @@ func main() {
 
 func setupRancher(t *testing.T) (*rancher.Client, error) {
 	cattleConfig := shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	rancherConfig, terraformConfig, terratestConfig := tfpConfig.LoadTFPConfigs(cattleConfig)
+	rancherConfig, terraformConfig, terratestConfig, standaloneConfig := tfpConfig.LoadTFPConfigs(cattleConfig)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.SanityKeyPath, terratestConfig.PathToRepo, terraformConfig.Provider)
 	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)
@@ -56,6 +57,8 @@ func setupRancher(t *testing.T) (*rancher.Client, error) {
 	if err != nil && *rancherConfig.Cleanup {
 		cleanup.Cleanup(nil, terraformOptions, keyPath)
 	}
+
+	provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.RancherTagVersion)
 
 	return client, err
 }


### PR DESCRIPTION
### Issue: N/A

### Description
In a recent Hostbusters 2.12 retro, it was acknowledged the level of issues that were being seen. One of the takeaways is that more coverage of basic provisioning is needed. While `tfp-automation` conducts daily sanity testing, it would be preferred if we have `rancher/tests` do this as well.

That way, every day, we have standard users provisioning RKE2/K3s with the Rancher2 provider and with non Terraform. The new `daily-cluster-provisioning.yml` is essentially a copy/paste from `recurring-runs.yml` with the following edits:
- Scaling part of the configs have been removed
- Resource prefix here is `gha-prov`
- This runs once each weekday as opposed to once a week
- `check-rancher-tag` will NOT trigger this workflow when new tags are cut