### PR TITLE
Fix community path to tests repo

### DIFF
--- a/.github/workflows/community-daily-cluster-provisioning.yml
+++ b/.github/workflows/community-daily-cluster-provisioning.yml
@@ -203,7 +203,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
               rke2Registries:
@@ -489,7 +489,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
               rke2Registries:

--- a/.github/workflows/community-recurring-tests.yml
+++ b/.github/workflows/community-recurring-tests.yml
@@ -205,7 +205,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
               rke2Registries:
@@ -495,7 +495,7 @@ jobs:
             cni: "${{ secrets.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
               rke2Registries:


### PR DESCRIPTION
### Description
The community workflows had the incorrect path to repo for the actual `rancher/tests`. This is a small PR to fix that.