### PR TITLE
Updated call to VerifyCluster in Restricted Admin Test

### DIFF
--- a/validation/rbac/globalroles/deprecated_restrictedadmin_role_test.go
+++ b/validation/rbac/globalroles/deprecated_restrictedadmin_role_test.go
@@ -103,7 +103,7 @@ func (ra *RestrictedAdminTestSuite) TestRestrictedAdminCreateK3sCluster() {
 	clusterObject, err := provisioning.CreateProvisioningCluster(restrictedAdminClient, provider, credentialSpec, ra.clusterConfig, machineConfigSpec, nil)
 	require.NoError(ra.T(), err)
 
-	provisioning.VerifyCluster(ra.T(), ra.client, ra.clusterConfig, clusterObject)
+	provisioning.VerifyCluster(ra.T(), ra.client, clusterObject)
 }
 
 func (ra *RestrictedAdminTestSuite) TestRestrictedAdminGlobalSettings() {


### PR DESCRIPTION
Removing clusterConfig argument in call to VerifyCluster since the function has been updated to not use it. 