### PR TITLE
Updated Qase schema to include test time

### DIFF
--- a/.github/actions/run-hostbusters-test-suites/action.yaml
+++ b/.github/actions/run-hostbusters-test-suites/action.yaml
@@ -8,7 +8,7 @@ runs:
       run: |
         set +e
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/certificates/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=60m -tags=recurring -v -run "TestCertRotationTestSuite/TestCertRotation";
+        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestCertRotationTestSuite/TestCertRotation";
         ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
         ./validation/reporter
       shell: bash
@@ -18,7 +18,7 @@ runs:
       run: |
         set +e
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=60m -tags=recurring -v -run "TestDeleteClusterTestSuite/TestDeletingCluster";
+        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestDeleteClusterTestSuite/TestDeletingCluster";
         ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
         ./validation/reporter
       shell: bash
@@ -28,7 +28,7 @@ runs:
       run: |
         set +e
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=60m -tags=recurring -v -run "TestDeleteInitMachineTestSuite/TestDeleteInitMachine";
+        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestDeleteInitMachineTestSuite/TestDeleteInitMachine";
         ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
         ./validation/reporter
       shell: bash
@@ -38,7 +38,7 @@ runs:
       run: |
         set +e
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=60m -tags=recurring -v -run "TestNodeReplacingTestSuite/TestReplacingNodes";
+        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestNodeReplacingTestSuite/TestReplacingNodes";
         ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
         ./validation/reporter
       shell: bash
@@ -68,7 +68,7 @@ runs:
       run: |
         set +e
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=60m -tags=recurring -v -run "TestCustomClusterNodeScalingTestSuite/TestScalingCustomClusterNodes";
+        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestCustomClusterNodeScalingTestSuite/TestScalingCustomClusterNodes";
         ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
         ./validation/reporter
       shell: bash
@@ -78,7 +78,7 @@ runs:
       run: |
         set +e
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=60m -tags=recurring -v -run "TestNodeScalingTestSuite/TestScalingNodePools";
+        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestNodeScalingTestSuite/TestScalingNodePools";
         ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
         ./validation/reporter
       shell: bash
@@ -88,7 +88,7 @@ runs:
       run: |
         set +e
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=60m -tags=recurring -v -run "TestSnapshotRecurringTestSuite/TestSnapshotRecurringRestores";
+        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestSnapshotRecurringTestSuite/TestSnapshotRecurringRestores";
         ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
         ./validation/reporter
       shell: bash
@@ -98,7 +98,7 @@ runs:
       run: |
         set +e
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=60m -tags=recurring -v -run "TestSnapshotRestoreTestSuite/TestSnapshotRestore";
+        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestSnapshotRestoreTestSuite/TestSnapshotRestore";
         ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
         ./validation/reporter
       shell: bash
@@ -108,7 +108,7 @@ runs:
       run: |
         set +e
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=60m -tags=recurring -v -run "TestSnapshotRestoreWindowsTestSuite/TestSnapshotRestoreWindows";
+        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestSnapshotRestoreWindowsTestSuite/TestSnapshotRestoreWindows";
         ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
         ./validation/reporter
       shell: bash
@@ -118,7 +118,7 @@ runs:
       run: |
         set +e
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=60m -tags=recurring -v -run "TestKubernetesUpgradeTestSuite/TestUpgradeKubernetes";
+        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestKubernetesUpgradeTestSuite/TestUpgradeKubernetes";
         ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
         ./validation/reporter
       shell: bash
@@ -128,7 +128,7 @@ runs:
       run: |
         set +e
         gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=60m -tags=recurring -v -run "TestWindowsKubernetesUpgradeTestSuite/TestUpgradeWindowsKubernetes";
+        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestWindowsKubernetesUpgradeTestSuite/TestUpgradeWindowsKubernetes";
         ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
         ./validation/reporter
       shell: bash

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -52,7 +52,7 @@ permissions:
 env:
   CLOUD_PROVIDER_VERSION: "5.95.0"
   HOSTNAME_PREFIX: "gha-recur"
-  TIMEOUT: "5h"
+  TIMEOUT: "9h"
 
 jobs:
   v2-12:

