### PR TITLE
Update recurring runs to use strategy matrix

### DIFF
--- a/.github/actions/run-hostbusters-test-suites/action.yaml
+++ b/.github/actions/run-hostbusters-test-suites/action.yaml
@@ -1,135 +1,59 @@
 ---
-name: Run Test Suites
-description: "Runs various test suites"
-runs:
-  using: composite
-  steps:
-    - name: Run Certificate Rotation Test Suite
-      run: |
-        set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/certificates/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestCertRotationTestSuite/TestCertRotation";
-        ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-        ./validation/reporter
-      shell: bash
-      continue-on-error: true
-    
-    - name: Run Delete Cluster Tests
-      run: |
-        set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestDeleteClusterTestSuite/TestDeletingCluster";
-        ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-        ./validation/reporter
-      shell: bash
-      continue-on-error: true
+ name: Run Test Suite
+ description: "Runs a specific test suite based on input"
+ inputs:
+   suite:
+     description: "The test suite to run"
+     required: true
+ runs:
+   using: composite
+   steps:
+     - name: Run Selected Test Suite
+       run: |
+         set +e
+         case "${{ inputs.suite }}" in
+           cert-rotation)
+             gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/certificates/rke2k3s \
+             --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v -run "TestCertRotationTestSuite/TestCertRotation";;
+           delete-cluster)
+             gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/rke2k3s \
+             --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v -run "TestDeleteClusterTestSuite/TestDeletingCluster";;
+           delete-init-machine)
+             gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/rke2k3s \
+             --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v -run "TestDeleteInitMachineTestSuite/TestDeleteInitMachine";;
+           node-replacing)
+             gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/rke2k3s \
+             --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v -run "TestNodeReplacingTestSuite/TestReplacingNodes";;
+           scaling-custom-cluster)
+             gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/rke2k3s \
+             --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v -run "TestCustomClusterNodeScalingTestSuite/TestScalingCustomClusterNodes";;
+           scaling-node-driver)
+             gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/rke2k3s \
+             --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v -run "TestNodeScalingTestSuite/TestScalingNodePools";;
+           k3s-provisioning)
+             gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s \
+             --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v;;
+           rke2-provisioning)
+             gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 \
+             --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v;;
+           snapshot)
+             gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/rke2k3s \
+             --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v -run "TestSnapshotRestoreTestSuite/TestSnapshotRestore";;
+           snapshot-windows)
+             gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/rke2k3s \
+             --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v -run "TestSnapshotRestoreWindowsTestSuite/TestSnapshotRestoreWindows";;
+           snapshot-recurring)
+             gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/rke2k3s \
+             --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v -run "TestSnapshotRecurringTestSuite/TestSnapshotRecurringRestores";;
+           upgrade)
+             gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/rke2k3s \
+             --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v -run "TestKubernetesUpgradeTestSuite/TestUpgradeKubernetes";;
+           upgrade-windows)
+             gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/rke2k3s \
+             --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v -run "TestWindowsKubernetesUpgradeTestSuite/TestUpgradeWindowsKubernetes";;
+         esac
 
