### PR TITLE
Add platform-qa test runner workflows

### DIFF
--- a/.github/scripts/platform-qa-create-cattle-config.sh
+++ b/.github/scripts/platform-qa-create-cattle-config.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -e
+
+cat > cattle-config.yaml <<EOF
+rancher:
+  host: "${RANCHER_HOST}"
+  adminToken: "${RANCHER_ADMIN_TOKEN}"
+  cleanup: true
+  insecure: true
+  clusterName: "${CLUSTER_NAME}"
+  adminPassword: "${RANCHER_ADMIN_PASSWORD}"
+
+registryInput:
+  name: "${QUAY_REGISTRY_NAME}"
+  username: "${QUAY_REGISTRY_USERNAME}"
+  password: "${QUAY_REGISTRY_PASSWORD}"
+
+awsCredentials:
+  accessKey: "${AWS_ACCESS_KEY_ID}"
+  secretKey: "${AWS_SECRET_ACCESS_KEY}"
+  defaultRegion: "${AWS_REGION}"
+
+clusterConfig:
+  machinePools:
+  - machinePoolConfig:
+      etcd: true
+      controlplane: true
+      worker: true
+      quantity: 1
+      drainBeforeDelete: true
+      hostnameLengthLimit: 29
+      nodeStartupTimeout: "600s"
+      unhealthyNodeTimeout: "300s"
+      maxUnhealthy: "2"
+      unhealthyRange: "2-4"
+  - machinePoolConfig:
+      worker: true
+      quantity: 2
+  kubernetesVersion: "${KUBERNETES_VERSION}"
+  provider: "${PROVIDER_AMAZON}"
+  cni: "${CNI}"
+  nodeProvider: "ec2"
+  networking:
+    stackPreference: "ipv4"
+  hardened: false
+
+awsMachineConfigs:
+  region: "${AWS_REGION}"
+  awsMachineConfig:
+  - roles: ["etcd","controlplane","worker"]
+    ami: "${AWS_AMI}"
+    instanceType: "${AWS_INSTANCE_TYPE}"
+    sshUser: "${AWS_USER}"
+    vpcId: "${AWS_VPC_ID}"
+    volumeType: "${AWS_VOLUME_TYPE}"
+    zone: "${AWS_ZONE_LETTER}"
+    retries: "5"
+    rootSize: "${AWS_ROOT_SIZE}"
+    securityGroup: [${AWS_QA_SECURITY_GROUP_NAMES}]
+
+awsEC2Configs:
+  region: "${AWS_REGION}"
+  awsSecretAccessKey: "${AWS_SECRET_ACCESS_KEY}"
+  awsAccessKeyID: "${AWS_ACCESS_KEY_ID}"
+  awsEC2Config:
+    - instanceType: "${AWS_INSTANCE_TYPE}"
+      awsRegionAZ: "${AWS_REGION}${AWS_ZONE_LETTER}"
+      awsAMI: "${AWS_AMI}"
+      awsSecurityGroups: [${AWS_QA_SECURITY_GROUP_NAMES}]
+      awsSSHKeyName: "${SSH_PRIVATE_KEY_NAME}.pem"
+      awsCICDInstanceTag: "platform-qa"
+      awsIAMProfile: "${AWS_IAM_PROFILE}"
+      awsUser: "${AWS_USER}"
+      volumeSize: "${AWS_ROOT_SIZE}"
+      roles: ["etcd", "controlplane", "worker"]
+sshPath: 
+  sshPath: "${SSH_PRIVATE_KEY_PATH}"
+EOF