--- a/actions/provisioning/qase.go
+++ b/actions/provisioning/qase.go
@@ -1,6 +1,8 @@
 package provisioning
 
 import (
+	"time"
+
 	rancherEc2 "github.com/rancher/shepherd/clients/ec2"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
@@ -28,12 +30,15 @@ func GetProvisioningSchemaParams(client *rancher.Client, cattleConfig map[string
 		return nil
 	}
 
+	currentDate := time.Now().Format("2006-01-02 03:04PM")
+
 	osParam := upstream.Params{Title: "OS", Values: osNames}
 	providerParam := upstream.Params{Title: "Provider", Values: []string{clusterConfig.Provider}}
 	k8sParam := upstream.Params{Title: "K8sVersion", Values: []string{clusterConfig.KubernetesVersion}}
 	cniParam := upstream.Params{Title: "CNI", Values: []string{clusterConfig.CNI}}
+	timeParam := upstream.Params{Title: "Time", Values: []string{currentDate}}
 
-	params = append(params, providerParam, osParam, k8sParam, cniParam)
+	params = append(params, providerParam, osParam, k8sParam, cniParam, timeParam)
 
 	return params
 }
@@ -54,12 +59,15 @@ func GetCustomSchemaParams(client *rancher.Client, cattleConfig map[string]any) 
 		return nil
 	}
 
+	currentDate := time.Now().Format("2006-01-02 03:04PM")
+
 	osParam := upstream.Params{Title: "OS", Values: osNames}
 	providerParam := upstream.Params{Title: "Provider", Values: []string{clusterConfig.Provider}}
 	k8sParam := upstream.Params{Title: "K8sVersion", Values: []string{clusterConfig.KubernetesVersion}}
 	cniParam := upstream.Params{Title: "CNI", Values: []string{clusterConfig.CNI}}
+	timeParam := upstream.Params{Title: "Time", Values: []string{currentDate}}
 
-	params = append(params, providerParam, osParam, k8sParam, cniParam)
+	params = append(params, providerParam, osParam, k8sParam, cniParam, timeParam)
 
 	return params
 }

--- a/validation/certificates/rke2k3s/cert_rotation_test.go
+++ b/validation/certificates/rke2k3s/cert_rotation_test.go
@@ -15,10 +15,13 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/validation/certificates"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -96,6 +99,12 @@ func (c *CertRotationTestSuite) TestCertRotation() {
 		c.Run(tt.name, func() {
 			require.NoError(c.T(), certificates.RotateCerts(c.client, cluster.Name))
 		})
+
+		params := provisioning.GetProvisioningSchemaParams(c.client, c.cattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
 	}
 }
 

--- a/validation/certificates/rke2k3s/cert_rotation_wins_test.go
+++ b/validation/certificates/rke2k3s/cert_rotation_wins_test.go
@@ -15,10 +15,13 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/validation/certificates"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -92,6 +95,12 @@ func (c *CertRotationWindowsTestSuite) TestCertRotationWindows() {
 		c.Run(tt.name, func() {
 			require.NoError(c.T(), certificates.RotateCerts(c.client, cluster.Name))
 		})
+
+		params := provisioning.GetProvisioningSchemaParams(c.client, c.cattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
 	}
 }
 

--- a/validation/deleting/rke2k3s/delete_cluster_test.go
+++ b/validation/deleting/rke2k3s/delete_cluster_test.go
@@ -16,8 +16,10 @@ import (
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -92,6 +94,12 @@ func (d *DeleteClusterTestSuite) TestDeletingCluster() {
 			extClusters.DeleteK3SRKE2Cluster(d.client, tt.clusterID)
 			provisioning.VerifyDeleteRKE2K3SCluster(d.T(), d.client, tt.clusterID)
 		})
+
+		params := provisioning.GetProvisioningSchemaParams(d.client, d.cattleConfig)
+		err := qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
 	}
 }
 

--- a/validation/deleting/rke2k3s/delete_init_machine_test.go
+++ b/validation/deleting/rke2k3s/delete_init_machine_test.go
@@ -14,9 +14,12 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -91,6 +94,12 @@ func (d *DeleteInitMachineTestSuite) TestDeleteInitMachine() {
 			err := deleteInitMachine(d.client, tt.clusterID)
 			require.NoError(d.T(), err)
 		})
+
+		params := provisioning.GetProvisioningSchemaParams(d.client, d.cattleConfig)
+		err := qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
 	}
 }
 

--- a/validation/nodescaling/rke2k3s/scale_replace_test.go
+++ b/validation/nodescaling/rke2k3s/scale_replace_test.go
@@ -15,10 +15,13 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/machinepools"
+	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/scalinginput"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -117,6 +120,12 @@ func (s *NodeReplacingTestSuite) TestReplacingNodes() {
 			err := scalinginput.ReplaceNodes(s.client, cluster.Name, tt.nodeRoles.Etcd, tt.nodeRoles.ControlPlane, tt.nodeRoles.Worker)
 			require.NoError(s.T(), err)
 		})
