### PR TITLE
Removing quotes in the security groups names

### DIFF
--- a/.github/workflows/daily-cluster-provisioning.yml
+++ b/.github/workflows/daily-cluster-provisioning.yml
@@ -249,7 +249,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -259,7 +259,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -532,7 +532,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -542,7 +542,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -815,7 +815,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -825,7 +825,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -1097,7 +1097,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -1107,7 +1107,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-daily-provisioning-windows"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -246,7 +246,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -256,7 +256,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs-wins"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -516,7 +516,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -526,7 +526,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs-wins"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -786,7 +786,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -796,7 +796,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs-wins"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
@@ -1055,7 +1055,7 @@ jobs:
               - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
@@ -1065,7 +1065,7 @@ jobs:
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: ["${{ secrets.AWS_SECURITY_GROUP_NAMES }}"]
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "hb-recurring-runs-wins"
                 awsUser: "${{ secrets.AWS_WINDOWS_USER }}"


### PR DESCRIPTION
### Description
Whack-a-mole continues with the config issues in the Hostbusters workflows. Removing the quotes in the security groups names now to completely revert it back to when the last "working" Rancher server was.