### PR TITLE
psact cleanup enhancement

### DIFF
--- a/actions/clusters/clusters.go
+++ b/actions/clusters/clusters.go
@@ -934,3 +934,19 @@ func GetClusterType(client *rancher.Client, clusterName string) (string, error) 
 	return clusterType, nil
 
 }
+
+// DeletePSACT deletes a Pod Security Admission Configuration Template (PSACT) by its ID.
+func DeletePSACT(client *rancher.Client, psactID string) error {
+	psact, err := client.Steve.SteveType(clusters.PodSecurityAdmissionSteveResoureType).ByID(psactID)
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("Deleting PSACT %s...", psact.Name)
+	err = client.Steve.SteveType(clusters.PodSecurityAdmissionSteveResoureType).Delete(psact)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
resolves intermittent failures seen when session cleanup does not always clean up resources in the expected order.  It is crucial downstream custom psact cluster is deleted before the custom psact itself is deleted, otherwise the test will fail as the "resource is still in use".

This PR disables the session cleanup `r.session.Cleanup()`, in place of manual cleanup logic to control the flow of resource deletion