### PR TITLE
Logging levels

### DIFF
--- a/actions/clusters/clusters.go
+++ b/actions/clusters/clusters.go
@@ -896,7 +896,7 @@ func CheckServiceAccountTokenSecret(client *rancher.Client, clusterName string) 
 	}
 
 	if cluster.ServiceAccountTokenSecret == "" {
-		logrus.Warn("warning: serviceAccountTokenSecret does not exist in this cluster!")
+		logrus.Warningf("ServiceAccountTokenSecret does not exist on cluster (%s)", clusterName)
 		return false, nil
 	}
 

--- a/actions/go.mod
+++ b/actions/go.mod
@@ -60,7 +60,7 @@ replace (
 
 require (
 	github.com/rancher/rancher/pkg/apis v0.0.0
-	github.com/rancher/shepherd v0.0.0-20250825193534-ac295ac065d7
+	github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70
 )
 
 require (

--- a/actions/go.sum
+++ b/actions/go.sum
@@ -340,8 +340,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20250806201723-9a7af3779b9d h1:TZd6Wp
 github.com/rancher/rancher/pkg/apis v0.0.0-20250806201723-9a7af3779b9d/go.mod h1:IhaOGqACWRoyF+xXpd5CvGt02XeJyDdOC8W3Rdz1cW0=
 github.com/rancher/rke v1.8.0-rc.4 h1:jowVyaF3LsJonC7vNsAwWf3MONHAtEFUD/j3UzNSE5U=
 github.com/rancher/rke v1.8.0-rc.4/go.mod h1:x9N1abruzDFMwTpqq2cnaDYpKCptlNoW8VraNWB6Pc4=
-github.com/rancher/shepherd v0.0.0-20250825193534-ac295ac065d7 h1:hWHXlIkxtv33ULiRXyNm64fDJ0YlP94yU2+nI+Ko4Mc=
-github.com/rancher/shepherd v0.0.0-20250825193534-ac295ac065d7/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
+github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70 h1:XouRIvo2zm8Y/hi2LZJPKZj2LuEaTmxf3M7L650Ly+I=
+github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd h1:M3oVcVktMhNk8l3ZRW94kroqzWzE/VGbZfLw/F0rw5Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd/go.mod h1:VfRrgue4yl6O0GYakMGYgyByu7ySooPQWWRxTt2MIEI=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/actions/hardening/k3s/harden_nodes.go
+++ b/actions/hardening/k3s/harden_nodes.go
@@ -16,7 +16,7 @@ const (
 // HardenK3SNodes hardens the nodes by setting kernel parameters and creating the etcd user
 func HardenK3SNodes(nodes []*nodes.Node, nodeRoles []string, kubeVersion, pathToRepo string) error {
 	for key, node := range nodes {
-		logrus.Infof("Setting kernel parameters on node: %s", node.NodeID)
+		logrus.Tracef("Setting kernel parameters on node: %s", node.NodeID)
 		_, err := node.ExecuteCommand("sudo bash -c 'echo vm.panic_on_oom=0 >> " + sysctlConf + "'")
 		if err != nil {
 			return err
@@ -43,7 +43,7 @@ func HardenK3SNodes(nodes []*nodes.Node, nodeRoles []string, kubeVersion, pathTo
 		}
 
 		if strings.Contains(nodeRoles[key], "--controlplane") {
-			logrus.Infof("Copying over files to node %s", node.NodeID)
+			logrus.Tracef("Copying over files to node %s", node.NodeID)
 			userDir, err := os.UserHomeDir()
 			if err != nil {
 				return err

--- a/actions/hardening/rke2/harden_nodes.go
+++ b/actions/hardening/rke2/harden_nodes.go
@@ -16,7 +16,7 @@ const (
 // HardenRKE2Nodes hardens the nodes by setting kernel parameters and creating the etcd user
 func HardenRKE2Nodes(nodes []*nodes.Node, nodeRoles []string) error {
 	for _, node := range nodes {
-		logrus.Infof("Setting kernel parameters on node: %s", node.NodeID)
+		logrus.Tracef("Setting kernel parameters on node: %s", node.NodeID)
 		_, err := node.ExecuteCommand("sudo bash -c 'echo vm.panic_on_oom=0 >> " + kubeletConf + "'")
 		if err != nil {
 			return err
@@ -42,7 +42,7 @@ func HardenRKE2Nodes(nodes []*nodes.Node, nodeRoles []string) error {
 			return err
 		}
 
-		logrus.Infof("Creating etcd user on node: %s", node.NodeID)
+		logrus.Tracef("Creating etcd user on node: %s", node.NodeID)
 		_, err = node.ExecuteCommand("sudo useradd -r -c \"etcd user\" -s /sbin/nologin -M etcd -U")
 		if err != nil {
 			return err
@@ -57,7 +57,7 @@ func HardenRKE2Nodes(nodes []*nodes.Node, nodeRoles []string) error {
 func PostRKE2HardeningConfig(nodes []*nodes.Node, nodeRoles []string, pathToRepo string) error {
 	for key, node := range nodes {
 		if strings.Contains(nodeRoles[key], "--controlplane") {
-			logrus.Infof("Copying over files to node %s", node.NodeID)
+			logrus.Tracef("Copying over files to node %s", node.NodeID)
 			userDir, err := os.UserHomeDir()
 			if err != nil {
 				return err

--- a/actions/logging/logging.go
+++ b/actions/logging/logging.go
@@ -1,0 +1,45 @@
+package logging
+
+import "github.com/sirupsen/logrus"
+
+const (
+	LoggingKey = "logging"
+)
+
+type Logging struct {
+	Level *string `json:"level,omitempty" yaml:"level,omitempty"`
+}
+
+func SetLogger(loggingConfig *Logging) error {
+	var loggingLevel logrus.Level
+	var err error
+	if loggingConfig != nil {
+		if loggingConfig.Level != nil {
+			loggingLevel, err = logrus.ParseLevel(*loggingConfig.Level)
+			if err != nil {
+				return err
+			}
+		} else {
+			loggingLevel = logrus.InfoLevel
+		}
+	} else {
+		loggingLevel = logrus.InfoLevel
+	}
+
+	logrus.SetLevel(loggingLevel)
+	setLogrusFormatter()
+	logrus.Infof("Setting logging level to: %s", loggingLevel.String())
+
+	return nil
+}
+
+func setLogrusFormatter() {
+	formatter := &logrus.TextFormatter{}
+	formatter.DisableQuote = true
+	formatter.TimestampFormat = "2006-01-02 15:04:05"
+	formatter.FullTimestamp = true
+	formatter.ForceColors = true
+	formatter.PadLevelText = true
+	formatter.DisableLevelTruncation = true
+	logrus.SetFormatter(formatter)
+}

--- a/actions/provisioning/permutations/permutations.go
+++ b/actions/provisioning/permutations/permutations.go
@@ -84,7 +84,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						reports.TimeoutClusterReport(clusterObject, err)
 						require.NoError(s.T(), err)
 
-						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
+						provisioning.VerifyCluster(s.T(), client, clusterObject)
 
 					case RKE1ProvisionCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
@@ -112,7 +112,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						reports.TimeoutClusterReport(clusterObject, err)
 						require.NoError(s.T(), err)
 
-						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
+						provisioning.VerifyCluster(s.T(), client, clusterObject)
 
 					case RKE1CustomCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
@@ -141,7 +141,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						reports.TimeoutClusterReport(clusterObject, err)
 						require.NoError(s.T(), err)
 
-						provisioning.VerifyCluster(s.T(), client, testClusterConfig, clusterObject)
+						provisioning.VerifyCluster(s.T(), client, clusterObject)
 
 					case RKE1AirgapCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion

--- a/actions/services/create.go
+++ b/actions/services/create.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -9,7 +10,7 @@ import (
 // CreateService is a helper function to create a service in the downstream cluster
 func CreateService(steveclient *steveV1.Client, service corev1.Service) (*steveV1.SteveAPIObject, error) {
 	logrus.Infof("Creating service: %s", service.Name)
-	serviceResp, err := steveclient.SteveType(ServiceSteveType).Create(service)
+	serviceResp, err := steveclient.SteveType(stevetypes.Service).Create(service)
 	if err != nil {
 		return nil, err
 	}

--- a/actions/services/verify.go
+++ b/actions/services/verify.go
@@ -16,6 +16,8 @@ import (
 	extensionClusters "github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/defaults"
 	extdefault "github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/stevestates"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/ingresses"
 	"github.com/rancher/shepherd/extensions/kubectl"
 	"github.com/rancher/shepherd/extensions/sshkeys"
@@ -29,21 +31,18 @@ import (
 )
 
 const (
-	active              = "active"
 	noSuchHostSubString = "no such host"
 )
 
 // VerifyService waits for a service to be ready in the downstream cluster
 func VerifyService(steveclient *steveV1.Client, serviceResp *steveV1.SteveAPIObject) error {
 	err := kwait.PollUntilContextTimeout(context.TODO(), 500*time.Millisecond, defaults.OneMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
-		service, err := steveclient.SteveType(ServiceSteveType).ByID(serviceResp.ID)
+		service, err := steveclient.SteveType(stevetypes.Service).ByID(serviceResp.ID)
 		if err != nil {
 			return false, nil
 		}
 
-		if service.State.Name == active {
-			logrus.Infof("Successfully created service: %s", service.Name)
-
+		if service.State.Name == stevestates.Active {
 			return true, nil
 		}
 

--- a/actions/workloads/deployment/verify.go
+++ b/actions/workloads/deployment/verify.go
@@ -10,6 +10,7 @@ import (
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/charts"
 	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/workloads"
 	namegen "github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/wrangler"
@@ -29,7 +30,7 @@ const (
 // VerifyDeployment waits for a deployment to be ready in the downstream cluster
 func VerifyDeployment(steveClient *steveV1.Client, deployment *steveV1.SteveAPIObject) error {
 	err := kwait.PollUntilContextTimeout(context.TODO(), 500*time.Millisecond, defaults.FifteenMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
-		deploymentResp, err := steveClient.SteveType(DeploymentSteveType).ByID(deployment.Namespace + "/" + deployment.Name)
+		deploymentResp, err := steveClient.SteveType(stevetypes.Deployment).ByID(deployment.Namespace + "/" + deployment.Name)
 		if err != nil {
 			return false, nil
 		}

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 require (
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/rancher/rancher v0.0.0-20250806201723-9a7af3779b9d
-	github.com/rancher/shepherd v0.0.0-20250825193534-ac295ac065d7
+	github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70
 	github.com/rancher/tests/actions v0.0.0-20250806190403-cb1746eb0d9d
 	github.com/rancher/tests/interoperability v0.0.0-00010101000000-000000000000
 	github.com/rancher/tfp-automation v0.0.0-20250903201820-5b10667cd9f7

--- a/go.sum
+++ b/go.sum
@@ -2203,8 +2203,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20250806201723-9a7af3779b9d h1:TZd6Wp
 github.com/rancher/rancher/pkg/apis v0.0.0-20250806201723-9a7af3779b9d/go.mod h1:IhaOGqACWRoyF+xXpd5CvGt02XeJyDdOC8W3Rdz1cW0=
 github.com/rancher/rke v1.8.0-rc.4 h1:jowVyaF3LsJonC7vNsAwWf3MONHAtEFUD/j3UzNSE5U=
 github.com/rancher/rke v1.8.0-rc.4/go.mod h1:x9N1abruzDFMwTpqq2cnaDYpKCptlNoW8VraNWB6Pc4=
-github.com/rancher/shepherd v0.0.0-20250825193534-ac295ac065d7 h1:hWHXlIkxtv33ULiRXyNm64fDJ0YlP94yU2+nI+Ko4Mc=
-github.com/rancher/shepherd v0.0.0-20250825193534-ac295ac065d7/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
+github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70 h1:XouRIvo2zm8Y/hi2LZJPKZj2LuEaTmxf3M7L650Ly+I=
+github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd h1:M3oVcVktMhNk8l3ZRW94kroqzWzE/VGbZfLw/F0rw5Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd/go.mod h1:VfRrgue4yl6O0GYakMGYgyByu7ySooPQWWRxTt2MIEI=
 github.com/rancher/tfp-automation v0.0.0-20250903201820-5b10667cd9f7 h1:7x5sIOuvk6C0Xx40jw+57/ODFZvL8eD/VCuYrVzpVcU=

--- a/interoperability/go.mod
+++ b/interoperability/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/rancher/fleet/pkg/apis v0.13.0
 	github.com/rancher/norman v0.7.0
 	github.com/rancher/rancher/pkg/apis v0.0.0
-	github.com/rancher/shepherd v0.0.0-20250825193534-ac295ac065d7
+	github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70
 	github.com/rancher/tests/actions v0.0.0-20250505204226-5b136337f7c5
 	github.com/rancher/tfp-automation v0.0.0-20250611224440-c60e4d69096c
 	github.com/sirupsen/logrus v1.9.3

--- a/interoperability/go.sum
+++ b/interoperability/go.sum
@@ -2097,8 +2097,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20250806201723-9a7af3779b9d h1:TZd6Wp
 github.com/rancher/rancher/pkg/apis v0.0.0-20250806201723-9a7af3779b9d/go.mod h1:IhaOGqACWRoyF+xXpd5CvGt02XeJyDdOC8W3Rdz1cW0=
 github.com/rancher/rke v1.8.0-rc.4 h1:jowVyaF3LsJonC7vNsAwWf3MONHAtEFUD/j3UzNSE5U=
 github.com/rancher/rke v1.8.0-rc.4/go.mod h1:x9N1abruzDFMwTpqq2cnaDYpKCptlNoW8VraNWB6Pc4=
-github.com/rancher/shepherd v0.0.0-20250825193534-ac295ac065d7 h1:hWHXlIkxtv33ULiRXyNm64fDJ0YlP94yU2+nI+Ko4Mc=
-github.com/rancher/shepherd v0.0.0-20250825193534-ac295ac065d7/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
+github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70 h1:XouRIvo2zm8Y/hi2LZJPKZj2LuEaTmxf3M7L650Ly+I=
+github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd h1:M3oVcVktMhNk8l3ZRW94kroqzWzE/VGbZfLw/F0rw5Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd/go.mod h1:VfRrgue4yl6O0GYakMGYgyByu7ySooPQWWRxTt2MIEI=
 github.com/rancher/tfp-automation v0.0.0-20250611224440-c60e4d69096c h1:qxp0e4ZnCX8EBdECPOejAY0vYQVac3zqZN/qhnMaUSk=

--- a/validation/auth/kubeconfigs/kubeconfigs_test.go
+++ b/validation/auth/kubeconfigs/kubeconfigs_test.go
@@ -71,17 +71,17 @@ func (kc *KubeconfigTestSuite) SetupSuite() {
 	cluster2ID, err := clusters.GetClusterIDByName(kc.client, clusterObject2.Name)
 	require.NoError(kc.T(), err)
 
-	provisioning.VerifyCluster(kc.T(), kc.client, aceClusterConfig1, aceClusterObject1)
+	provisioning.VerifyCluster(kc.T(), kc.client, aceClusterObject1)
 	kc.aceCluster1, err = kc.client.Management.Cluster.ByID(aceCluster1ID)
 	require.NoError(kc.T(), err)
 	log.Infof("ACE-enabled cluster created: %s (%s)", kc.aceCluster1.Name, aceCluster1ID)
 
-	provisioning.VerifyCluster(kc.T(), kc.client, aceClusterConfig2, aceClusterObject2)
+	provisioning.VerifyCluster(kc.T(), kc.client, aceClusterObject2)
 	kc.aceCluster2, err = kc.client.Management.Cluster.ByID(aceCluster2ID)
 	require.NoError(kc.T(), err)
 	log.Infof("ACE-enabled cluster created: %s (%s)", kc.aceCluster2.Name, aceCluster2ID)
 
-	provisioning.VerifyCluster(kc.T(), kc.client, clusterConfig2, clusterObject2)
+	provisioning.VerifyCluster(kc.T(), kc.client, clusterObject2)
 	kc.cluster2, err = kc.client.Management.Cluster.ByID(cluster2ID)
 	require.NoError(kc.T(), err)
 	log.Infof("ACE-disabled cluster created: %s (%s)", kc.cluster2.Name, cluster2ID)

--- a/validation/certificates/cert_rotation.go
+++ b/validation/certificates/cert_rotation.go
@@ -69,7 +69,7 @@ func RotateCerts(client *rancher.Client, clusterName string) error {
 		return err
 	}
 
-	nodeList, err := steveclient.SteveType("node").List(nil)
+	nodeList, err := steveclient.SteveType(stevetypes.Node).List(nil)
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,6 @@ func RotateCerts(client *rancher.Client, clusterName string) error {
 
 	updatedCluster.Spec = *clusterSpec
 
-	logrus.Infof("Rotating certs...")
 	_, err = client.Steve.SteveType(stevetypes.Provisioning).Update(cluster, updatedCluster)
 	if err != nil {
 		return err
@@ -136,6 +135,7 @@ func RotateCerts(client *rancher.Client, clusterName string) error {
 		return err
 	}
 
+	logrus.Infof("Waiting for cluster (%s) to be active", cluster.Name)
 	clusterCheckFunc := clusters.IsProvisioningClusterReady
 	err = wait.WatchWait(clusterWait, clusterCheckFunc)
 	if err != nil {
@@ -157,8 +157,6 @@ func RotateCerts(client *rancher.Client, clusterName string) error {
 	if !isAllCertRotated {
 		return errors.New("Certificates weren't properly rotated")
 	}
-
-	logrus.Infof("Cert Rotation Complete.")
 
 	return nil
 }
@@ -251,7 +249,7 @@ func getCertificatesFromMachine(client *rancher.Client, machineNode *v1.SteveAPI
 		return nil, err
 	}
 
-	logrus.Infof("Getting certificates from machine: %s", machineNode.Name)
+	logrus.Debugf("Getting certificates from machine: %s", machineNode.Name)
 
 	clusterType := machineNode.Labels["node.kubernetes.io/instance-type"]
 	certsPath := "/var/lib/rancher/" + clusterType + "/server/tls/"

--- a/validation/charts/backup_restore/backup_restore.go
+++ b/validation/charts/backup_restore/backup_restore.go
@@ -311,7 +311,7 @@ func createRKE2dsCluster(t *testing.T, client *rancher.Client) (*v1.SteveAPIObje
 		return nil, nil, err
 	}
 
-	provisioning.VerifyCluster(t, client, testClusterConfig, steveObject)
+	provisioning.VerifyCluster(t, client, steveObject)
 
 	return steveObject, testClusterConfig, nil
 }

--- a/validation/charts/backup_restore/backup_restore_test.go
+++ b/validation/charts/backup_restore/backup_restore_test.go
@@ -76,7 +76,7 @@ func (b *BackupTestSuite) TestS3InPlaceRestore() {
 	require.NoError(b.T(), err)
 
 	logrus.Info("Provisioning a downstream RKE2 cluster...")
-	rke2SteveObj, rke2ClusterConfig, err := createRKE2dsCluster(b.T(), b.client)
+	rke2SteveObj, _, err := createRKE2dsCluster(b.T(), b.client)
 	require.NoError(b.T(), err)
 
 	logrus.Info("Creating a backup of the local cluster...")
@@ -113,7 +113,7 @@ func (b *BackupTestSuite) TestS3InPlaceRestore() {
 
 	logrus.Info("Validating downstream clusters are in an Active status...")
 	provisioning.VerifyRKE1Cluster(b.T(), b.client, rke1ClusterConfig, rke1ClusterObj)
-	provisioning.VerifyCluster(b.T(), b.client, rke2ClusterConfig, rke2SteveObj)
+	provisioning.VerifyCluster(b.T(), b.client, rke2SteveObj)
 }
 
 func TestBackupTestSuite(t *testing.T) {

--- a/validation/deleting/rke2k3s/delete_init_machine.go
+++ b/validation/deleting/rke2k3s/delete_init_machine.go
@@ -22,13 +22,13 @@ func deleteInitMachine(client *rancher.Client, clusterID string) error {
 		return err
 	}
 
-	logrus.Info("Awaiting machine deletion...")
+	logrus.Debugf("Waiting for the init machine to be deleted on cluster (%s)", clusterID)
 	err = steve.WaitForResourceDeletion(client.Steve, initMachine, defaults.FiveHundredMillisecondTimeout, defaults.TenMinuteTimeout)
 	if err != nil {
 		return err
 	}
 
-	logrus.Info("Awaiting machine replacement...")
+	logrus.Debugf("Waiting for the init machine to be replaced on cluster (%s)", clusterID)
 	err = clusters.WatchAndWaitForCluster(client, clusterID)
 	if err != nil {
 		return err

--- a/validation/deleting/rke2k3s/delete_init_machine_test.go
+++ b/validation/deleting/rke2k3s/delete_init_machine_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/rancher/shepherd/clients/ec2"
 	"github.com/rancher/shepherd/clients/rancher"
 	extClusters "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
@@ -51,6 +53,12 @@ func (d *DeleteInitMachineTestSuite) SetupSuite() {
 
 	d.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, d.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(d.T(), err)
+
 	rke2ClusterConfig := new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, d.cattleConfig, rke2ClusterConfig)
 
@@ -73,9 +81,11 @@ func (d *DeleteInitMachineTestSuite) SetupSuite() {
 	rke2ClusterConfig.MachinePools = nodeRolesStandard
 	k3sClusterConfig.MachinePools = nodeRolesStandard
 
+	logrus.Info("Provisioning RKE2 cluster")
 	d.rke2ClusterID, err = resources.ProvisionRKE2K3SCluster(d.T(), standardUserClient, extClusters.RKE2ClusterType.String(), rke2ClusterConfig, awsEC2Configs, true, false)
 	require.NoError(d.T(), err)
 
+	logrus.Info("Provisioning K3S cluster")
 	d.k3sClusterID, err = resources.ProvisionRKE2K3SCluster(d.T(), standardUserClient, extClusters.K3SClusterType.String(), k3sClusterConfig, awsEC2Configs, true, false)
 	require.NoError(d.T(), err)
 }
@@ -90,13 +100,20 @@ func (d *DeleteInitMachineTestSuite) TestDeleteInitMachine() {
 	}
 
 	for _, tt := range tests {
+		cluster, err := d.client.Steve.SteveType(stevetypes.Provisioning).ByID(tt.clusterID)
+		require.NoError(d.T(), err)
+
 		d.Run(tt.name, func() {
+			logrus.Infof("Deleting init machine on cluster (%s)", cluster.Name)
 			err := deleteInitMachine(d.client, tt.clusterID)
 			require.NoError(d.T(), err)
+
+			logrus.Infof("Verifying cluster (%s)", cluster.Name)
+			provisioning.VerifyCluster(d.T(), d.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(d.client, d.cattleConfig)
-		err := qase.UpdateSchemaParameters(tt.name, params)
+		err = qase.UpdateSchemaParameters(tt.name, params)
 		if err != nil {
 			logrus.Warningf("Failed to upload schema parameters %s", err)
 		}

--- a/validation/fleet/provisioning/airgap/fleet_in_airgap_test.go
+++ b/validation/fleet/provisioning/airgap/fleet_in_airgap_test.go
@@ -176,7 +176,7 @@ func (a *AirGapRKE2CustomClusterTestSuite) TestCustomClusterWithGitRepo() {
 		reports.TimeoutClusterReport(clusterObject, err)
 		require.NoError(a.T(), err)
 
-		provisioning.VerifyCluster(a.T(), a.standardClient, testClusterConfig, clusterObject)
+		provisioning.VerifyCluster(a.T(), a.standardClient, clusterObject)
 
 		status := &apisV1.ClusterStatus{}
 		err = steveV1.ConvertToK8sType(clusterObject.Status, status)

--- a/validation/fleet/provisioning/new_cluster_existing_gitrepo_test.go
+++ b/validation/fleet/provisioning/new_cluster_existing_gitrepo_test.go
@@ -181,7 +181,7 @@ func (f *FleetWithProvisioningTestSuite) TestHardenedAfterAddedGitRepo() {
 			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(f.T(), err)
 
-			provisioning.VerifyCluster(f.T(), tt.client, testClusterConfig, clusterObject)
+			provisioning.VerifyCluster(f.T(), tt.client, clusterObject)
 
 			status := &provv1.ClusterStatus{}
 			err = steveV1.ConvertToK8sType(clusterObject.Status, status)
@@ -268,7 +268,7 @@ func (f *FleetWithProvisioningTestSuite) TestWindowsAfterAddedGitRepo() {
 			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(f.T(), err)
 
-			provisioning.VerifyCluster(f.T(), tt.client, testClusterConfig, clusterObject)
+			provisioning.VerifyCluster(f.T(), tt.client, clusterObject)
 
 			status := &provv1.ClusterStatus{}
 			err = steveV1.ConvertToK8sType(clusterObject.Status, status)

--- a/validation/fleet/snapshot/snapshot_restore_existing_gitrepo_test.go
+++ b/validation/fleet/snapshot/snapshot_restore_existing_gitrepo_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	extensionscluster "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	extensionsfleet "github.com/rancher/shepherd/extensions/fleet"
 	"github.com/rancher/shepherd/extensions/workloads"
 	"github.com/rancher/shepherd/extensions/workloads/pods"
@@ -177,13 +179,13 @@ func (f *FleetWithSnapshotTestSuite) TestSnapshotThenFleetRestore() {
 			gitRepoObject, err = extensionsfleet.CreateFleetGitRepo(client, f.fleetGitRepo)
 			require.NoError(f.T(), err)
 
-			err = fleet.VerifyGitRepo(client, gitRepoObject.ID, f.clusterID, fleet.Namespace+"/"+client.RancherConfig.ClusterName)
+			err = fleet.VerifyGitRepo(client, gitRepoObject.ID, f.clusterID, namespaces.FleetDefault+"/"+client.RancherConfig.ClusterName)
 			require.NoError(f.T(), err)
 
 			err = etcdsnapshot.RestoreAndValidateSnapshotV2Prov(client, snapshotName, tt.etcdSnapshot, cluster, f.clusterID)
 			require.NoError(f.T(), err)
 
-			_, err = steveClient.SteveType(etcdsnapshot.DeploymentSteveType).ByID(postDeploymentResp.ID)
+			_, err = steveClient.SteveType(stevetypes.Deployment).ByID(postDeploymentResp.ID)
 			require.Error(f.T(), err)
 
 			_, err = steveClient.SteveType("service").ByID(postServiceResp.ID)

--- a/validation/nodescaling/rke2k3s/scaling_custom_cluster_test.go
+++ b/validation/nodescaling/rke2k3s/scaling_custom_cluster_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/rancher/shepherd/clients/ec2"
 	"github.com/rancher/shepherd/clients/rancher"
 	extClusters "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
@@ -55,6 +57,12 @@ func (s *CustomClusterNodeScalingTestSuite) SetupSuite() {
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, s.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(s.T(), err)
+
 	rke2ClusterConfig := new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, s.cattleConfig, rke2ClusterConfig)
 
@@ -80,9 +88,11 @@ func (s *CustomClusterNodeScalingTestSuite) SetupSuite() {
 	rke2ClusterConfig.MachinePools = nodeRolesStandard
 	k3sClusterConfig.MachinePools = nodeRolesStandard
 
+	logrus.Info("Provisioning RKE2 cluster")
 	s.rke2ClusterID, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.RKE2ClusterType.String(), rke2ClusterConfig, awsEC2Configs, true, true)
 	require.NoError(s.T(), err)
 
+	logrus.Info("Provisioning K3S cluster")
 	s.k3sClusterID, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.K3SClusterType.String(), k3sClusterConfig, awsEC2Configs, true, true)
 	require.NoError(s.T(), err)
 }
@@ -131,14 +141,20 @@ func (s *CustomClusterNodeScalingTestSuite) TestScalingCustomClusterNodes() {
 	}
 
 	for _, tt := range tests {
+		cluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).ByID(tt.clusterID)
+		require.NoError(s.T(), err)
+
 		s.Run(tt.name, func() {
 			awsEC2Configs := new(ec2.AWSEC2Configs)
 			operations.LoadObjectFromMap(ec2.ConfigurationFileKey, s.cattleConfig, awsEC2Configs)
 			nodescaling.ScalingRKE2K3SCustomClusterPools(s.T(), s.client, tt.clusterID, s.scalingConfig.NodeProvider, tt.nodeRoles, awsEC2Configs)
+
+			logrus.Infof("Verifying cluster (%s)", cluster.Name)
+			provisioning.VerifyCluster(s.T(), s.client, cluster)
 		})
 
 		params := provisioning.GetCustomSchemaParams(s.client, s.cattleConfig)
-		err := qase.UpdateSchemaParameters(tt.name, params)
+		err = qase.UpdateSchemaParameters(tt.name, params)
 		if err != nil {
 			logrus.Warningf("Failed to upload schema parameters %s", err)
 		}

--- a/validation/nodescaling/rke2k3s/scaling_node_driver_test.go
+++ b/validation/nodescaling/rke2k3s/scaling_node_driver_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/rancher/shepherd/clients/ec2"
 	"github.com/rancher/shepherd/clients/rancher"
 	extClusters "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
@@ -56,6 +58,12 @@ func (s *NodeScalingTestSuite) SetupSuite() {
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, s.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(s.T(), err)
+
 	s.rke2ClusterConfig = new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, s.cattleConfig, s.rke2ClusterConfig)
 
@@ -81,9 +89,11 @@ func (s *NodeScalingTestSuite) SetupSuite() {
 	s.rke2ClusterConfig.MachinePools = nodeRolesStandard
 	k3sClusterConfig.MachinePools = nodeRolesStandard
 
+	logrus.Info("Provisioning RKE2 cluster")
 	s.rke2ClusterID, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.RKE2ClusterType.String(), s.rke2ClusterConfig, awsEC2Configs, true, false)
 	require.NoError(s.T(), err)
 
+	logrus.Info("Provisioning K3S cluster")
 	s.k3sClusterID, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.K3SClusterType.String(), k3sClusterConfig, awsEC2Configs, true, false)
 	require.NoError(s.T(), err)
 }
@@ -125,16 +135,22 @@ func (s *NodeScalingTestSuite) TestScalingNodePools() {
 	}
 
 	for _, tt := range tests {
+		cluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).ByID(tt.clusterID)
+		require.NoError(s.T(), err)
+
 		s.Run(tt.name, func() {
 			if s.rke2ClusterConfig.Provider != "vsphere" && tt.isWindows {
 				s.T().Skip("Windows test requires access to vSphere")
 			}
 
 			nodescaling.ScalingRKE2K3SNodePools(s.T(), s.client, tt.clusterID, tt.nodeRoles)
+
+			logrus.Infof("Verifying cluster (%s)", cluster.Name)
+			provisioning.VerifyCluster(s.T(), s.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(s.client, s.cattleConfig)
-		err := qase.UpdateSchemaParameters(tt.name, params)
+		err = qase.UpdateSchemaParameters(tt.name, params)
 		if err != nil {
 			logrus.Warningf("Failed to upload schema parameters %s", err)
 		}

--- a/validation/provisioning/k3s/README.md
+++ b/validation/provisioning/k3s/README.md
@@ -5,7 +5,8 @@
 2. [Tests Cases](#Test-Cases)
 3. [Configurations](#Configurations)
 4. [Configuration Defaults](#defaults)
-5. [Back to general provisioning](../README.md)
+5. [Logging Levels](#Logging)
+6. [Back to general provisioning](../README.md)
 
 
 ## Test Cases
@@ -517,6 +518,13 @@ This package contains a defaults folder which contains default test configuratio
 Any data the user provides will override these defaults which are stored here: [defaults](defaults/defaults.yaml). 
 
 
+## Logging
+This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 
+
+```yaml
+logging:
+   level: "trace" #trace debug, info, warning, error
+```
 
 ## Additional
 1. If the tests passes immediately without warning, try adding the `-count=1` or run `go clean -cache`. This will avoid previous results from interfering with the new test run.

--- a/validation/provisioning/k3s/dynamic_node_driver_test.go
+++ b/validation/provisioning/k3s/dynamic_node_driver_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/config/permutationdata"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -39,6 +40,12 @@ func dynamicNodeDriverSetup(t *testing.T) DynamicNodeDriverTest {
 	k.client = client
 
 	cattleConfig := config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	assert.NoError(t, err)
 
 	providerPermutation, err := permutationdata.CreateProviderPermutation(cattleConfig)
 	assert.NoError(t, err)
@@ -88,11 +95,12 @@ func TestDynamicNodeDriver(t *testing.T) {
 				credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
 				machineConfigSpec := machinepools.LoadMachineConfigs(string(provider.Name))
 
+				logrus.Info("Provisioning cluster")
 				cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 				assert.NoError(t, err)
 
 				logrus.Infof("Verifying cluster (%s)", cluster.Name)
-				provisioning.VerifyCluster(t, tt.client, clusterConfig, cluster)
+				provisioning.VerifyCluster(t, tt.client, cluster)
 			}
 		})
 	}

--- a/validation/provisioning/k3s/hardened_test.go
+++ b/validation/provisioning/k3s/hardened_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/charts"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
@@ -51,6 +52,12 @@ func hardenedSetup(t *testing.T) hardenedTest {
 	k.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	k.cattleConfig, err = defaults.LoadPackageDefaults(k.cattleConfig, "")
+	assert.NoError(t, err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, k.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
 	assert.NoError(t, err)
 
 	k.cattleConfig, err = defaults.SetK8sDefault(client, defaults.K3S, k.cattleConfig)
@@ -99,32 +106,35 @@ func TestHardened(t *testing.T) {
 			awsEC2Configs := new(ec2.AWSEC2Configs)
 			operations.LoadObjectFromMap(ec2.ConfigurationFileKey, k.cattleConfig, awsEC2Configs)
 
-			clusterObject, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
-			reports.TimeoutClusterReport(clusterObject, err)
+			logrus.Info("Provisioning cluster")
+			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
+			reports.TimeoutClusterReport(cluster, err)
 			assert.NoError(t, err)
 
-			provisioning.VerifyCluster(t, tt.client, clusterConfig, clusterObject)
+			logrus.Infof("Verifying cluster (%s)", cluster.Name)
+			provisioning.VerifyCluster(t, tt.client, cluster)
 
-			cluster, err := extensionscluster.NewClusterMeta(tt.client, clusterObject.Name)
-			reports.TimeoutClusterReport(clusterObject, err)
+			clusterMeta, err := extensionscluster.NewClusterMeta(tt.client, cluster.Name)
+			reports.TimeoutClusterReport(cluster, err)
 			assert.NoError(t, err)
 
 			latestCISBenchmarkVersion, err := tt.client.Catalog.GetLatestChartVersion(charts.CISBenchmarkName, catalog.RancherChartRepo)
 			assert.NoError(t, err)
 
 			project, err := projects.GetProjectByName(tt.client, cluster.ID, cis.System)
-			reports.TimeoutClusterReport(clusterObject, err)
+			reports.TimeoutClusterReport(cluster, err)
 			assert.NoError(t, err)
 
 			k.project = project
 			require.NotEmpty(t, k.project)
 
 			k.chartInstallOptions = &charts.InstallOptions{
-				Cluster:   cluster,
+				Cluster:   clusterMeta,
 				Version:   latestCISBenchmarkVersion,
 				ProjectID: k.project.ID,
 			}
 
+			logrus.Infof("Running CIS Benchmark on cluster (%s)", cluster.Name)
 			cis.SetupCISBenchmarkChart(tt.client, k.project.ClusterID, k.chartInstallOptions, charts.CISBenchmarkNamespace)
 			cis.RunCISScan(tt.client, k.project.ClusterID, tt.scanProfileName)
 		})

--- a/validation/provisioning/k3s/hostname_truncation_test.go
+++ b/validation/provisioning/k3s/hostname_truncation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
@@ -42,6 +43,12 @@ func hostnameTruncationSetup(t *testing.T) hostnameTruncationTest {
 	k.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	k.cattleConfig, err = defaults.LoadPackageDefaults(k.cattleConfig, "")
+	assert.NoError(t, err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, k.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
 	assert.NoError(t, err)
 
 	k.cattleConfig, err = defaults.SetK8sDefault(k.client, defaults.K3S, k.cattleConfig)
@@ -99,11 +106,15 @@ func TestHostnameTruncation(t *testing.T) {
 			credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
 			machineConfigSpec := machinepools.LoadMachineConfigs(string(provider.Name))
 
-			clusterObject, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, hostnamePools)
+			logrus.Info("Provisioning cluster")
+			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, hostnamePools)
 			assert.NoError(t, err)
 
-			provisioning.VerifyCluster(t, tt.client, clusterConfig, clusterObject)
-			provisioning.VerifyHostnameLength(t, k.client, clusterObject)
+			logrus.Infof("Verifying cluster (%s)", cluster.Name)
+			provisioning.VerifyCluster(t, tt.client, cluster)
+
+			logrus.Infof("Verifying hostname truncation on %s", cluster.Name)
+			provisioning.VerifyHostnameLength(t, k.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, k.cattleConfig)

--- a/validation/provisioning/registries/registry_test.go
+++ b/validation/provisioning/registries/registry_test.go
@@ -346,7 +346,7 @@ func (rt *RegistryTestSuite) TestRegistriesK3S() {
 				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(rt.T(), err)
 
-				provisioning.VerifyCluster(rt.T(), subClient, testConfig, clusterObject)
+				provisioning.VerifyCluster(rt.T(), subClient, clusterObject)
 			})
 		}
 	}
@@ -369,7 +369,7 @@ func (rt *RegistryTestSuite) TestRegistriesK3S() {
 				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(rt.T(), err)
 
-				provisioning.VerifyCluster(rt.T(), subClient, testConfig, clusterObject)
+				provisioning.VerifyCluster(rt.T(), subClient, clusterObject)
 			})
 		}
 	}
@@ -418,7 +418,7 @@ func (rt *RegistryTestSuite) TestRegistriesRKE2() {
 				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(rt.T(), err)
 
-				provisioning.VerifyCluster(rt.T(), subClient, testConfig, clusterObject)
+				provisioning.VerifyCluster(rt.T(), subClient, clusterObject)
 			})
 		}
 	}
@@ -439,7 +439,7 @@ func (rt *RegistryTestSuite) TestRegistriesRKE2() {
 				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(rt.T(), err)
 
-				provisioning.VerifyCluster(rt.T(), subClient, testConfig, clusterObject)
+				provisioning.VerifyCluster(rt.T(), subClient, clusterObject)
 			})
 		}
 	}

--- a/validation/provisioning/resources/cisbenchmark/cisbenchmark.go
+++ b/validation/provisioning/resources/cisbenchmark/cisbenchmark.go
@@ -25,38 +25,38 @@ const (
 
 // SetupCISBenchmarkChart installs the CIS Benchmark chart and waits for all resources to be ready.
 func SetupCISBenchmarkChart(client *rancher.Client, projectClusterID string, chartInstallOptions *charts.InstallOptions, benchmarkNamespace string) error {
-	logrus.Infof("Installing CIS Benchmark chart...")
+	logrus.Debugf("Installing CIS Benchmark chart...")
 	err := charts.InstallCISBenchmarkChart(client, chartInstallOptions)
 	if err != nil {
 		return err
 	}
 
-	logrus.Infof("Waiting for CIS Benchmark chart deployments to have expected number of available replicas...")
+	logrus.Debugf("Waiting for CIS Benchmark chart deployments to have expected number of available replicas...")
 	err = extensionscharts.WatchAndWaitDeployments(client, projectClusterID, benchmarkNamespace, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
-	logrus.Infof("Waiting for CIS Benchmark chart DaemonSets to have expected number of available nodes...")
+	logrus.Debugf("Waiting for CIS Benchmark chart DaemonSets to have expected number of available nodes...")
 	err = extensionscharts.WatchAndWaitDaemonSets(client, projectClusterID, benchmarkNamespace, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
-	logrus.Infof("Waiting for CIS Benchmark chart StatefulSets to have expected number of ready replicas...")
+	logrus.Debugf("Waiting for CIS Benchmark chart StatefulSets to have expected number of ready replicas...")
 	err = extensionscharts.WatchAndWaitStatefulSets(client, projectClusterID, benchmarkNamespace, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
-	logrus.Infof("Successfully installed CIS Benchmark chart!")
+	logrus.Debugf("Successfully installed CIS Benchmark chart!")
 
 	return nil
 }
 
 // RunCISScan runs the CIS Benchmark scan with the specified profile name.
 func RunCISScan(client *rancher.Client, projectClusterID, scanProfileName string) error {
-	logrus.Infof("Running CIS Benchmark scan: %s", scanProfileName)
+	logrus.Debugf("Running CIS Benchmark scan: %s", scanProfileName)
 
 	cisScan := cis.ClusterScan{
 		ObjectMeta: metav1.ObjectMeta{

--- a/validation/provisioning/resources/provisioncluster/provision_cluster.go
+++ b/validation/provisioning/resources/provisioncluster/provision_cluster.go
@@ -46,7 +46,7 @@ func ProvisionRKE2K3SCluster(t *testing.T, client *rancher.Client, clusterType s
 		clusterObject, err = provisioning.CreateProvisioningCustomCluster(client, &externalNodeProvider, clusterConfig, ec2Configs)
 		require.NoError(t, err)
 
-		provisioning.VerifyCluster(t, client, clusterConfig, clusterObject)
+		provisioning.VerifyCluster(t, client, clusterObject)
 	} else {
 		provider := provisioning.CreateProvider(clusterConfig.Provider)
 		credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
@@ -55,7 +55,7 @@ func ProvisionRKE2K3SCluster(t *testing.T, client *rancher.Client, clusterType s
 		clusterObject, err = provisioning.CreateProvisioningCluster(client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 		require.NoError(t, err)
 
-		provisioning.VerifyCluster(t, client, clusterConfig, clusterObject)
+		provisioning.VerifyCluster(t, client, clusterObject)
 	}
 
 	return clusterObject.ID, nil

--- a/validation/provisioning/rke2/README.md
+++ b/validation/provisioning/rke2/README.md
@@ -5,7 +5,8 @@
 2. [Tests Cases](#Test-Cases)
 3. [Configurations](#Configurations)
 4. [Configuration Defaults](#defaults)
-5. [Back to general provisioning](../README.md)
+5. [Logging Levels](#Logging)
+6. [Back to general provisioning](../README.md)
 
 
 ## Test Cases
@@ -576,6 +577,13 @@ This package contains a defaults folder which contains default test configuratio
 Any data the user provides will override these defaults which are stored here: [defaults](defaults/defaults.yaml). 
 
 
+## Logging
+This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 
+
+```yaml
+logging:
+   level: "trace" #trace debug, info, warning, error
+```
 
 ## Additional
 1. If the tests passes immediately without warning, try adding the `-count=1` or run `go clean -cache`. This will avoid previous results from interfering with the new test run.

--- a/validation/provisioning/rke2/data_directories_test.go
+++ b/validation/provisioning/rke2/data_directories_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
@@ -42,6 +43,12 @@ func dataDirectoriesSetup(t *testing.T) dataDirectoriesTest {
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
+	assert.NoError(t, err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
 	assert.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
@@ -99,10 +106,14 @@ func TestDataDirectories(t *testing.T) {
 			credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
 			machineConfigSpec := machinepools.LoadMachineConfigs(string(provider.Name))
 
+			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			provisioning.VerifyCluster(t, tt.client, clusterConfig, cluster)
+			logrus.Infof("Verifying cluster (%s)", cluster.Name)
+			provisioning.VerifyCluster(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster (%s) data directories", cluster.Name)
 			provisioning.VerifyDataDirectories(t, r.client, clusterConfig, machineConfigSpec, cluster)
 		})
 

--- a/validation/provisioning/rke2/dynamic_custom_test.go
+++ b/validation/provisioning/rke2/dynamic_custom_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/config/permutationdata"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/reports"
@@ -42,6 +43,12 @@ func dynamicCustomSetup(t *testing.T) dynamicCustomTest {
 	r.client = client
 
 	cattleConfig := config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	assert.NoError(t, err)
 
 	providerPermutation, err := permutationdata.CreateProviderPermutation(cattleConfig)
 	assert.NoError(t, err)
@@ -96,12 +103,16 @@ func TestDynamicCustom(t *testing.T) {
 				awsEC2Configs := new(ec2.AWSEC2Configs)
 				config.LoadConfig(ec2.ConfigurationFileKey, awsEC2Configs)
 
-				clusterObject, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
-				reports.TimeoutClusterReport(clusterObject, err)
+				logrus.Info("Provisioning cluster")
+				cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
+				reports.TimeoutClusterReport(cluster, err)
 				require.NoError(t, err)
 
-				provisioning.VerifyCluster(t, tt.client, clusterConfig, clusterObject)
-				cloudprovider.VerifyCloudProvider(t, tt.client, "rke2", nil, clusterConfig, clusterObject, nil)
+				logrus.Infof("Verifying cluster (%s)", cluster.Name)
+				provisioning.VerifyCluster(t, tt.client, cluster)
+
+				logrus.Infof("Verifying cloud provider on cluster (%s)", cluster.Name)
+				cloudprovider.VerifyCloudProvider(t, tt.client, defaults.RKE2, nil, clusterConfig, cluster, nil)
 			}
 		})
 	}

--- a/validation/provisioning/rke2/node_driver_test.go
+++ b/validation/provisioning/rke2/node_driver_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
@@ -41,6 +42,12 @@ func nodeDriverSetup(t *testing.T) nodeDriverTest {
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
+	assert.NoError(t, err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
 	assert.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
@@ -102,10 +109,12 @@ func TestNodeDriver(t *testing.T) {
 			credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
 			machineConfigSpec := machinepools.LoadMachineConfigs(string(provider.Name))
 
+			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			provisioning.VerifyCluster(t, tt.client, clusterConfig, cluster)
+			logrus.Infof("Verifying cluster (%s)", cluster.Name)
+			provisioning.VerifyCluster(t, tt.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
+++ b/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
@@ -95,7 +95,7 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCre
 	clusterObject, err := provisioning.CreateProvisioningCluster(createdRaReplacementUserClient, provider, credentialSpec, ra.clusterConfig, machineConfigSpec, nil)
 	require.NoError(ra.T(), err)
 
-	provisioning.VerifyCluster(ra.T(), ra.client, ra.clusterConfig, clusterObject)
+	provisioning.VerifyCluster(ra.T(), ra.client, clusterObject)
 }
 
 func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementListGlobalSettings() {

--- a/validation/rbac/globalrolesv2/globalroles_v2_test.go
+++ b/validation/rbac/globalrolesv2/globalroles_v2_test.go
@@ -174,7 +174,7 @@ func (gr *GlobalRolesV2TestSuite) TestClusterCreationAfterAddingGlobalRoleWithIn
 	provisioning.VerifyRKE1Cluster(gr.T(), userClient, testClusterConfig, clusterObject)
 	_, steveObject, testClusterConfig, err := createDownstreamCluster(userClient, "RKE2")
 	require.NoError(gr.T(), err)
-	provisioning.VerifyCluster(gr.T(), userClient, testClusterConfig, steveObject)
+	provisioning.VerifyCluster(gr.T(), userClient, steveObject)
 
 	gr.validateRBACResources(createdUser, createdGlobalRole, inheritedClusterRoles)
 }
@@ -423,9 +423,9 @@ func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromClu
 	defer subSession.Cleanup()
 
 	log.Info("Create a RKE2 downstream cluster.")
-	_, rke2SteveObject, testClusterConfig, err := createDownstreamCluster(gr.client, "RKE2")
+	_, rke2SteveObject, _, err := createDownstreamCluster(gr.client, "RKE2")
 	require.NoError(gr.T(), err)
-	provisioning.VerifyCluster(gr.T(), gr.client, testClusterConfig, rke2SteveObject)
+	provisioning.VerifyCluster(gr.T(), gr.client, rke2SteveObject)
 
 	log.Info("Create a global role with inheritedClusterRoles.")
 	inheritedClusterRoles := []string{rbac.ClusterOwner.String()}

--- a/validation/snapshot/rke2k3s/snapshot_recurring_test.go
+++ b/validation/snapshot/rke2k3s/snapshot_recurring_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/etcdsnapshot"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
@@ -53,6 +54,12 @@ func (s *SnapshotRecurringTestSuite) SetupSuite() {
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, s.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(s.T(), err)
+
 	rke2ClusterConfig := new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, s.cattleConfig, rke2ClusterConfig)
 
@@ -75,9 +82,11 @@ func (s *SnapshotRecurringTestSuite) SetupSuite() {
 	rke2ClusterConfig.MachinePools = nodeRolesStandard
 	k3sClusterConfig.MachinePools = nodeRolesStandard
 
+	logrus.Info("Provisioning RKE2 cluster")
 	s.rke2ClusterID, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.RKE2ClusterType.String(), rke2ClusterConfig, awsEC2Configs, true, false)
 	require.NoError(s.T(), err)
 
+	logrus.Info("Provisioning K3S cluster")
 	s.k3sClusterID, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.K3SClusterType.String(), k3sClusterConfig, awsEC2Configs, true, false)
 	require.NoError(s.T(), err)
 }

--- a/validation/snapshot/rke2k3s/snapshot_restore_test.go
+++ b/validation/snapshot/rke2k3s/snapshot_restore_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/etcdsnapshot"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
@@ -58,6 +59,12 @@ func (s *SnapshotRestoreTestSuite) SetupSuite() {
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, s.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(s.T(), err)
+
 	rke2ClusterConfig := new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, s.cattleConfig, rke2ClusterConfig)
 
@@ -80,9 +87,11 @@ func (s *SnapshotRestoreTestSuite) SetupSuite() {
 	rke2ClusterConfig.MachinePools = nodeRolesStandard
 	k3sClusterConfig.MachinePools = nodeRolesStandard
 
+	logrus.Info("Provisioning RKE2 cluster")
 	s.rke2ClusterID, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.RKE2ClusterType.String(), rke2ClusterConfig, awsEC2Configs, false, false)
 	require.NoError(s.T(), err)
 
+	logrus.Info("Provisioning K3S cluster")
 	s.k3sClusterID, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.K3SClusterType.String(), k3sClusterConfig, awsEC2Configs, false, false)
 	require.NoError(s.T(), err)
 }

--- a/validation/snapshot/rke2k3s/snapshot_restore_wins_test.go
+++ b/validation/snapshot/rke2k3s/snapshot_restore_wins_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/etcdsnapshot"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
@@ -52,6 +53,12 @@ func (s *SnapshotRestoreWindowsTestSuite) SetupSuite() {
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, s.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(s.T(), err)
+
 	clusterConfig := new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, s.cattleConfig, clusterConfig)
 
@@ -72,6 +79,7 @@ func (s *SnapshotRestoreWindowsTestSuite) SetupSuite() {
 
 	clusterConfig.MachinePools = nodeRolesStandard
 
+	logrus.Info("Provisioning RKE2 windows cluster")
 	s.rke2ClusterID, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.RKE2ClusterType.String(), clusterConfig, awsEC2Configs, true, true)
 	require.NoError(s.T(), err)
 }

--- a/validation/snapshot/rke2k3s/snapshot_s3_restore_test.go
+++ b/validation/snapshot/rke2k3s/snapshot_s3_restore_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/etcdsnapshot"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
@@ -54,6 +55,12 @@ func (s *S3SnapshotRestoreTestSuite) SetupSuite() {
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, s.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(s.T(), err)
+
 	rke2ClusterConfig := new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, s.cattleConfig, rke2ClusterConfig)
 
@@ -76,9 +83,11 @@ func (s *S3SnapshotRestoreTestSuite) SetupSuite() {
 	rke2ClusterConfig.MachinePools = nodeRolesStandard
 	k3sClusterConfig.MachinePools = nodeRolesStandard
 
+	logrus.Info("Provisioning RKE2 cluster")
 	s.rke2ClusterID, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.RKE2ClusterType.String(), rke2ClusterConfig, awsEC2Configs, true, false)
 	require.NoError(s.T(), err)
 
+	logrus.Info("Provisioning K3S cluster")
 	s.k3sClusterID, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.K3SClusterType.String(), k3sClusterConfig, awsEC2Configs, true, false)
 	require.NoError(s.T(), err)
 }

--- a/validation/upgrade/kubernetes.go
+++ b/validation/upgrade/kubernetes.go
@@ -83,7 +83,7 @@ func DownstreamCluster(u *suite.Suite, testName string, client *rancher.Client, 
 		upgradedCluster, err := upgradeRKE2K3SCluster(u.T(), client, clusterID, testConfig)
 		require.NoError(u.T(), err)
 
-		provisioning.VerifyCluster(u.T(), client, testConfig, upgradedCluster)
+		provisioning.VerifyCluster(u.T(), client, upgradedCluster)
 	}
 }
 

--- a/validation/upgrade/rke2k3s/cloud_provider_aws_migration_test.go
+++ b/validation/upgrade/rke2k3s/cloud_provider_aws_migration_test.go
@@ -16,10 +16,12 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioninginput"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/rancher/tests/validation/upgrade"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -52,6 +54,12 @@ func (u *MigrateCloudProviderSuite) SetupSuite() {
 
 	u.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, u.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(u.T(), err)
+
 	u.clusterConfig = new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, u.cattleConfig, u.clusterConfig)
 
@@ -70,6 +78,7 @@ func (u *MigrateCloudProviderSuite) SetupSuite() {
 
 	u.clusterConfig.MachinePools = nodeRolesStandard
 
+	logrus.Info("Provisioning RKE2 cluster")
 	u.rke2ClusterID, err = resources.ProvisionRKE2K3SCluster(u.T(), u.standardUserClient, extClusters.RKE2ClusterType.String(), u.clusterConfig, awsEC2Configs, true, false)
 	require.NoError(u.T(), err)
 }

--- a/validation/upgrade/rke2k3s/kubernetes_test.go
+++ b/validation/upgrade/rke2k3s/kubernetes_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
@@ -58,6 +59,12 @@ func (u *UpgradeKubernetesTestSuite) SetupSuite() {
 
 	u.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, u.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(u.T(), err)
+
 	u.rke2ClusterConfig = new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, u.cattleConfig, u.rke2ClusterConfig)
 
@@ -80,9 +87,11 @@ func (u *UpgradeKubernetesTestSuite) SetupSuite() {
 	u.rke2ClusterConfig.MachinePools = nodeRolesStandard
 	u.k3sClusterConfig.MachinePools = nodeRolesStandard
 
+	logrus.Info("Provisioning RKE2 cluster")
 	u.rke2ClusterID, err = resources.ProvisionRKE2K3SCluster(u.T(), standardUserClient, extClusters.RKE2ClusterType.String(), u.rke2ClusterConfig, awsEC2Configs, false, false)
 	require.NoError(u.T(), err)
 
+	logrus.Info("Provisioning K3S cluster")
 	u.k3sClusterID, err = resources.ProvisionRKE2K3SCluster(u.T(), standardUserClient, extClusters.K3SClusterType.String(), u.k3sClusterConfig, awsEC2Configs, false, false)
 	require.NoError(u.T(), err)
 }

--- a/validation/upgrade/rke2k3s/kubernetes_wins_test.go
+++ b/validation/upgrade/rke2k3s/kubernetes_wins_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/upgradeinput"
@@ -58,6 +59,12 @@ func (u *UpgradeWindowsKubernetesTestSuite) SetupSuite() {
 
 	u.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, u.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(u.T(), err)
+
 	u.clusterConfig = new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, u.cattleConfig, u.clusterConfig)
 
@@ -78,6 +85,7 @@ func (u *UpgradeWindowsKubernetesTestSuite) SetupSuite() {
 
 	u.clusterConfig.MachinePools = nodeRolesStandard
 
+	logrus.Info("Provisioning RKE2 cluster")
 	u.rke2ClusterID, err = resources.ProvisionRKE2K3SCluster(u.T(), standardUserClient, extClusters.RKE2ClusterType.String(), u.clusterConfig, awsEC2Configs, true, true)
 	require.NoError(u.T(), err)
 


### PR DESCRIPTION
Purpose: To update the logging for our tests to be filterable via the logrus logging levels. The main reason this was necessary is that our recurring runs have a lot of logs and it is becoming harder to sift through what is relevant.

Changes:
-  Added logging levels via the new logging package
- Added log styling via the logging package
- Updated the snapshot auto replace test to fix an issue that was causing the test to fail.
- Updated the snapshot package to fix an issue that was causing k3s clusters to be upgraded to an rke2 k8s version
- Updated a bunch of constants to point to shepherd defaults.
- Removed a stale constants and code