### PR TITLE
Fix config issues in hostbusters workflows

### DIFF
--- a/.github/actions/run-hostbusters-test-suites/action.yaml
+++ b/.github/actions/run-hostbusters-test-suites/action.yaml
@@ -8,65 +8,76 @@ runs:
       run: |
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/certificates/rke2k3s \
         --junitfile results.xml -- -timeout=60m -tags=recurring -v -run "TestCertRotationTestSuite/TestCertRotation"
+      shell: bash
     
     - name: Run Delete Cluster Tests
       run: |
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/rke2k3s \
         --junitfile results.xml -- -timeout=60m -tags=recurring -v -run "TestDeleteClusterTestSuite/TestDeletingCluster"
+      shell: bash
 
     - name: Run Delete Init Machine Tests
       run: |
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/rke2k3s \
         --junitfile results.xml -- -timeout=60m -tags=recurring -v -run "TestDeleteInitMachineTestSuite/TestDeleteInitMachine"
+      shell: bash
 
     - name: Run Node Replacing Tests
       run: |
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/rke2k3s \
         --junitfile results.xml -- -timeout=60m -tags=recurring -v -run "TestNodeReplacingTestSuite/TestReplacingNodes"
+      shell: bash
 
     - name: Run K3S Provisioning Tests
       run: |
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s \
         --junitfile results.xml -- -timeout=3h -tags=recurring -v
+      shell: bash
 
     - name: Run RKE2 Provisioning Tests
       run: |
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 \
         --junitfile results.xml -- -timeout=3h -tags=recurring -v
+      shell: bash
 
     - name: Run Scaling Custom Cluster Tests
       run: |
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/rke2k3s \
         --junitfile results.xml -- -timeout=60m -tags=recurring -v -run "TestCustomClusterNodeScalingTestSuite/TestScalingCustomClusterNodes"
+      shell: bash
 
     - name: Run Scaling Node Driver Cluster Tests
       run: |
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/rke2k3s \
         --junitfile results.xml -- -timeout=60m -tags=recurring -v -run "TestNodeScalingTestSuite/TestScalingNodePools"
+      shell: bash
 
     - name: Run Snapshot Recurring Tests
       run: |
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/rke2k3s \
         --junitfile results.xml -- -timeout=60m -tags=recurring -v -run "TestSnapshotRecurringTestSuite/TestSnapshotRecurringRestores"
+      shell: bash
 
     - name: Run Snapshot Tests
       run: |
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/rke2k3s \
         --junitfile results.xml -- -timeout=60m -tags=recurring -v -run "TestSnapshotRestoreTestSuite/TestSnapshotRestore"
+      shell: bash
 
     - name: Run Snapshot Windows Tests
       run: |
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/rke2k3s \
         --junitfile results.xml -- -timeout=60m -tags=recurring -v -run "TestSnapshotRestoreWindowsTestSuite/TestSnapshotRestoreWindows"
+      shell: bash
 
     - name: Run Upgrade Tests
       run: |
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/rke2k3s \
         --junitfile results.xml -- -timeout=60m -tags=recurring -v -run "TestKubernetesUpgradeTestSuite/TestUpgradeKubernetes"
+      shell: bash
 
     - name: Run Upgrade Windows Tests
       run: |
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/rke2k3s \
         --junitfile results.xml -- -timeout=60m -tags=recurring -v -run "TestWindowsKubernetesUpgradeTestSuite/TestUpgradeWindowsKubernetes"
-
       shell: bash

--- a/.github/workflows/daily-cluster-provisioning.yml
+++ b/.github/workflows/daily-cluster-provisioning.yml
@@ -206,6 +206,7 @@ jobs:
             region: "${{ secrets.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
@@ -228,7 +229,7 @@ jobs:
                 awsCICDInstanceTag: "hb-daily-provisioning"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ secrets.AWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
@@ -237,7 +238,7 @@ jobs:
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -271,11 +272,13 @@ jobs:
         run: |
           gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s \
           --junitfile results.xml -- -timeout=3h -tags=recurring -v
+        shell: bash
 
       - name: Run RKE2 Provisioning Tests
         run: |
           gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 \
           --junitfile results.xml -- -timeout=3h -tags=recurring -v
+        shell: bash
 
       - name: Reporting Results to Qase
         if: always()
@@ -460,6 +463,7 @@ jobs:
             region: "${{ secrets.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
@@ -482,7 +486,7 @@ jobs:
                 awsCICDInstanceTag: "hb-daily-provisioning"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ secrets.AWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
@@ -491,7 +495,7 @@ jobs:
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -525,11 +529,13 @@ jobs:
         run: |
           gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s \
           --junitfile results.xml -- -timeout=3h -tags=recurring -v
+        shell: bash
 
       - name: Run RKE2 Provisioning Tests
         run: |
           gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 \
           --junitfile results.xml -- -timeout=3h -tags=recurring -v
+        shell: bash
 
       - name: Reporting Results to Qase
         if: always()
@@ -714,6 +720,7 @@ jobs:
             region: "${{ secrets.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
@@ -736,7 +743,7 @@ jobs:
                 awsCICDInstanceTag: "hb-daily-provisioning"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ secrets.AWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
@@ -745,7 +752,7 @@ jobs:
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -779,11 +786,13 @@ jobs:
         run: |
           gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s \
           --junitfile results.xml -- -timeout=3h -tags=recurring -v
+        shell: bash
 
       - name: Run RKE2 Provisioning Tests
         run: |
           gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 \
           --junitfile results.xml -- -timeout=3h -tags=recurring -v
+        shell: bash
 
       - name: Reporting Results to Qase
         if: always()
@@ -967,6 +976,7 @@ jobs:
             region: "${{ secrets.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
@@ -989,7 +999,7 @@ jobs:
                 awsCICDInstanceTag: "hb-daily-provisioning-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ secrets.AWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
@@ -998,7 +1008,7 @@ jobs:
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -1032,11 +1042,13 @@ jobs:
         run: |
           gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s \
           --junitfile results.xml -- -timeout=3h -tags=recurring -v
+        shell: bash
 
       - name: Run RKE2 Provisioning Tests
         run: |
           gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 \
           --junitfile results.xml -- -timeout=3h -tags=recurring -v
+        shell: bash
 
       - name: Reporting Results to Qase
         if: always()

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -235,7 +235,7 @@ jobs:
                 awsCICDInstanceTag: "hb-recurring-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ secrets.AWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
@@ -244,7 +244,7 @@ jobs:
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs-wins"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -479,7 +479,7 @@ jobs:
                 awsCICDInstanceTag: "hb-recurring-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ secrets.AWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
@@ -488,7 +488,7 @@ jobs:
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs-wins"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -723,7 +723,7 @@ jobs:
                 awsCICDInstanceTag: "hb-recurring-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ secrets.AWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
@@ -732,7 +732,7 @@ jobs:
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs-wins"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
@@ -966,7 +966,7 @@ jobs:
                 awsCICDInstanceTag: "hb-recurring-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ secrets.AWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
@@ -975,7 +975,7 @@ jobs:
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs-wins"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
-                volumeSize: "${{ vars.AWS_ROOT_SIZE }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"


### PR DESCRIPTION
### Issue: N/A

### Description
From our first runs, noted several issues in the workflows. The following PR fixes these issues noted:
- `volumeSize` removes the quotes to be read as integers
- `shell: bash` is added to the `run-hostbusters-test-suites` action; failed as the run command didn't know which shell to invoke
- Add missing `ami` to the `awsMachineConfigs`; caused PSACT tests to fail