### PR TITLE
Update CreateStandardUser to return creds

### DIFF
--- a/validation/certificates/rke1/cert_rotation_test.go
+++ b/validation/certificates/rke1/cert_rotation_test.go
@@ -39,7 +39,7 @@ func (c *RKE1CertRotationTestSuite) SetupSuite() {
 
 	c.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(c.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(c.client)
 	require.NoError(c.T(), err)
 
 	nodeRolesStandard := []provisioninginput.NodePools{

--- a/validation/certificates/rke2k3s/cert_rotation_test.go
+++ b/validation/certificates/rke2k3s/cert_rotation_test.go
@@ -49,7 +49,7 @@ func (c *CertRotationTestSuite) SetupSuite() {
 
 	c.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(c.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(c.client)
 	require.NoError(c.T(), err)
 
 	c.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/certificates/rke2k3s/cert_rotation_wins_test.go
+++ b/validation/certificates/rke2k3s/cert_rotation_wins_test.go
@@ -49,7 +49,7 @@ func (c *CertRotationWindowsTestSuite) SetupSuite() {
 
 	c.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(c.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(c.client)
 	require.NoError(c.T(), err)
 
 	c.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/deleting/rke1/delete_cluster_test.go
+++ b/validation/deleting/rke1/delete_cluster_test.go
@@ -40,7 +40,7 @@ func (d *DeleteRKE1ClusterTestSuite) SetupSuite() {
 
 	d.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(d.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(d.client)
 	require.NoError(d.T(), err)
 
 	nodeRolesStandard := []provisioninginput.NodePools{

--- a/validation/deleting/rke2k3s/delete_cluster_test.go
+++ b/validation/deleting/rke2k3s/delete_cluster_test.go
@@ -47,7 +47,7 @@ func (d *DeleteClusterTestSuite) SetupSuite() {
 
 	d.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(d.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(d.client)
 	require.NoError(d.T(), err)
 
 	d.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/deleting/rke2k3s/delete_init_machine_test.go
+++ b/validation/deleting/rke2k3s/delete_init_machine_test.go
@@ -48,7 +48,7 @@ func (d *DeleteInitMachineTestSuite) SetupSuite() {
 
 	d.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(d.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(d.client)
 	require.NoError(d.T(), err)
 
 	d.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/nodescaling/rke1/scale_replace_rke1_test.go
+++ b/validation/nodescaling/rke1/scale_replace_rke1_test.go
@@ -40,7 +40,7 @@ func (s *RKE1NodeReplacingTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	nodeRolesStandard := []provisioninginput.NodePools{

--- a/validation/nodescaling/rke1/scaling_custom_cluster_rke1_test.go
+++ b/validation/nodescaling/rke1/scaling_custom_cluster_rke1_test.go
@@ -46,7 +46,7 @@ func (s *RKE1CustomClusterNodeScalingTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	nodeRolesStandard := []provisioninginput.NodePools{

--- a/validation/nodescaling/rke1/scaling_node_driver_rke1_test.go
+++ b/validation/nodescaling/rke1/scaling_node_driver_rke1_test.go
@@ -46,7 +46,7 @@ func (s *RKE1NodeScalingTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	nodeRolesStandard := []provisioninginput.NodePools{

--- a/validation/nodescaling/rke2k3s/auto_replace_test.go
+++ b/validation/nodescaling/rke2k3s/auto_replace_test.go
@@ -48,7 +48,7 @@ func (s *AutoReplaceSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/nodescaling/rke2k3s/scale_replace_test.go
+++ b/validation/nodescaling/rke2k3s/scale_replace_test.go
@@ -54,7 +54,7 @@ func (s *NodeReplacingTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/nodescaling/rke2k3s/scaling_custom_cluster_test.go
+++ b/validation/nodescaling/rke2k3s/scaling_custom_cluster_test.go
@@ -52,7 +52,7 @@ func (s *CustomClusterNodeScalingTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/nodescaling/rke2k3s/scaling_node_driver_test.go
+++ b/validation/nodescaling/rke2k3s/scaling_node_driver_test.go
@@ -53,7 +53,7 @@ func (s *NodeScalingTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/provisioning/k3s/custom_test.go
+++ b/validation/provisioning/k3s/custom_test.go
@@ -53,7 +53,7 @@ func customSetup(t *testing.T) customTest {
 	k.cattleConfig, err = defaults.SetK8sDefault(k.client, defaults.K3S, k.cattleConfig)
 	assert.NoError(t, err)
 
-	k.standardUserClient, err = standard.CreateStandardUser(k.client)
+	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
 	assert.NoError(t, err)
 
 	return k

--- a/validation/provisioning/k3s/data_directories_test.go
+++ b/validation/provisioning/k3s/data_directories_test.go
@@ -54,7 +54,7 @@ func dataDirectoriesSetup(t *testing.T) dataDirectoriesTest {
 	k.cattleConfig, err = defaults.SetK8sDefault(k.client, defaults.K3S, k.cattleConfig)
 	assert.NoError(t, err)
 
-	k.standardUserClient, err = standard.CreateStandardUser(k.client)
+	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
 	assert.NoError(t, err)
 
 	return k

--- a/validation/provisioning/k3s/dynamic_custom_test.go
+++ b/validation/provisioning/k3s/dynamic_custom_test.go
@@ -60,7 +60,7 @@ func dynamicCustomSetup(t *testing.T) dynamicCustomTest {
 
 	k.cattleConfigs = append(k.cattleConfigs, permutedConfigs...)
 
-	k.standardUserClient, err = standard.CreateStandardUser(k.client)
+	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
 	assert.NoError(t, err)
 
 	return k

--- a/validation/provisioning/k3s/dynamic_node_driver_test.go
+++ b/validation/provisioning/k3s/dynamic_node_driver_test.go
@@ -58,7 +58,7 @@ func dynamicNodeDriverSetup(t *testing.T) DynamicNodeDriverTest {
 
 	k.cattleConfigs = append(k.cattleConfigs, permutedConfigs...)
 
-	k.standardUserClient, err = standard.CreateStandardUser(k.client)
+	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
 	assert.NoError(t, err)
 
 	return k

--- a/validation/provisioning/k3s/hardened_test.go
+++ b/validation/provisioning/k3s/hardened_test.go
@@ -63,7 +63,7 @@ func hardenedSetup(t *testing.T) hardenedTest {
 	k.cattleConfig, err = defaults.SetK8sDefault(client, defaults.K3S, k.cattleConfig)
 	assert.NoError(t, err)
 
-	k.standardUserClient, err = standard.CreateStandardUser(k.client)
+	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
 	assert.NoError(t, err)
 
 	return k

--- a/validation/provisioning/k3s/hostname_truncation_test.go
+++ b/validation/provisioning/k3s/hostname_truncation_test.go
@@ -54,7 +54,7 @@ func hostnameTruncationSetup(t *testing.T) hostnameTruncationTest {
 	k.cattleConfig, err = defaults.SetK8sDefault(k.client, defaults.K3S, k.cattleConfig)
 	assert.NoError(t, err)
 
-	k.standardUserClient, err = standard.CreateStandardUser(k.client)
+	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
 	assert.NoError(t, err)
 
 	return k

--- a/validation/provisioning/k3s/node_driver_test.go
+++ b/validation/provisioning/k3s/node_driver_test.go
@@ -53,7 +53,7 @@ func nodeDriverSetup(t *testing.T) nodeDriverTest {
 	k.cattleConfig, err = defaults.SetK8sDefault(k.client, defaults.K3S, k.cattleConfig)
 	assert.NoError(t, err)
 
-	k.standardUserClient, err = standard.CreateStandardUser(k.client)
+	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
 	assert.NoError(t, err)
 
 	return k

--- a/validation/provisioning/k3s/psact_test.go
+++ b/validation/provisioning/k3s/psact_test.go
@@ -54,7 +54,7 @@ func psactSetup(t *testing.T) psactTest {
 	k.cattleConfig, err = defaults.SetK8sDefault(client, defaults.K3S, k.cattleConfig)
 	assert.NoError(t, err)
 
-	k.standardUserClient, err = standard.CreateStandardUser(k.client)
+	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
 	assert.NoError(t, err)
 
 	return k

--- a/validation/provisioning/k3s/template_test.go
+++ b/validation/provisioning/k3s/template_test.go
@@ -75,7 +75,7 @@ func templateSetup(t *testing.T) templateTest {
 	k.cloudCredentials, err = provider.CloudCredFunc(client, cloudCredentialConfig)
 	assert.NoError(t, err)
 
-	k.standardUserClient, err = standard.CreateStandardUser(k.client)
+	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
 	assert.NoError(t, err)
 
 	return k

--- a/validation/provisioning/resources/standarduser/standarduser.go
+++ b/validation/provisioning/resources/standarduser/standarduser.go
@@ -9,7 +9,7 @@ import (
 )
 
 // CreateStandardUser is a helper function that creates a standard user in the Rancher cluster.
-func CreateStandardUser(client *rancher.Client) (*rancher.Client, error) {
+func CreateStandardUser(client *rancher.Client) (*rancher.Client, string, string, error) {
 	enabled := true
 	testuser := namegen.AppendRandomString("testuser-")
 	testpassword := password.GenerateUserPassword("testpass-")
@@ -23,15 +23,15 @@ func CreateStandardUser(client *rancher.Client) (*rancher.Client, error) {
 
 	newUser, err := users.CreateUserWithRole(client, user, "user")
 	if err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
 
 	newUser.Password = user.Password
 
 	standardUserClient, err := client.AsUser(newUser)
 	if err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
 
-	return standardUserClient, nil
+	return standardUserClient, testuser, testpassword, nil
 }

--- a/validation/provisioning/rke2/ace_test.go
+++ b/validation/provisioning/rke2/ace_test.go
@@ -56,7 +56,7 @@ func aceSetup(t *testing.T) aceTest {
 	r.cattleConfig, err = defaults.SetK8sDefault(client, defaults.RKE2, r.cattleConfig)
 	require.NoError(t, err)
 
-	r.standardUserClient, err = standard.CreateStandardUser(r.client)
+	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	assert.NoError(t, err)
 
 	return r

--- a/validation/provisioning/rke2/agent_customization_test.go
+++ b/validation/provisioning/rke2/agent_customization_test.go
@@ -55,7 +55,7 @@ func agentCustomizationSetup(t *testing.T) agentCustomizationTest {
 	r.cattleConfig, err = defaults.SetK8sDefault(client, defaults.RKE2, r.cattleConfig)
 	assert.NoError(t, err)
 
-	r.standardUserClient, err = standard.CreateStandardUser(r.client)
+	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	assert.NoError(t, err)
 
 	return r

--- a/validation/provisioning/rke2/cloud_provider_test.go
+++ b/validation/provisioning/rke2/cloud_provider_test.go
@@ -56,7 +56,7 @@ func cloudProviderSetup(t *testing.T) cloudProviderTest {
 	r.cattleConfig, err = defaults.SetK8sDefault(client, defaults.RKE2, r.cattleConfig)
 	assert.NoError(t, err)
 
-	r.standardUserClient, err = standard.CreateStandardUser(r.client)
+	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	assert.NoError(t, err)
 
 	return r

--- a/validation/provisioning/rke2/custom_test.go
+++ b/validation/provisioning/rke2/custom_test.go
@@ -53,7 +53,7 @@ func customSetup(t *testing.T) customTest {
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
 	assert.NoError(t, err)
 
-	r.standardUserClient, err = standard.CreateStandardUser(r.client)
+	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	assert.NoError(t, err)
 
 	return r

--- a/validation/provisioning/rke2/data_directories_test.go
+++ b/validation/provisioning/rke2/data_directories_test.go
@@ -54,7 +54,7 @@ func dataDirectoriesSetup(t *testing.T) dataDirectoriesTest {
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
 	assert.NoError(t, err)
 
-	r.standardUserClient, err = standard.CreateStandardUser(r.client)
+	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	assert.NoError(t, err)
 
 	return r

--- a/validation/provisioning/rke2/dynamic_custom_test.go
+++ b/validation/provisioning/rke2/dynamic_custom_test.go
@@ -64,7 +64,7 @@ func dynamicCustomSetup(t *testing.T) dynamicCustomTest {
 
 	r.cattleConfigs = append(r.cattleConfigs, permutedConfigs...)
 
-	r.standardUserClient, err = standard.CreateStandardUser(r.client)
+	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	assert.NoError(t, err)
 
 	return r

--- a/validation/provisioning/rke2/dynamic_node_driver_test.go
+++ b/validation/provisioning/rke2/dynamic_node_driver_test.go
@@ -62,7 +62,7 @@ func dynamicNodeDriverSetup(t *testing.T) DynamicNodeDriverTest {
 
 	r.cattleConfigs = append(r.cattleConfigs, permutedConfigs...)
 
-	r.standardUserClient, err = standard.CreateStandardUser(r.client)
+	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	assert.NoError(t, err)
 
 	return r

--- a/validation/provisioning/rke2/hardened_test.go
+++ b/validation/provisioning/rke2/hardened_test.go
@@ -62,7 +62,7 @@ func hardenedSetup(t *testing.T) hardenedTest {
 	r.cattleConfig, err = defaults.SetK8sDefault(client, defaults.RKE2, r.cattleConfig)
 	assert.NoError(t, err)
 
-	r.standardUserClient, err = standard.CreateStandardUser(r.client)
+	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	assert.NoError(t, err)
 
 	return r

--- a/validation/provisioning/rke2/hostname_truncation_test.go
+++ b/validation/provisioning/rke2/hostname_truncation_test.go
@@ -53,7 +53,7 @@ func hostnameTruncationSetup(t *testing.T) hostnameTruncationTest {
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
 	assert.NoError(t, err)
 
-	r.standardUserClient, err = standard.CreateStandardUser(r.client)
+	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	assert.NoError(t, err)
 
 	return r

--- a/validation/provisioning/rke2/node_driver_test.go
+++ b/validation/provisioning/rke2/node_driver_test.go
@@ -53,7 +53,7 @@ func nodeDriverSetup(t *testing.T) nodeDriverTest {
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
 	assert.NoError(t, err)
 
-	r.standardUserClient, err = standard.CreateStandardUser(r.client)
+	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	assert.NoError(t, err)
 
 	return r

--- a/validation/provisioning/rke2/psact_test.go
+++ b/validation/provisioning/rke2/psact_test.go
@@ -57,7 +57,7 @@ func psactSetup(t *testing.T) psactTest {
 	r.cattleConfig, err = defaults.SetK8sDefault(client, defaults.RKE2, r.cattleConfig)
 	assert.NoError(t, err)
 
-	r.standardUserClient, err = standard.CreateStandardUser(r.client)
+	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	assert.NoError(t, err)
 
 	return r

--- a/validation/provisioning/rke2/template_test.go
+++ b/validation/provisioning/rke2/template_test.go
@@ -76,7 +76,7 @@ func templateSetup(t *testing.T) templateTest {
 	r.cloudCredentials, err = provider.CloudCredFunc(client, cloudCredentialConfig)
 	assert.NoError(t, err)
 
-	r.standardUserClient, err = standard.CreateStandardUser(r.client)
+	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	assert.NoError(t, err)
 
 	return r

--- a/validation/snapshot/rke1/snapshot_recurring_test.go
+++ b/validation/snapshot/rke1/snapshot_recurring_test.go
@@ -39,7 +39,7 @@ func (s *RKE1SnapshotRecurringTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	nodeRolesStandard := []provisioninginput.NodePools{

--- a/validation/snapshot/rke1/snapshot_restore_test.go
+++ b/validation/snapshot/rke1/snapshot_restore_test.go
@@ -44,7 +44,7 @@ func (s *RKE1SnapshotRestoreTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	nodeRolesStandard := []provisioninginput.NodePools{

--- a/validation/snapshot/rke1/snapshot_s3_restore_test.go
+++ b/validation/snapshot/rke1/snapshot_s3_restore_test.go
@@ -40,7 +40,7 @@ func (s *RKE1S3SnapshotRestoreTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	nodeRolesStandard := []provisioninginput.NodePools{

--- a/validation/snapshot/rke2k3s/snapshot_recurring_test.go
+++ b/validation/snapshot/rke2k3s/snapshot_recurring_test.go
@@ -49,7 +49,7 @@ func (s *SnapshotRecurringTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/snapshot/rke2k3s/snapshot_restore_test.go
+++ b/validation/snapshot/rke2k3s/snapshot_restore_test.go
@@ -54,7 +54,7 @@ func (s *SnapshotRestoreTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/snapshot/rke2k3s/snapshot_restore_wins_test.go
+++ b/validation/snapshot/rke2k3s/snapshot_restore_wins_test.go
@@ -48,7 +48,7 @@ func (s *SnapshotRestoreWindowsTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/snapshot/rke2k3s/snapshot_retention_test.go
+++ b/validation/snapshot/rke2k3s/snapshot_retention_test.go
@@ -56,7 +56,7 @@ func (s *SnapshotRetentionTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/snapshot/rke2k3s/snapshot_s3_restore_test.go
+++ b/validation/snapshot/rke2k3s/snapshot_s3_restore_test.go
@@ -50,7 +50,7 @@ func (s *S3SnapshotRestoreTestSuite) SetupSuite() {
 
 	s.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(s.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(s.client)
 	require.NoError(s.T(), err)
 
 	s.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/upgrade/rke1/cloud_provider_version_test.go
+++ b/validation/upgrade/rke1/cloud_provider_version_test.go
@@ -41,7 +41,7 @@ func (u *UpgradeCloudProviderSuite) SetupSuite() {
 
 	u.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(u.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(u.client)
 	require.NoError(u.T(), err)
 
 	nodeRolesStandard := []provisioninginput.NodePools{

--- a/validation/upgrade/rke1/kubernetes_test.go
+++ b/validation/upgrade/rke1/kubernetes_test.go
@@ -46,7 +46,7 @@ func (u *UpgradeRKE1KubernetesTestSuite) SetupSuite() {
 
 	u.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(u.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(u.client)
 	require.NoError(u.T(), err)
 
 	nodeRolesStandard := []provisioninginput.NodePools{

--- a/validation/upgrade/rke2k3s/cloud_provider_aws_migration_test.go
+++ b/validation/upgrade/rke2k3s/cloud_provider_aws_migration_test.go
@@ -49,7 +49,7 @@ func (u *MigrateCloudProviderSuite) SetupSuite() {
 
 	u.client = client
 
-	u.standardUserClient, err = standard.CreateStandardUser(u.client)
+	u.standardUserClient, _, _, err = standard.CreateStandardUser(u.client)
 	require.NoError(u.T(), err)
 
 	u.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/upgrade/rke2k3s/kubernetes_test.go
+++ b/validation/upgrade/rke2k3s/kubernetes_test.go
@@ -54,7 +54,7 @@ func (u *UpgradeKubernetesTestSuite) SetupSuite() {
 
 	u.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(u.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(u.client)
 	require.NoError(u.T(), err)
 
 	u.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))

--- a/validation/upgrade/rke2k3s/kubernetes_wins_test.go
+++ b/validation/upgrade/rke2k3s/kubernetes_wins_test.go
@@ -54,7 +54,7 @@ func (u *UpgradeWindowsKubernetesTestSuite) SetupSuite() {
 
 	u.client = client
 
-	standardUserClient, err := standard.CreateStandardUser(u.client)
+	standardUserClient, _, _, err := standard.CreateStandardUser(u.client)
 	require.NoError(u.T(), err)
 
 	u.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))


### PR DESCRIPTION
### Description
As part of upcoming `tfp-automation` changes that we have coming to better enhance our tests and how standard users are being used, we need to be sure that we are returning the test user and test password credentials.