+
+		params := provisioning.GetProvisioningSchemaParams(s.client, s.cattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
 	}
 }
 

--- a/validation/nodescaling/rke2k3s/scaling_custom_cluster_test.go
+++ b/validation/nodescaling/rke2k3s/scaling_custom_cluster_test.go
@@ -15,11 +15,14 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/machinepools"
+	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/scalinginput"
 	"github.com/rancher/tests/validation/nodescaling"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -133,6 +136,12 @@ func (s *CustomClusterNodeScalingTestSuite) TestScalingCustomClusterNodes() {
 			operations.LoadObjectFromMap(ec2.ConfigurationFileKey, s.cattleConfig, awsEC2Configs)
 			nodescaling.ScalingRKE2K3SCustomClusterPools(s.T(), s.client, tt.clusterID, s.scalingConfig.NodeProvider, tt.nodeRoles, awsEC2Configs)
 		})
+
+		params := provisioning.GetCustomSchemaParams(s.client, s.cattleConfig)
+		err := qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
 	}
 }
 

--- a/validation/nodescaling/rke2k3s/scaling_node_driver_test.go
+++ b/validation/nodescaling/rke2k3s/scaling_node_driver_test.go
@@ -15,11 +15,14 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/machinepools"
+	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/scalinginput"
 	"github.com/rancher/tests/validation/nodescaling"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -129,6 +132,12 @@ func (s *NodeScalingTestSuite) TestScalingNodePools() {
 
 			nodescaling.ScalingRKE2K3SNodePools(s.T(), s.client, tt.clusterID, tt.nodeRoles)
 		})
+
+		params := provisioning.GetProvisioningSchemaParams(s.client, s.cattleConfig)
+		err := qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
 	}
 }
 

--- a/validation/snapshot/rke2k3s/snapshot_recurring_test.go
+++ b/validation/snapshot/rke2k3s/snapshot_recurring_test.go
@@ -16,9 +16,12 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/etcdsnapshot"
+	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -103,6 +106,12 @@ func (s *SnapshotRecurringTestSuite) TestSnapshotRecurringRestores() {
 			err := etcdsnapshot.CreateAndValidateSnapshotRestore(s.client, cluster.Name, tt.etcdSnapshot, containerImage)
 			require.NoError(s.T(), err)
 		})
+
+		params := provisioning.GetProvisioningSchemaParams(s.client, s.cattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
 	}
 }
 

--- a/validation/snapshot/rke2k3s/snapshot_restore_test.go
+++ b/validation/snapshot/rke2k3s/snapshot_restore_test.go
@@ -16,9 +16,12 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/etcdsnapshot"
+	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -126,6 +129,12 @@ func (s *SnapshotRestoreTestSuite) TestSnapshotRestore() {
 			err := etcdsnapshot.CreateAndValidateSnapshotRestore(s.client, cluster.Name, tt.etcdSnapshot, containerImage)
 			require.NoError(s.T(), err)
 		})
+
+		params := provisioning.GetProvisioningSchemaParams(s.client, s.cattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
 	}
 }
 

--- a/validation/snapshot/rke2k3s/snapshot_restore_wins_test.go
+++ b/validation/snapshot/rke2k3s/snapshot_restore_wins_test.go
@@ -16,9 +16,12 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/etcdsnapshot"
+	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -96,6 +99,12 @@ func (s *SnapshotRestoreWindowsTestSuite) TestSnapshotRestoreWindows() {
 			err := etcdsnapshot.CreateAndValidateSnapshotRestore(s.client, cluster.Name, tt.etcdSnapshot, windowsContainerImage)
 			require.NoError(s.T(), err)
 		})
+
+		params := provisioning.GetProvisioningSchemaParams(s.client, s.cattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
 	}
 }
 

--- a/validation/snapshot/rke2k3s/snapshot_s3_restore_test.go
+++ b/validation/snapshot/rke2k3s/snapshot_s3_restore_test.go
@@ -16,9 +16,12 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/etcdsnapshot"
+	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -104,6 +107,12 @@ func (s *S3SnapshotRestoreTestSuite) TestS3SnapshotRestore() {
 			err := etcdsnapshot.CreateAndValidateSnapshotRestore(s.client, cluster.Name, tt.etcdSnapshot, containerImage)
 			require.NoError(s.T(), err)
 		})
+
+		params := provisioning.GetProvisioningSchemaParams(s.client, s.cattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
 	}
 }
 


### PR DESCRIPTION
### Description
As per offline discussions, as we are consolidating our Qase test runs, we want to mirror what tfp-automation is doing with our test names and add the time and date it runs. This is so that we will get a "new" test appearing in Qase.