--- a/.github/scripts/platform-qa-get-rancher-version.sh
+++ b/.github/scripts/platform-qa-get-rancher-version.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+if ! command -v jq &> /dev/null; then
+  sudo apt-get update
+  sudo apt-get install -y jq
+fi
+
+VERSION=$(curl -k -s -H "Authorization: Bearer $RANCHER_ADMIN_TOKEN" \
+  "https://$RANCHER_HOST/v1/management.cattle.io.settings/server-version" | jq -r '.value // empty')
+
+if [ -z "$VERSION" ]; then
+  echo "⚠️ v1 API failed, falling back to v3 API..."
+  VERSION=$(curl -k -s -H "Authorization: Bearer $RANCHER_ADMIN_TOKEN" \
+    "https://$RANCHER_HOST/v3/settings/server-version" | jq -r '.value // empty')
+fi
+
+if [ -z "$VERSION" ]; then
+  echo "❌ Unable to fetch Rancher version from v1 or v3 API. Exiting."
+  exit 1
+fi
+
+echo "Full Rancher version: $VERSION"
+echo "RANCHER_FULL_VERSION=$VERSION" >> $GITHUB_ENV
+
+SHORT_VERSION=$(echo "$VERSION" | sed -E 's/^v?([0-9]+\.[0-9]+).*/\1/')
+echo "Rancher short version: $SHORT_VERSION"
+echo "RANCHER_SHORT_VERSION=$SHORT_VERSION" >> $GITHUB_ENV

--- a/.github/scripts/platform-qa-report-to-qase.sh
+++ b/.github/scripts/platform-qa-report-to-qase.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+RESULTS_JSON="${1:-}"
+PACKAGE_NAME="${2:-}"
+QASE_TEST_RUN_ID="${3:-}"
+QASE_AUTOMATION_TOKEN="${4:-}"
+
+if [ -z "$RESULTS_JSON" ] || [ -z "$PACKAGE_NAME" ] || [ -z "$QASE_TEST_RUN_ID" ] || [ -z "$QASE_AUTOMATION_TOKEN" ]; then
+  echo "Usage: $0 <results_json> <package_name> <qase_test_run_id> <qase_automation_token>"
+  exit 1
+fi
+
+if [ -z "$GITHUB_WORKSPACE" ]; then
+  echo "❌ GITHUB_WORKSPACE must be set"
+  exit 1
+fi
+
+echo "📤 Reporting test results to Qase for package: $PACKAGE_NAME"
+RESULTS_DIR=$(mktemp -d)
+trap 'rm -rf "$RESULTS_DIR"' EXIT
+
+PACKAGE_SAFE=$(echo "$PACKAGE_NAME" | tr '/' '_')
+PACKAGE_RESULTS_JSON="$RESULTS_DIR/results_${PACKAGE_SAFE}.json"
+cp "$RESULTS_JSON" "$PACKAGE_RESULTS_JSON"
+
+REPORTER_SCRIPT="${GITHUB_WORKSPACE}/rancher-tests/validation/pipeline/scripts/build_qase_reporter.sh"
+REPORTER_BINARY="${GITHUB_WORKSPACE}/rancher-tests/validation/reporter"
+
+chmod +x "$REPORTER_SCRIPT"
+"$REPORTER_SCRIPT" || { echo "❌ Failed to build Qase reporter"; exit 1; }
+
+if [ ! -f "$REPORTER_BINARY" ]; then
+  echo "❌ Reporter binary not found at $REPORTER_BINARY"
+  exit 1
+fi
+
+cp "$PACKAGE_RESULTS_JSON" "$RESULTS_DIR/results.json"
+cd "$RESULTS_DIR"
+chmod +x "$REPORTER_BINARY"
+export QASE_TEST_RUN_ID QASE_AUTOMATION_TOKEN
+"$REPORTER_BINARY" --results results.json
+
+rm -f "${GITHUB_WORKSPACE}/rancher-tests/results.xml" "${GITHUB_WORKSPACE}/rancher-tests/results.json"
+rm -rf "$RESULTS_DIR"
+
+echo "✅ Test Results have been published to Qase for package: $PACKAGE_NAME"

