### PR TITLE
update build tags for tests owned by platform qa

### DIFF
--- a/validation/projects/project_scoped_secrets_test.go
+++ b/validation/projects/project_scoped_secrets_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !(2.8 || 2.9 || 2.10 || 2.11)
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !2.8 && !2.9 && !2.10 && !2.11
 
 package projects
 

--- a/validation/rbac/clusterandprojectroles/manage_workloads_role_test.go
+++ b/validation/rbac/clusterandprojectroles/manage_workloads_role_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !2.8 && !2.9
 
 package clusterandprojectroles
 

--- a/validation/rbac/crtb/crtb_status_field_test.go
+++ b/validation/rbac/crtb/crtb_status_field_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || stress) && !sanity && !extended
+//go:build (validation || infra.any || cluster.any || stress) && !sanity && !extended && !2.8 && !2.9 && !2.10
 
 package crtb
 

--- a/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
+++ b/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
@@ -1,4 +1,4 @@
-//go:build !pit.daily && !pit.weekly && !pit.event
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !2.8 && !2.9 && !2.10
 
 package globalroles
 

--- a/validation/rbac/globalroles/standarduser_manage_users_test.go
+++ b/validation/rbac/globalroles/standarduser_manage_users_test.go
@@ -1,4 +1,4 @@
-//go:build !pit.daily && !pit.weekly && !pit.event
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !2.8 && !2.9 && !2.10
 
 package globalroles
 

--- a/validation/rbac/globalrolesv2/globalroles_v2_webhook_test.go
+++ b/validation/rbac/globalrolesv2/globalroles_v2_webhook_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || sanity) && !stress && !extended
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress
 
 package globalrolesv2
 

--- a/validation/rbac/globalrolesv2/namespacedrules_test.go
+++ b/validation/rbac/globalrolesv2/namespacedrules_test.go
@@ -1,4 +1,4 @@
-//go:build !pit.daily && !pit.weekly && !pit.event
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress
 
 package globalrolesv2
 

--- a/validation/rbac/grb/grb_status_field_test.go
+++ b/validation/rbac/grb/grb_status_field_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !2.8 && !2.9 && !2.10
 
 package grb
 

--- a/validation/rbac/grb/grb_upn_test.go
+++ b/validation/rbac/grb/grb_upn_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !(2.8 || 2.9 || 2.10)
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !2.8 && !2.9 && !2.10
 
 package grb
 

--- a/validation/rbac/psa/project_updatepsa_test.go
+++ b/validation/rbac/psa/project_updatepsa_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !(2.8 || 2.9 || 2.10 || 2.11)
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !2.8 && !2.9 && !2.10 && !2.11
 
 package psa
 


### PR DESCRIPTION
https://github.com/rancher/qa-tasks/issues/1991

Some existing tests owned by Platform QA are missing build tags. This PR adds the missing tags.

Also, Go build constraints (//go:build) do not allow negating a grouped expression i.e., !(2.8 || 2.9) is invalid because the negation operator ! can only be applied to a single term.
The valid way to express this is by combining negations with &&:
 - !2.8 && !2.9 → valid
 - !(2.8 || 2.9) → invalid

This PR also updates the build constraints to use the correct syntax.
