### PR TITLE
Fix identing in templateTest

### DIFF
--- a/.github/workflows/daily-cluster-provisioning.yml
+++ b/.github/workflows/daily-cluster-provisioning.yml
@@ -269,15 +269,15 @@ jobs:
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
           
           templateTest:
-          repo:
-            metadata:
-              name: "test"
-            spec:
-              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-              gitBranch: main
-              insecureSkipTLSVerify: true
-          templateProvider: "aws"
-          templateName: "cluster-template1"
+            repo:
+              metadata:
+                name: "test"
+              spec:
+                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+                gitBranch: main
+                insecureSkipTLSVerify: true
+            templateProvider: "aws"
+            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -552,15 +552,15 @@ jobs:
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
 
           templateTest:
-          repo:
-            metadata:
-              name: "test"
-            spec:
-              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-              gitBranch: main
-              insecureSkipTLSVerify: true
-          templateProvider: "aws"
-          templateName: "cluster-template1"
+            repo:
+              metadata:
+                name: "test"
+              spec:
+                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+                gitBranch: main
+                insecureSkipTLSVerify: true
+            templateProvider: "aws"
+            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -835,15 +835,15 @@ jobs:
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
           
           templateTest:
-          repo:
-            metadata:
-              name: "test"
-            spec:
-              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-              gitBranch: main
-              insecureSkipTLSVerify: true
-          templateProvider: "aws"
-          templateName: "cluster-template1"
+            repo:
+              metadata:
+                name: "test"
+              spec:
+                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+                gitBranch: main
+                insecureSkipTLSVerify: true
+            templateProvider: "aws"
+            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1117,15 +1117,15 @@ jobs:
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
 
           templateTest:
-          repo:
-            metadata:
-              name: "test"
-            spec:
-              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-              gitBranch: main
-              insecureSkipTLSVerify: true
-          templateProvider: "aws"
-          templateName: "cluster-template1"
+            repo:
+              metadata:
+                name: "test"
+              spec:
+                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+                gitBranch: main
+                insecureSkipTLSVerify: true
+            templateProvider: "aws"
+            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -266,15 +266,15 @@ jobs:
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
 
           templateTest:
-          repo:
-            metadata:
-              name: "test"
-            spec:
-              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-              gitBranch: main
-              insecureSkipTLSVerify: true
-          templateProvider: "aws"
-          templateName: "cluster-template1"
+            repo:
+              metadata:
+                name: "test"
+              spec:
+                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+                gitBranch: main
+                insecureSkipTLSVerify: true
+            templateProvider: "aws"
+            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -536,15 +536,15 @@ jobs:
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
 
           templateTest:
-          repo:
-            metadata:
-              name: "test"
-            spec:
-              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-              gitBranch: main
-              insecureSkipTLSVerify: true
-          templateProvider: "aws"
-          templateName: "cluster-template1"
+            repo:
+              metadata:
+                name: "test"
+              spec:
+                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+                gitBranch: main
+                insecureSkipTLSVerify: true
+            templateProvider: "aws"
+            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -806,15 +806,15 @@ jobs:
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
 
           templateTest:
-          repo:
-            metadata:
-              name: "test"
-            spec:
-              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-              gitBranch: main
-              insecureSkipTLSVerify: true
-          templateProvider: "aws"
-          templateName: "cluster-template1"
+            repo:
+              metadata:
+                name: "test"
+              spec:
+                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+                gitBranch: main
+                insecureSkipTLSVerify: true
+            templateProvider: "aws"
+            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1075,15 +1075,15 @@ jobs:
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
 
           templateTest:
-          repo:
-            metadata:
-              name: "test"
-            spec:
-              gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-              gitBranch: main
-              insecureSkipTLSVerify: true
-          templateProvider: "aws"
-          templateName: "cluster-template1"
+            repo:
+              metadata:
+                name: "test"
+              spec:
+                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+                gitBranch: main
+                insecureSkipTLSVerify: true
+            templateProvider: "aws"
+            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG


### PR DESCRIPTION
### Description
There is an error in the last provisioning run and it is:

```
Run go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/createRancherServer.go
panic: error converting YAML to JSON: yaml: line 104: did not find expected ',' or ']'
```
In recent changes, `templateTest` was added the config. However, the ident is incorrect. 