### PR TITLE
Update clusterConfig to handle IPv6 parameters

### DIFF
--- a/actions/provisioninginput/config.go
+++ b/actions/provisioninginput/config.go
@@ -167,6 +167,7 @@ type Networking struct {
 	NodePortServicePortRange string                          `json:"nodePortServicePortRange,omitempty" yaml:"nodePortServicePortRange,omitempty"`
 	TLSSan                   []string                        `json:"tlsSan,omitempty" yaml:"tlsSan,omitempty"`
 	LocalClusterAuthEndpoint *rkev1.LocalClusterAuthEndpoint `json:"localClusterAuthEndpoint,omitempty" yaml:"localClusterAuthEndpoint,omitempty"`
+	StackPreference          string                          `json:"stackPreference,omitempty" yaml:"stackPreference,omitempty"`
 }
 
 type Advanced struct {


### PR DESCRIPTION
### Description
As we ramp up further with IPv6 testing, the automation needs to be able to account for this as well. This PR updates the `clusterConfig` to be able to handle `stackPreference`. This is needed for IPv6 downstream clusters so that you can specify values `ipv4`, `dual` or `ipv6`.

`clusterCIDR` and `serviceCIDR` are already included, so only need to update the `machineGlobalConfigMap` if that is specified in the user's config file.