### PR TITLE
Fix observedGenerationRemote value

### DIFF
--- a/validation/rbac/crtb/crtb.go
+++ b/validation/rbac/crtb/crtb.go
@@ -96,8 +96,8 @@ func verifyClusterRoleTemplateBindingStatusField(crtb *v3.ClusterRoleTemplateBin
 		}
 	}
 
-	if status.ObservedGenerationRemote != 2 {
-		return fmt.Errorf("observedGenerationRemote is not 2, found: %d", status.ObservedGenerationRemote)
+	if status.ObservedGenerationRemote != 1 {
+		return fmt.Errorf("observedGenerationRemote is not 1, found: %d", status.ObservedGenerationRemote)
 	}
 
 	if status.SummaryRemote != completedSummary {


### PR DESCRIPTION
This PR fixes the ObservedGenerationRemote value in the verifyClusterRoleTemplateBindingStatusField function to the correct expected value. 