--- a/.github/workflows/platform-qa-package-dispatcher.yml
+++ b/.github/workflows/platform-qa-package-dispatcher.yml
@@ -1,0 +1,134 @@
+name: Platform QA Package Dispatcher
+
+on:
+  workflow_dispatch:
+    inputs:
+      rancher_hosts:
+        description: "Comma-separated Rancher hosts. Example: cluster1.qa.rancher.space,cluster2.qa.rancher.space"
+        required: true
+      admin_tokens:
+        description: "Comma-separated Admin API tokens (same order as Rancher hosts)"
+        required: true
+      cluster_names:
+        description: "Comma-separated downstream cluster names (same order as Rancher hosts)"
+        required: true
+      kubernetes_versions:
+        description: "Comma-separated Kubernetes versions (same order as Rancher hosts) Example: v1.31.11+k3s1,v1.32.7+k3s1"
+        required: true
+      test_packages:
+        description: "Comma-separated test package paths (e.g. validation/rbac,validation/projects)"
+        required: true
+        default: "validation/rbac,validation/projects,validation/auth"
+      run_all_tests:
+        description: "Run all test files in the package?"
+        required: true
+        default: "true"
+        type: choice
+        options: ["true", "false"]
+      recursive_tests:
+        description: "Recursively find and run tests in sub-packages?"
+        required: true
+        default: "true"
+        type: choice
+        options: ["true", "false"]
+      test_selector:
+        description: "Test suite or test name regex, if run_all_tests=false (e.g. ^TestSuiteName$ or ^TestSuite/TestCase$)"
+        required: false
+      exclude_test_files:
+        description: "Test files to exclude (comma-separated), if run_all_tests=true (e.g. rbac_test.go,projects_test.go)"
+        required: false
+      qase_test_run_ids:
+        description: "Comma-separated Qase test run IDs (same order as Rancher hosts). Leave empty if not reporting to Qase"
+        required: false
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Flatten package list (only if recursive)
+        id: flatten-pkg
+        if: ${{ github.event.inputs.recursive_tests == 'true' }}
+        run: |
+          INPUT_PKGS="${{ github.event.inputs.test_packages }}"
+          FLATTENED=()
+          declare -A unique_packages
+          
+          IFS=',' read -ra PKGS <<< "$INPUT_PKGS"
+          for pkg in "${PKGS[@]}"; do
+            DIRS=$(find "$pkg" -type f -name '*_test.go' -printf '%h\n' | sort -u)
+
+
+            if [ -n "$DIRS" ]; then
+              while IFS= read -r dir; do
+                unique_packages["$dir"]=1
+              done <<< "$DIRS"
+            fi
+          done
+
+          FLAT_LIST=$(IFS=','; echo "${!unique_packages[*]}")
+          echo "Flattened list: $FLAT_LIST"
+          echo "test_packages=$FLAT_LIST" >> $GITHUB_OUTPUT
+
+      - name: Dispatch package runner workflow for each cluster
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const workflow_id = "platform-qa-package-runner.yml";
+            const ref = "main"; 
+            const hosts = "${{ github.event.inputs.rancher_hosts }}".split(',').map(s => s.trim());
+            const tokens = "${{ github.event.inputs.admin_tokens }}".split(',').map(s => s.trim());
+            const clusters = "${{ github.event.inputs.cluster_names }}".split(',').map(s => s.trim());
+            const kubernetesVersions = "${{ github.event.inputs.kubernetes_versions }}".split(',').map(s => s.trim());
+            const qaseRunsRaw = "${{ github.event.inputs.qase_test_run_ids }}";
+            const qaseRuns = qaseRunsRaw ? qaseRunsRaw.split(',').map(s => s.trim()) : [];
+
+            const test_packages = "${{ steps.flatten-pkg.outputs.test_packages || github.event.inputs.test_packages }}";
+
+            if (hosts.length !== tokens.length || tokens.length !== clusters.length) {
+              throw new Error("Input lengths for rancher_hosts, admin_tokens, and cluster_names must match");
+            }
+            if (kubernetesVersions.length !== hosts.length) {
+              throw new Error("Kubernetes versions count must match rancher_hosts count");
+            }
+
+            for (let i = 0; i < hosts.length; i++) {
+              const host = hosts[i];
+              const token = tokens[i];
+              const cluster = clusters[i];
+              const qaseRun = qaseRuns[i] || "";
+              const reportToQase = qaseRun !== "" ? "true" : "false";
+              const k8sVersion = kubernetesVersions[i] || "";
+
+              console.log(`🚀 Dispatching for host=${host}, cluster=${cluster}, packages=${test_packages}`);
+
+              const inputs = {
+                rancher_host: host,
+                admin_token: token,
+                cluster_name: cluster,
+                kubernetes_version: k8sVersion,
+                test_packages,
+                run_all_tests: "${{ github.event.inputs.run_all_tests }}",
+                test_selector: "${{ github.event.inputs.test_selector }}",
+                exclude_test_files: "${{ github.event.inputs.exclude_test_files }}",
+                qase_test_run_id: qaseRun,
+                report_to_qase: reportToQase
+              };
+
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id,
+                ref,
+                inputs
+              });
+            }