-    - name: Run Delete Init Machine Tests
-      run: |
-        set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestDeleteInitMachineTestSuite/TestDeleteInitMachine";
-        ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-        ./validation/reporter
-      shell: bash
-      continue-on-error: true
-
-    - name: Run Node Replacing Tests
-      run: |
-        set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestNodeReplacingTestSuite/TestReplacingNodes";
-        ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-        ./validation/reporter
-      shell: bash
-      continue-on-error: true
-
-    - name: Run K3S Provisioning Tests
-      run: |
-        set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v;
-        ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-        ./validation/reporter
-      shell: bash
-      continue-on-error: true
-
-    - name: Run RKE2 Provisioning Tests
-      run: |
-        set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 \
-        --junitfile results.xml --jsonfile results.json -- -timeout=3h -tags=recurring -v;
-        ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-        ./validation/reporter
-      shell: bash
-      continue-on-error: true
-
-    - name: Run Scaling Custom Cluster Tests
-      run: |
-        set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestCustomClusterNodeScalingTestSuite/TestScalingCustomClusterNodes";
-        ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-        ./validation/reporter
-      shell: bash
-      continue-on-error: true
-
-    - name: Run Scaling Node Driver Cluster Tests
-      run: |
-        set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestNodeScalingTestSuite/TestScalingNodePools";
-        ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-        ./validation/reporter
-      shell: bash
-      continue-on-error: true
-
-    - name: Run Snapshot Recurring Tests
-      run: |
-        set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestSnapshotRecurringTestSuite/TestSnapshotRecurringRestores";
-        ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-        ./validation/reporter
-      shell: bash
-      continue-on-error: true
-
-    - name: Run Snapshot Tests
-      run: |
-        set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestSnapshotRestoreTestSuite/TestSnapshotRestore";
-        ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-        ./validation/reporter
-      shell: bash
-      continue-on-error: true
-
-    - name: Run Snapshot Windows Tests
-      run: |
-        set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestSnapshotRestoreWindowsTestSuite/TestSnapshotRestoreWindows";
-        ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-        ./validation/reporter
-      shell: bash
-      continue-on-error: true
-
-    - name: Run Upgrade Tests
-      run: |
-        set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestKubernetesUpgradeTestSuite/TestUpgradeKubernetes";
-        ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-        ./validation/reporter
-      shell: bash
-      continue-on-error: true
-
-    - name: Run Upgrade Windows Tests
-      run: |
-        set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/rke2k3s \
-        --junitfile results.xml --jsonfile results.json -- -timeout=180m -tags=recurring -v -run "TestWindowsKubernetesUpgradeTestSuite/TestUpgradeWindowsKubernetes";
-        ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-        ./validation/reporter
-      shell: bash
-      continue-on-error: true
+         ./validation/pipeline/scripts/build_qase_reporter_v2.sh
+         ./validation/reporter
+       shell: bash
+       continue-on-error: true

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -62,6 +62,22 @@ jobs:
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
+    strategy:
+      matrix:
+        suite:
+          - cert-rotation
+          - delete-cluster
+          - delete-init-machine
+          - node-replacing
+          - scaling-custom-cluster
+          - scaling-node-driver
+          - k3s-provisioning
+          - rke2-provisioning
+          - snapshot
+          - snapshot-windows
+          - snapshot-recurring
+          - upgrade
+          - upgrade-windows
 
     steps:
       - name: Checkout repository
@@ -303,6 +319,8 @@ jobs:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        with:
+          suite: ${{ matrix.suite }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Refresh AWS credentials
@@ -327,6 +345,22 @@ jobs:
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: staging-latest
+    strategy:
+      matrix:
+        suite:
+          - cert-rotation
+          - delete-cluster
+          - delete-init-machine
+          - node-replacing
+          - scaling-custom-cluster
+          - scaling-node-driver
+          - k3s-provisioning
+          - rke2-provisioning
+          - snapshot
+          - snapshot-windows
+          - snapshot-recurring
+          - upgrade
+          - upgrade-windows
 
     steps:
       - name: Checkout repository
@@ -567,6 +601,8 @@ jobs:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        with:
+          suite: ${{ matrix.suite }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Refresh AWS credentials
@@ -591,6 +627,22 @@ jobs:
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: staging-latest
+    strategy:
+      matrix:
+        suite:
+          - cert-rotation
+          - delete-cluster
+          - delete-init-machine
+          - node-replacing
+          - scaling-custom-cluster
+          - scaling-node-driver
+          - k3s-provisioning
+          - rke2-provisioning
+          - snapshot
+          - snapshot-windows
+          - snapshot-recurring
+          - upgrade
+          - upgrade-windows
 
     steps:
       - name: Checkout repository
@@ -831,6 +883,8 @@ jobs:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        with:
+          suite: ${{ matrix.suite }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Refresh AWS credentials
@@ -854,6 +908,22 @@ jobs:
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}
     runs-on: ubuntu-latest
     environment: staging-latest
+    strategy:
+      matrix:
+        suite:
+          - cert-rotation
+          - delete-cluster
+          - delete-init-machine
+          - node-replacing
+          - scaling-custom-cluster
+          - scaling-node-driver
+          - k3s-provisioning
+          - rke2-provisioning
+          - snapshot
+          - snapshot-windows
+          - snapshot-recurring
+          - upgrade
+          - upgrade-windows
 
     steps:
       - name: Checkout repository
@@ -1094,6 +1164,8 @@ jobs:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        with:
+          suite: ${{ matrix.suite }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Refresh AWS credentials


### PR DESCRIPTION
### Description
This week of recurring runs has highlighted multiple data points, but arguably the most important is the need for a long term solution for growing tests. Specifically, all of the tests are not running right now as it hits the hosted runners 6 hour time limit. Strategy matrix not only gets around this, but it offers individualized 6 hour windows for EACH job and they run in parallel.

This PR looks to update each job to have this new enhancement. 