### PR TITLE
Add missing template config + fix security groups

### DIFF
--- a/.github/workflows/daily-cluster-provisioning.yml
+++ b/.github/workflows/daily-cluster-provisioning.yml
@@ -249,7 +249,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -259,7 +259,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -267,6 +267,17 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+          
+          templateTest:
+          repo:
+            metadata:
+              name: "test"
+            spec:
+              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+              gitBranch: main
+              insecureSkipTLSVerify: true
+          templateProvider: "aws"
+          templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -521,7 +532,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -531,7 +542,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -539,6 +550,17 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+
+          templateTest:
+          repo:
+            metadata:
+              name: "test"
+            spec:
+              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+              gitBranch: main
+              insecureSkipTLSVerify: true
+          templateProvider: "aws"
+          templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -793,7 +815,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -803,7 +825,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -811,6 +833,17 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+          
+          templateTest:
+          repo:
+            metadata:
+              name: "test"
+            spec:
+              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+              gitBranch: main
+              insecureSkipTLSVerify: true
+          templateProvider: "aws"
+          templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1064,7 +1097,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -1074,7 +1107,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -1082,6 +1115,17 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+
+          templateTest:
+          repo:
+            metadata:
+              name: "test"
+            spec:
+              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+              gitBranch: main
+              insecureSkipTLSVerify: true
+          templateProvider: "aws"
+          templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -246,7 +246,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -256,7 +256,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs-wins"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -264,6 +264,17 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+
+          templateTest:
+          repo:
+            metadata:
+              name: "test"
+            spec:
+              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+              gitBranch: main
+              insecureSkipTLSVerify: true
+          templateProvider: "aws"
+          templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -505,7 +516,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -515,7 +526,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs-wins"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -523,6 +534,17 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+
+          templateTest:
+          repo:
+            metadata:
+              name: "test"
+            spec:
+              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+              gitBranch: main
+              insecureSkipTLSVerify: true
+          templateProvider: "aws"
+          templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -764,7 +786,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -774,7 +796,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs-wins"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -782,6 +804,17 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+
+          templateTest:
+          repo:
+            metadata:
+              name: "test"
+            spec:
+              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+              gitBranch: main
+              insecureSkipTLSVerify: true
+          templateProvider: "aws"
+          templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1022,7 +1055,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -1032,7 +1065,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs-wins"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -1040,6 +1073,17 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+
+          templateTest:
+          repo:
+            metadata:
+              name: "test"
+            spec:
+              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+              gitBranch: main
+              insecureSkipTLSVerify: true
+          templateProvider: "aws"
+          templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG


### PR DESCRIPTION
### Description
On a test run of the recurring runs/provisioning workflows, it was noted there were two issues:
- Security groups were not respected due to it not being read as a string
- Template test portion of the config was missing

This PR fixes those two things.