### PR TITLE
Update shepherd version to latest

### DIFF
--- a/actions/go.mod
+++ b/actions/go.mod
@@ -60,7 +60,7 @@ replace (
 
 require (
 	github.com/rancher/rancher/pkg/apis v0.0.0
-	github.com/rancher/shepherd v0.0.0-20250806164026-f0b65006babd
+	github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b
 )
 
 require (

--- a/actions/go.sum
+++ b/actions/go.sum
@@ -340,8 +340,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20250806201723-9a7af3779b9d h1:TZd6Wp
 github.com/rancher/rancher/pkg/apis v0.0.0-20250806201723-9a7af3779b9d/go.mod h1:IhaOGqACWRoyF+xXpd5CvGt02XeJyDdOC8W3Rdz1cW0=
 github.com/rancher/rke v1.8.0-rc.4 h1:jowVyaF3LsJonC7vNsAwWf3MONHAtEFUD/j3UzNSE5U=
 github.com/rancher/rke v1.8.0-rc.4/go.mod h1:x9N1abruzDFMwTpqq2cnaDYpKCptlNoW8VraNWB6Pc4=
-github.com/rancher/shepherd v0.0.0-20250806164026-f0b65006babd h1:0M6xSIbWmbA2pzJVoccGhXgiBAG1OQys0E2mjYbXt68=
-github.com/rancher/shepherd v0.0.0-20250806164026-f0b65006babd/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
+github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b h1:QIC9NNyUroMFInTwPYaJM27eb8xihHHOnamykw/TOMc=
+github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd h1:M3oVcVktMhNk8l3ZRW94kroqzWzE/VGbZfLw/F0rw5Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd/go.mod h1:VfRrgue4yl6O0GYakMGYgyByu7ySooPQWWRxTt2MIEI=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 require (
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/rancher/rancher v0.0.0-20250806201723-9a7af3779b9d
-	github.com/rancher/shepherd v0.0.0-20250806164026-f0b65006babd
+	github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b
 	github.com/rancher/tests/actions v0.0.0-20250806190403-cb1746eb0d9d
 	github.com/rancher/tests/interoperability v0.0.0-00010101000000-000000000000
 	github.com/rancher/tfp-automation v0.0.0-20250818213624-fa2af989eedb

--- a/go.sum
+++ b/go.sum
@@ -2203,8 +2203,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20250806201723-9a7af3779b9d h1:TZd6Wp
 github.com/rancher/rancher/pkg/apis v0.0.0-20250806201723-9a7af3779b9d/go.mod h1:IhaOGqACWRoyF+xXpd5CvGt02XeJyDdOC8W3Rdz1cW0=
 github.com/rancher/rke v1.8.0-rc.4 h1:jowVyaF3LsJonC7vNsAwWf3MONHAtEFUD/j3UzNSE5U=
 github.com/rancher/rke v1.8.0-rc.4/go.mod h1:x9N1abruzDFMwTpqq2cnaDYpKCptlNoW8VraNWB6Pc4=
-github.com/rancher/shepherd v0.0.0-20250806164026-f0b65006babd h1:0M6xSIbWmbA2pzJVoccGhXgiBAG1OQys0E2mjYbXt68=
-github.com/rancher/shepherd v0.0.0-20250806164026-f0b65006babd/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
+github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b h1:QIC9NNyUroMFInTwPYaJM27eb8xihHHOnamykw/TOMc=
+github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd h1:M3oVcVktMhNk8l3ZRW94kroqzWzE/VGbZfLw/F0rw5Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd/go.mod h1:VfRrgue4yl6O0GYakMGYgyByu7ySooPQWWRxTt2MIEI=
 github.com/rancher/tfp-automation v0.0.0-20250818213624-fa2af989eedb h1:9SS1cGUzIWK9PvmofdkOySXG/L232eJuQEfyYkiazUQ=

--- a/interoperability/go.mod
+++ b/interoperability/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.13.0
 	github.com/rancher/norman v0.7.0
 	github.com/rancher/rancher/pkg/apis v0.0.0
-	github.com/rancher/shepherd v0.0.0-20250806164026-f0b65006babd
+	github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b
 	github.com/rancher/tests/actions v0.0.0-20250505204226-5b136337f7c5
 	github.com/rancher/tfp-automation v0.0.0-20250611224440-c60e4d69096c
 	github.com/sirupsen/logrus v1.9.3

--- a/interoperability/go.sum
+++ b/interoperability/go.sum
@@ -2097,8 +2097,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20250806201723-9a7af3779b9d h1:TZd6Wp
 github.com/rancher/rancher/pkg/apis v0.0.0-20250806201723-9a7af3779b9d/go.mod h1:IhaOGqACWRoyF+xXpd5CvGt02XeJyDdOC8W3Rdz1cW0=
 github.com/rancher/rke v1.8.0-rc.4 h1:jowVyaF3LsJonC7vNsAwWf3MONHAtEFUD/j3UzNSE5U=
 github.com/rancher/rke v1.8.0-rc.4/go.mod h1:x9N1abruzDFMwTpqq2cnaDYpKCptlNoW8VraNWB6Pc4=
-github.com/rancher/shepherd v0.0.0-20250806164026-f0b65006babd h1:0M6xSIbWmbA2pzJVoccGhXgiBAG1OQys0E2mjYbXt68=
-github.com/rancher/shepherd v0.0.0-20250806164026-f0b65006babd/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
+github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b h1:QIC9NNyUroMFInTwPYaJM27eb8xihHHOnamykw/TOMc=
+github.com/rancher/shepherd v0.0.0-20250808210055-4a60b0f66c6b/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd h1:M3oVcVktMhNk8l3ZRW94kroqzWzE/VGbZfLw/F0rw5Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd/go.mod h1:VfRrgue4yl6O0GYakMGYgyByu7ySooPQWWRxTt2MIEI=
 github.com/rancher/tfp-automation v0.0.0-20250611224440-c60e4d69096c h1:qxp0e4ZnCX8EBdECPOejAY0vYQVac3zqZN/qhnMaUSk=


### PR DESCRIPTION
Currently, tests that use `AddProjectMember` helper function are failing. We need to update the Shepherd version to include the fix from [PR #410](https://github.com/rancher/shepherd/pull/410), which removes the if statement.