### PR TITLE
Fix verify rancher version for head commits

### DIFF
--- a/validation/recurring/infrastructure/setuprancher/createRancherServer.go
+++ b/validation/recurring/infrastructure/setuprancher/createRancherServer.go
@@ -58,7 +58,9 @@ func setupRancher(t *testing.T) (*rancher.Client, error) {
 		cleanup.Cleanup(nil, terraformOptions, keyPath)
 	}
 
-	provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.RancherTagVersion)
+	if standaloneConfig.RancherTagVersion != "head" {
+		provisioning.VerifyRancherVersion(t, rancherConfig.Host, standaloneConfig.RancherTagVersion)
+	}
 
 	return client, err
 }


### PR DESCRIPTION
### Description
The logs for `head` commit indicated that we neglected to update the rancher tag version to not look for `head`. We have this same change in `tfp-automation`, so just porting it over to here.