### PR TITLE
Consolidate Qase parameters + fix recurring runs schedule

### DIFF
--- a/.github/actions/get-qase-id/action.yaml
+++ b/.github/actions/get-qase-id/action.yaml
@@ -5,9 +5,6 @@ inputs:
   triggered_tag:
     description: "Rancher server tag version from triggered action"
     required: true
-  qase_release_id:
-    description: "Qase ID for the release test run"
-    required: true
   qase_rc_id:
     description: "Qase ID for the RC test run"
     required: false
@@ -32,7 +29,7 @@ runs:
           if [[ "$TRIGGERED_TAG" == *"-rc"* ]]; then
             QASE_ID="${{ inputs.qase_rc_id }}"
           else
-            QASE_ID="${{ inputs.qase_release_id }}"
+            QASE_ID="${{ inputs.qase_recurring_id }}"
           fi
         else
           QASE_ID="${{ inputs.qase_recurring_id }}"

--- a/.github/workflows/daily-cluster-provisioning.yml
+++ b/.github/workflows/daily-cluster-provisioning.yml
@@ -58,7 +58,7 @@ jobs:
     if: |
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12'))
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -138,9 +138,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_12 }}
           qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_12 }}
-          qase_recurring_id: ${{ vars.HB_QASE_DEFAULT_TEST_RUN_ID_2_12 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_12 }}
 
       - name: Create config.yaml
         run: |
@@ -325,7 +324,7 @@ jobs:
     if: |
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11'))
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: staging-latest
@@ -405,9 +404,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_11 }}
           qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_11 }}
-          qase_recurring_id: ${{ vars.HB_QASE_DEFAULT_TEST_RUN_ID_2_11 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_11 }}
 
       - name: Create config.yaml
         run: |
@@ -592,7 +590,7 @@ jobs:
     if: |
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10'))
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: staging-latest
@@ -672,9 +670,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_10 }}
           qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_10 }}
-          qase_recurring_id: ${{ vars.HB_QASE_DEFAULT_TEST_RUN_ID_2_10 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_10 }}
 
       - name: Create config.yaml
         run: |
@@ -858,7 +855,7 @@ jobs:
   v2-9:
     if: |
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.9')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.9'))
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.9.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}
     runs-on: ubuntu-latest
     environment: staging-latest
@@ -938,9 +935,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_9 }}
           qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_9 }}
-          qase_recurring_id: ${{ vars.HB_QASE_DEFAULT_TEST_RUN_ID_2_9 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_9 }}
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -58,7 +58,7 @@ jobs:
     if: |
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12'))
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-12 }}
     runs-on: ubuntu-latest
     environment: latest
@@ -143,9 +143,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_12 }}
           qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_12 }}
-          qase_recurring_id: ${{ vars.HB_QASE_DEFAULT_TEST_RUN_ID_2_12 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_12 }}
 
       - name: Create config.yaml
         run: |
@@ -330,7 +329,7 @@ jobs:
     if: |
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11'))
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
     environment: staging-latest
@@ -415,9 +414,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_11 }}
           qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_11 }}
-          qase_recurring_id: ${{ vars.HB_QASE_DEFAULT_TEST_RUN_ID_2_11 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_11 }}
 
       - name: Create config.yaml
         run: |
@@ -601,7 +599,7 @@ jobs:
     if: |
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10'))
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
     environment: staging-latest
@@ -686,9 +684,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_10 }}
           qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_10 }}
-          qase_recurring_id: ${{ vars.HB_QASE_DEFAULT_TEST_RUN_ID_2_10 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_10 }}
 
       - name: Create config.yaml
         run: |
@@ -871,7 +868,7 @@ jobs:
   v2-9:
     if: |
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.9')) ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.9'))
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.9.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}
     runs-on: ubuntu-latest
     environment: staging-latest
@@ -956,9 +953,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_9 }}
           qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_9 }}
-          qase_recurring_id: ${{ vars.HB_QASE_DEFAULT_TEST_RUN_ID_2_9 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_9 }}
 
       - name: Create config.yaml
         run: |

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/rancher/shepherd v0.0.0-20250825193534-ac295ac065d7
 	github.com/rancher/tests/actions v0.0.0-20250806190403-cb1746eb0d9d
 	github.com/rancher/tests/interoperability v0.0.0-00010101000000-000000000000
-	github.com/rancher/tfp-automation v0.0.0-20250818213624-fa2af989eedb
+	github.com/rancher/tfp-automation v0.0.0-20250902162211-174d96ffb988
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2207,8 +2207,8 @@ github.com/rancher/shepherd v0.0.0-20250825193534-ac295ac065d7 h1:hWHXlIkxtv33UL
 github.com/rancher/shepherd v0.0.0-20250825193534-ac295ac065d7/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd h1:M3oVcVktMhNk8l3ZRW94kroqzWzE/VGbZfLw/F0rw5Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd/go.mod h1:VfRrgue4yl6O0GYakMGYgyByu7ySooPQWWRxTt2MIEI=
-github.com/rancher/tfp-automation v0.0.0-20250818213624-fa2af989eedb h1:9SS1cGUzIWK9PvmofdkOySXG/L232eJuQEfyYkiazUQ=
-github.com/rancher/tfp-automation v0.0.0-20250818213624-fa2af989eedb/go.mod h1:6/hRFECaP8PHoP9hXKPPAAO3rKMrOn7HigqP/Bdq1VU=
+github.com/rancher/tfp-automation v0.0.0-20250902162211-174d96ffb988 h1:n4IvWeK5dIFvsS9vxiRUfMhlffDtUBeeZLNAZff4g2U=
+github.com/rancher/tfp-automation v0.0.0-20250902162211-174d96ffb988/go.mod h1:6/hRFECaP8PHoP9hXKPPAAO3rKMrOn7HigqP/Bdq1VU=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=


### PR DESCRIPTION
### Description
As part of this post release cycle, we discussed as a team to consolidate the Qase reporting to the following:
- RC test runs
- Recurring test runs

The latter will include daily testing and release testing runs, while the former is just for reporting RC test results. Additionally, this PR updates the scheduling for recurring runs to only run against alphas. This is to prevent them from running when RCs get cut or released versions are available.

Only our sanity checks will run when RCs or released versions are available, over in `rancher/tfp-automation` repo.