### PR TITLE
Update Prime workflows to set the Rancher chart URL

### DIFF
--- a/.github/actions/set-rancher-chart-url/action.yml
+++ b/.github/actions/set-rancher-chart-url/action.yml
@@ -1,0 +1,42 @@
+---
+name: "Set Rancher Chart URL"
+description: "Sets the Rancher url depending on the provided Rancher repo for Prime builds only"
+inputs:
+  rancher-repo:
+    description: "The rancher repo"
+    required: true
+  staging-chart-url:
+    description: "The chart url to use if the repo is latest or alpha"
+    required: true
+  fallback-chart-url:
+    description: "The fallback chart url if the repo is not latest or alpha"
+    default: ""
+  env-var-name:
+    description: "The name of the environment variable to set"
+    default: "RANCHER_HELM_CHART_URL"
+outputs:
+  chart_url:
+    description: "The determined chart url"
+    value: ${{ steps.determine-chart-url.outputs.chart_url }}
+runs:
+  using: "composite"
+  steps:
+    - name: Determine chart url
+      id: determine-chart-url
+      shell: bash
+      run: |
+        RANCHER_REPO="${{ inputs.rancher-repo }}"
+
+        if [[ "$RANCHER_REPO" == "latest" ]] || [[ "$RANCHER_REPO" == "alpha" ]]; then
+          CHART_URL="${{ inputs.staging-chart-url }}"
+        else
+          CHART_URL="${{ inputs.fallback-chart-url }}"
+        fi
+        
+        echo "chart_url=$CHART_URL" >> $GITHUB_OUTPUT
+    
+    - name: Set environment variable
+      uses: ./.github/actions/set-env-var
+      with:
+        key: ${{ inputs.env-var-name }}
+        value: ${{ steps.determine-chart-url.outputs.chart_url }}

--- a/.github/workflows/community-daily-cluster-provisioning.yml
+++ b/.github/workflows/community-daily-cluster-provisioning.yml
@@ -304,8 +304,9 @@ jobs:
         uses: ./.github/actions/run-hostbusters-daily-provisioning
 
       - name: Cleanup Infrastructure
+        if: always()
         working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve
+        run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
         if: always()
@@ -587,8 +588,9 @@ jobs:
         uses: ./.github/actions/run-hostbusters-daily-provisioning
 
       - name: Cleanup Infrastructure
+        if: always()
         working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve
+        run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
         if: always()

--- a/.github/workflows/community-recurring-tests.yml
+++ b/.github/workflows/community-recurring-tests.yml
@@ -309,8 +309,9 @@ jobs:
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
+        if: always()
         working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve
+        run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
         if: always()
@@ -597,8 +598,9 @@ jobs:
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
+        if: always()
         working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve
+        run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
         if: always()

--- a/.github/workflows/prime-daily-cluster-provisioning.yml
+++ b/.github/workflows/prime-daily-cluster-provisioning.yml
@@ -55,7 +55,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    environment: staging-alpha
+    environment: staging
 
     steps:
       - name: Checkout repository
@@ -139,6 +139,13 @@ jobs:
           rancher-version: ${{ env.RANCHER_VERSION }}
           fallback-repo: ${{ secrets.RANCHER_REPO }}
 
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
+
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -198,7 +205,7 @@ jobs:
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
@@ -315,8 +322,9 @@ jobs:
         uses: ./.github/actions/run-hostbusters-daily-provisioning
 
       - name: Cleanup Infrastructure
+        if: always()
         working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve
+        run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
         if: always()
@@ -339,7 +347,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
-    environment: staging-alpha
+    environment: staging
 
     steps:
       - name: Checkout repository
@@ -423,6 +431,13 @@ jobs:
           rancher-version: ${{ env.RANCHER_VERSION }}
           fallback-repo: ${{ secrets.RANCHER_REPO }}
 
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
+
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -482,7 +497,7 @@ jobs:
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
@@ -599,8 +614,9 @@ jobs:
         uses: ./.github/actions/run-hostbusters-daily-provisioning
 
       - name: Cleanup Infrastructure
+        if: always()
         working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve
+        run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
         if: always()
@@ -622,7 +638,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.9.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}
     runs-on: ubuntu-latest
-    environment: staging-alpha
+    environment: staging
 
     steps:
       - name: Checkout repository
@@ -706,6 +722,13 @@ jobs:
           rancher-version: ${{ env.RANCHER_VERSION }}
           fallback-repo: ${{ secrets.RANCHER_REPO }}
 
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
+
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -764,7 +787,7 @@ jobs:
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
@@ -881,8 +904,9 @@ jobs:
         uses: ./.github/actions/run-hostbusters-daily-provisioning
 
       - name: Cleanup Infrastructure
