### PR TITLE
Fix networking in the config so it is optional

### DIFF
--- a/actions/clusters/clusters.go
+++ b/actions/clusters/clusters.go
@@ -278,7 +278,7 @@ func NewK3SRKE2ClusterConfig(clusterName, namespace string, clustersConfig *Clus
 	}
 
 	var machineGlobalConfigMap rkev1.GenericMap
-	if clustersConfig.Networking.ClusterCIDR != "" || clustersConfig.Networking.ServiceCIDR != "" {
+	if clustersConfig.Networking != nil && (clustersConfig.Networking.ClusterCIDR != "" || clustersConfig.Networking.ServiceCIDR != "") {
 		machineGlobalConfigMap = rkev1.GenericMap{
 			Data: map[string]any{
 				"cluster-cidr":        clustersConfig.Networking.ClusterCIDR,
@@ -319,10 +319,7 @@ func NewK3SRKE2ClusterConfig(clusterName, namespace string, clustersConfig *Clus
 		FQDN:    "",
 	}
 
-	networking := &rkev1.Networking{
-		StackPreference: clustersConfig.Networking.StackPreference,
-	}
-
+	networking := &rkev1.Networking{}
 	if clustersConfig.Networking != nil {
 		if clustersConfig.Networking.LocalClusterAuthEndpoint != nil {
 			localClusterAuthEndpoint = *clustersConfig.Networking.LocalClusterAuthEndpoint


### PR DESCRIPTION
### Description
From a prior PR to add `stackPreference`, neglected to ensure that `networking` must stay as an optional field. As a result, the recurring runs are failing. This PR allows the `networking` to be optional again.