--- a/.github/workflows/platform-qa-package-runner.yml
+++ b/.github/workflows/platform-qa-package-runner.yml
@@ -1,0 +1,151 @@
+name: Platform QA Package Runner
+run-name: Platform QA Package Runner - Cluster ${{ github.event.inputs.rancher_host }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      rancher_host:
+        description: "Rancher host (e.g. mycluster.qa.rancher.space)"
+        required: true
+      admin_token:
+        description: "Admin token for Rancher API access"
+        required: true
+      cluster_name:
+        description: "Downstream cluster name"
+        required: true
+      kubernetes_version:
+        description: "Kubernetes version for the cluster (e.g. v1.32.7+k3s1)"
+        required: true
+      test_packages:
+        description: "Comma-separated test package paths (e.g. validation/rbac,validation/projects)"
+        required: true
+      run_all_tests:
+        description: "Run all test files in the package?"
+        required: true
+        default: "true"
+        type: choice
+        options: ["true", "false"]
+      test_selector:
+        description: "Test suite or test name regex, if run_all_tests=false"
+        required: false
+      exclude_test_files:
+        description: "Test files to exclude (comma-separated)"
+        required: false
+      report_to_qase:
+        description: "Enable Qase reporting"
+        required: false
+        default: "false"
+        type: choice
+        options: ["true", "false"]
+      qase_test_run_id:
+        description: "Qase Test Run ID, if report_to_qase=true"
+        required: false
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  run-package:
+    runs-on: ubuntu-latest
+    env:
+      RANCHER_HOST: ${{ github.event.inputs.rancher_host }}
+      RANCHER_ADMIN_TOKEN: ${{ github.event.inputs.admin_token }}
+      CLUSTER_NAME: ${{ github.event.inputs.cluster_name }}
+      TEST_PACKAGES: ${{ github.event.inputs.test_packages }}
+      RUN_ALL_TESTS: ${{ github.event.inputs.run_all_tests }}
+      EXCLUDE_TEST_FILES: ${{ github.event.inputs.exclude_test_files }}
+      TEST_SELECTOR: ${{ github.event.inputs.test_selector }}
+      REPORT_TO_QASE: ${{ github.event.inputs.report_to_qase }}
+      QASE_TEST_RUN_ID: ${{ github.event.inputs.qase_test_run_id }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Parse current and remaining packages
+        id: parse
+        run: |
+          IFS=',' read -ra PKGS <<< "$(echo "${{ github.event.inputs.test_packages }}" | xargs)"
+          CURRENT="${PKGS[0]}"
+          
+          REMAINING_PKGS=("${PKGS[@]:1}")
+          REMAINING=""
+          if [ ${#REMAINING_PKGS[@]} -gt 0 ]; then
+            REMAINING=$(IFS=,; echo "${REMAINING_PKGS[*]}")
+          fi
+
+          echo "current_pkg=$CURRENT" >> $GITHUB_OUTPUT
+          echo "remaining_packages=$REMAINING" >> $GITHUB_OUTPUT
+
+      - name: Trigger and wait for test runner to complete
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RANCHER_HOST: ${{ github.event.inputs.rancher_host }}
+          PKG: ${{ steps.parse.outputs.current_pkg }}
+        run: |
+          INPUTS=(
+            "-F" "rancher_host=${{ github.event.inputs.rancher_host }}"
+            "-F" "admin_token=${{ github.event.inputs.admin_token }}"
+            "-F" "cluster_name=${{ github.event.inputs.cluster_name }}"
+            "-F" "kubernetes_version=${{ github.event.inputs.kubernetes_version }}" 
+            "-F" "test_package=${{ steps.parse.outputs.current_pkg }}"
+            "-F" "run_all_tests=${{ github.event.inputs.run_all_tests }}"
+            "-F" "test_selector=${{ github.event.inputs.test_selector }}"
+            "-F" "exclude_test_files=${{ github.event.inputs.exclude_test_files }}"
+            "-F" "report_to_qase=${{ github.event.inputs.report_to_qase }}"
+            "-F" "qase_test_run_id=${{ github.event.inputs.qase_test_run_id }}"
+          )
+
+          echo "🚀 Triggering workflow for pkg=${{ steps.parse.outputs.current_pkg }}..."
+          gh workflow run "Platform QA Test Runner with Qase Reporting" \
+            --ref main "${INPUTS[@]}"
+
+          sleep 10
+          for i in {1..30}; do  
+            RUN_ID=$(gh run list --workflow "Platform QA Test Runner with Qase Reporting" \
+              --json databaseId,displayTitle,status,createdAt \
+              --limit 5 \
+              --jq '[.[] | select(.displayTitle == "Platform QA Test Runner - Cluster '"$RANCHER_HOST"' - Package '"$PKG"'") | select(.status == "queued" or .status == "in_progress")] | sort_by(.createdAt) | last | .databaseId')
+
+            if [ -n "$RUN_ID" ]; then
+              break
+            fi
+            echo "⏳ Waiting for run (cluster=$RANCHER_HOST, pkg=$PKG) to register..."
+            sleep 10
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "❌ Could not find run for cluster=$RANCHER_HOST pkg=$PKG"
+            exit 1
+          fi
+
+          echo "⏳ Waiting for run $RUN_ID (cluster=$RANCHER_HOST, pkg=$PKG) to complete..."
+          gh run watch "$RUN_ID" --interval 300 --exit-status
+
+      - name: Call Dispatcher for remaining packages
+        if: ${{ steps.parse.outputs.remaining_packages }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "platform-qa-package-dispatcher.yml",
+              ref: "main",
+              inputs: {
+                rancher_hosts: "${{ github.event.inputs.rancher_host }}",
+                admin_tokens: "${{ github.event.inputs.admin_token }}",
+                cluster_names: "${{ github.event.inputs.cluster_name }}",
+                kubernetes_versions: "${{ github.event.inputs.kubernetes_version }}",
+                test_packages: "${{ steps.parse.outputs.remaining_packages }}",
+                run_all_tests: "${{ github.event.inputs.run_all_tests }}",
+                recursive_tests: "false",
+                test_selector: "${{ github.event.inputs.test_selector }}",
+                exclude_test_files: "${{ github.event.inputs.exclude_test_files }}",
+                qase_test_run_ids: "${{ github.event.inputs.qase_test_run_id }}"
+              }
+            });

--- a/.github/workflows/platform-qa-test-runner.yml
+++ b/.github/workflows/platform-qa-test-runner.yml
@@ -1,0 +1,201 @@
+name: Platform QA Test Runner with Qase Reporting
+run-name: Platform QA Test Runner - Cluster ${{ github.event.inputs.rancher_host }} - Package ${{ github.event.inputs.test_package }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      rancher_host:
+        description: "Rancher host (e.g. mycluster.qa.rancher.space)"
+        required: true
+      admin_token:
+        description: "Admin token for Rancher API access"
+        required: true
+      cluster_name:
+        description: "Downstream cluster name"
+        required: true
+      kubernetes_version:
+        description: "Kubernetes version for the cluster (e.g. v1.32.7+k3s1)"
+        required: true
+        default: "v1.32.7+k3s1"
+      test_package:
+        description: "Single test package path (e.g. validation/rbac)"
+        required: true
+      run_all_tests:
+        description: "Run all test files in the package?"
+        required: true
+        default: "true"
+        type: choice
+        options: ["true", "false"]
+      test_selector:
+        description: "Test suite or test name regex (e.g. ^TestSuiteName$ or ^TestSuite/TestCase$), if run_all_tests=false"
+        required: false
+      exclude_test_files:
+        description: "Test files to exclude (comma-separated), if run_all_tests=true (e.g. rbac_test.go,projects_test.go)"
+        required: false
+      report_to_qase:
+        description: "Enable Qase reporting"
+        required: false
+        default: "false"
+        type: choice
+        options: ["true", "false"]
+      qase_test_run_id:
+        description: "Qase Test Run ID, if report_to_qase=true"
+        required: false
+
+permissions:
+  contents: read
+
+env:
+  QUAY_REGISTRY_NAME: ${{ secrets.QUAY_REGISTRY_NAME }}
+  QUAY_REGISTRY_USERNAME: ${{ secrets.QUAY_REGISTRY_USERNAME }}
+  QUAY_REGISTRY_PASSWORD: ${{ secrets.QUAY_REGISTRY_PASSWORD }}
+  AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  RANCHER_ADMIN_PASSWORD: ${{ secrets.RANCHER_ADMIN_PASSWORD }}
+  AWS_IAM_PROFILE: ${{ secrets.AWS_IAM_PROFILE }}
+  AWS_AMI: ${{ secrets.AWS_AMI }}
+  AWS_USER: ${{ secrets.AWS_USER }}
+  AWS_VPC_ID: ${{ secrets.AWS_VPC_ID }}
+  AWS_SECURITY_GROUP_NAMES: ${{ secrets.AWS_QA_SECURITY_GROUP_NAMES }}
+  PROVIDER_AMAZON: ${{ vars.PROVIDER_AMAZON }}
+  CNI: ${{ secrets.CNI }}
+  AWS_INSTANCE_TYPE: ${{ vars.AWS_INSTANCE_TYPE }}
+  AWS_VOLUME_TYPE: ${{ vars.AWS_VOLUME_TYPE }}
+  AWS_ZONE_LETTER: ${{ vars.AWS_ZONE_LETTER }}
+  AWS_ROOT_SIZE: ${{ vars.AWS_ROOT_SIZE }}
+  SSH_PRIVATE_KEY_PATH: ${{ secrets.SSH_PRIVATE_KEY_PATH }}
+  SSH_PRIVATE_KEY_NAME: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+  QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    env:
+      RANCHER_HOST: ${{ github.event.inputs.rancher_host }}
+      RANCHER_ADMIN_TOKEN: ${{ github.event.inputs.admin_token }}
+      CLUSTER_NAME: ${{ github.event.inputs.cluster_name }}
+      KUBERNETES_VERSION: ${{ github.event.inputs.kubernetes_version }}
+      TEST_PACKAGE: ${{ github.event.inputs.test_package }}
+      RUN_ALL_TESTS: ${{ github.event.inputs.run_all_tests }}
+      EXCLUDE_TEST_FILES: ${{ github.event.inputs.exclude_test_files }}
+      TEST_SELECTOR: ${{ github.event.inputs.test_selector }}
+      REPORT_TO_QASE: ${{ github.event.inputs.report_to_qase }}
+      QASE_TEST_RUN_ID: ${{ github.event.inputs.qase_test_run_id }}
+      GOTESTSUM_OUTPUT_BUFFER: 0
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Go 
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Create cattle config
+        run: bash .github/scripts/platform-qa-create-cattle-config.sh
+
+      - name: Get Rancher version
+        run: bash .github/scripts/platform-qa-get-rancher-version.sh
+        env:
+          RANCHER_ADMIN_TOKEN: ${{ env.RANCHER_ADMIN_TOKEN }}
+          RANCHER_HOST: ${{ env.RANCHER_HOST }}
+
+      - name: Run all tests in package
+        if: github.event.inputs.run_all_tests == 'true'
+        env:
+          CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config.yaml
+        run: |
+          REPO_ROOT="${GITHUB_WORKSPACE}"
+          PACKAGE="$TEST_PACKAGE"
+          TAGS="validation"
+
+          if [ ! -d "$PACKAGE" ]; then
+            echo "❌ Package $PACKAGE not found. Exiting."
+            exit 1
+          fi
+
+          echo "🔎 Package: $PACKAGE"
+          cd "$REPO_ROOT/$PACKAGE"
+
+          ALL_TEST_FILES=$(ls *_test.go 2>/dev/null | grep -E -v '(^_deprecated_|^deprecated_)' || true)
+
+          FILTERED_TEST_FILES=""
+          for file in $ALL_TEST_FILES; do
+            if grep -q "\!$RANCHER_SHORT_VERSION" "$file"; then
+              echo "Skipping $file (excluded for version $RANCHER_SHORT_VERSION)"
+              continue
+            fi
+            FILTERED_TEST_FILES="$FILTERED_TEST_FILES $file"
+          done
+
+          if [ -n "$EXCLUDE_TEST_FILES" ]; then
+            EXCLUDE_PATTERN_FILE=$(mktemp)
+            echo "$EXCLUDE_TEST_FILES" | tr ',' '\n' > "$EXCLUDE_PATTERN_FILE"
+            FILTERED_TEST_FILES=$(echo "$FILTERED_TEST_FILES" | tr ' ' '\n' | grep -x -v -f "$EXCLUDE_PATTERN_FILE" | tr '\n' ' ' || true)
+            rm "$EXCLUDE_PATTERN_FILE"
+          fi
+
+          FILTERED_TEST_FILES=$(echo "$FILTERED_TEST_FILES" | xargs)
+
+          if [ -z "$FILTERED_TEST_FILES" ]; then
+            echo "⚠️ No test files found after applying filters. Exiting."
+            exit 0
+          fi
+
+          NON_TEST_GO_FILES=$(ls *.go 2>/dev/null | grep -v '_test.go' || true)
+          FILES_TO_COMPILE_AND_RUN="$FILTERED_TEST_FILES $NON_TEST_GO_FILES"
+
+          echo "$(date +'%T') — 🚀 Running tests in package $PACKAGE"
+          echo "   Test Files: $FILTERED_TEST_FILES"
+          echo "   With tags: $TAGS"
+
+          stdbuf -oL gotestsum \
+            --format=standard-verbose \
+            --junitfile "$GITHUB_WORKSPACE/results-${PACKAGE//\//-}.xml" \
+            --jsonfile "$GITHUB_WORKSPACE/results-${PACKAGE//\//-}.json" \
+            -- -v -tags="$TAGS" -timeout 6h $FILES_TO_COMPILE_AND_RUN || echo "$(date +'%T') ⚠️ Test failed in $PACKAGE"
+
+      - name: Run single test with selector
+        if: github.event.inputs.run_all_tests == 'false'
+        env:
+          CATTLE_TEST_CONFIG: ${{ github.workspace }}/cattle-config.yaml
+        run: |
+          REPO_ROOT="${GITHUB_WORKSPACE}"
+          PACKAGE="$TEST_PACKAGE"
+          TAGS="validation"
+          
+          if [ -z "$TEST_SELECTOR" ]; then
+            echo "❌ test_selector input is required when run_all_tests is false"
+            exit 1
+          fi
+          
+          echo "▶ Running selector: '$TEST_SELECTOR' with tags: $TAGS for package: $PACKAGE"
+
+          stdbuf -oL gotestsum \
+            --format=standard-verbose \
+            --junitfile "$GITHUB_WORKSPACE/results-${PACKAGE//\//-}.xml" \
+            --jsonfile "$GITHUB_WORKSPACE/results-${PACKAGE//\//-}.json" \
+            --packages="github.com/rancher/tests/$PACKAGE" \
+            -- -v -tags="$TAGS" -timeout 6h -run "$TEST_SELECTOR" || echo "$(date +'%T')  ⚠️ Test failed in $PACKAGE"
+
+      - name: Report results to Qase
+        if: github.event.inputs.report_to_qase == 'true'
+        run: |
+          PACKAGE="$TEST_PACKAGE"
+          if [ -z "$QASE_TEST_RUN_ID" ]; then
+            echo "⚠️ QASE reporting requested but no test run ID provided. Skipping reporting."
+            exit 0
+          fi
+          
+          bash "$GITHUB_WORKSPACE/.github/scripts/platform-qa-report-to-qase.sh" \
+            "$GITHUB_WORKSPACE/results-${PACKAGE//\//-}.json" \
+            "$PACKAGE" \
+            "$QASE_TEST_RUN_ID" \
+            "$QASE_AUTOMATION_TOKEN"


### PR DESCRIPTION
Our current Release testing process requires manually triggering a separate Jenkins job for each test suite on each cluster. For example, running 10 suites across 3 clusters means triggering 30 individual jobs. Each suite has to be triggered individually and waiting between jobs slows the process significantly and makes managing multiple releases in parallel very challenging

We implemented a **single-trigger GHA workflow** that:
1. Runs all tests across multiple clusters in parallel.
2. Executes multiple test packages sequentially per cluster to prevent conflicts.
3. Automatically reports results to Qase.

This is achieved using three coordinated workflows:
- Dispatcher Workflow – Main entry point that distributes test packages across clusters.
- Package Runner Workflow – Executes multiple packages sequentially on a cluster.
- Test Runner Workflow – Runs actual tests for a specific package and publishes results to Qase.