+        if: always()
         working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve
+        run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
         if: always()

--- a/.github/workflows/prime-recurring-tests.yml
+++ b/.github/workflows/prime-recurring-tests.yml
@@ -55,7 +55,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-11 }}
     runs-on: ubuntu-latest
-    environment: staging-alpha
+    environment: staging
     strategy:
       matrix:
         suite:
@@ -144,6 +144,13 @@ jobs:
           rancher-version: ${{ env.RANCHER_VERSION }}
           fallback-repo: ${{ secrets.RANCHER_REPO }}
 
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
+
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -197,7 +204,7 @@ jobs:
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
@@ -319,8 +326,9 @@ jobs:
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
+        if: always()
         working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve
+        run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
         if: always()
@@ -343,7 +351,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-10 }}
     runs-on: ubuntu-latest
-    environment: staging-alpha
+    environment: staging
     strategy:
       matrix:
         suite:
@@ -432,6 +440,13 @@ jobs:
           rancher-version: ${{ env.RANCHER_VERSION }}
           fallback-repo: ${{ secrets.RANCHER_REPO }}
 
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
+
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -485,7 +500,7 @@ jobs:
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
@@ -607,8 +622,9 @@ jobs:
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
+        if: always()
         working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve
+        run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
         if: always()
@@ -630,7 +646,7 @@ jobs:
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.9.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ inputs.rancher_version || github.event.inputs.rancher-version-2-9 }}
     runs-on: ubuntu-latest
-    environment: staging-alpha
+    environment: staging
     strategy:
       matrix:
         suite:
@@ -719,6 +735,13 @@ jobs:
           rancher-version: ${{ env.RANCHER_VERSION }}
           fallback-repo: ${{ secrets.RANCHER_REPO }}
 
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
+
       - name: Get Qase ID
         id: get-qase-id
         uses: ./.github/actions/get-qase-id
@@ -771,7 +794,7 @@ jobs:
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ env.RANCHER_VERSION }}"
@@ -893,8 +916,9 @@ jobs:
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
+        if: always()
         working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve
+        run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
         if: always()

--- a/go.mod
+++ b/go.mod
@@ -71,9 +71,9 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/rancher/rancher v0.0.0-20250806201723-9a7af3779b9d
 	github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70
-	github.com/rancher/tests/actions v0.0.0-20250806190403-cb1746eb0d9d
+	github.com/rancher/tests/actions v0.0.0-20250905194519-8b56fea58b3a
 	github.com/rancher/tests/interoperability v0.0.0-00010101000000-000000000000
-	github.com/rancher/tfp-automation v0.0.0-20250903201820-5b10667cd9f7
+	github.com/rancher/tfp-automation v0.0.0-20250910183726-98dab225378b
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2207,8 +2207,8 @@ github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70 h1:XouRIvo2zm8Y/h
 github.com/rancher/shepherd v0.0.0-20250909212212-7933bb572f70/go.mod h1:GzGXUZYnFmXho1GyvkrGFQawAuHvvC7VDHjHOGnHEIM=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd h1:M3oVcVktMhNk8l3ZRW94kroqzWzE/VGbZfLw/F0rw5Y=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250710162344-185ff9f785cd/go.mod h1:VfRrgue4yl6O0GYakMGYgyByu7ySooPQWWRxTt2MIEI=
-github.com/rancher/tfp-automation v0.0.0-20250903201820-5b10667cd9f7 h1:7x5sIOuvk6C0Xx40jw+57/ODFZvL8eD/VCuYrVzpVcU=
-github.com/rancher/tfp-automation v0.0.0-20250903201820-5b10667cd9f7/go.mod h1:6/hRFECaP8PHoP9hXKPPAAO3rKMrOn7HigqP/Bdq1VU=
+github.com/rancher/tfp-automation v0.0.0-20250910183726-98dab225378b h1:TSULnh1e26ya1RyaHrDFvfXfIPUDT5lD5lkZ/C8KloM=
+github.com/rancher/tfp-automation v0.0.0-20250910183726-98dab225378b/go.mod h1:nzmR+xFBlLlX1rugqX06vKVAIytGS2wTX62nC+kuDog=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=


### PR DESCRIPTION
### Description
With the recent splitting of prime and community, today's earlier scheduling runs revealed that the prime builds failed. Digging deeper, it is because the helm chart URLs are not being used correctly for the set environment. To fix this, the environments are set to prime and we have a new set-rancher-chart-url custom action.

If the rancher repo is latest or alpha, then use the staging helm chart URL. Otherwise, use the prime chart URL. In addition, fixing some other misc issues.