### PR TITLE
Update grv2 test to use K3s instead of RKE1

### DIFF
--- a/validation/rbac/globalrolesv2/README.md
+++ b/validation/rbac/globalrolesv2/README.md
@@ -30,8 +30,6 @@ provisioningInput:
      controlplane: true
      worker: true
      quantity: 1
- rke1KubernetesVersion:
-   - "v1.28.10-rancher1-1"
  rke2KubernetesVersion:
    - "v1.28.10+rke2r1"
  k3sKubernetesVersion:

--- a/validation/rbac/globalrolesv2/globalroles_v2.go
+++ b/validation/rbac/globalrolesv2/globalroles_v2.go
@@ -95,20 +95,19 @@ func createDownstreamCluster(client *rancher.Client, clusterType string) (*manag
 	var err error
 
 	switch clusterType {
-	case "RKE1":
-		nodeAndRoles := []provisioninginput.NodePools{
-			provisioninginput.AllRolesNodePool,
+	case "K3S":
+		nodeAndRoles := []provisioninginput.MachinePools{
+			provisioninginput.AllRolesMachinePool,
 		}
-		testClusterConfig.NodePools = nodeAndRoles
-		testClusterConfig.KubernetesVersion = provisioningConfig.RKE1KubernetesVersions[0]
-		clusterObject, _, err = provisioning.CreateProvisioningRKE1CustomCluster(client, &externalNodeProvider, testClusterConfig, awsEC2Configs)
+		testClusterConfig.MachinePools = nodeAndRoles
+		testClusterConfig.KubernetesVersion = provisioningConfig.K3SKubernetesVersions[0]
+		steveObject, err = provisioning.CreateProvisioningCustomCluster(client, &externalNodeProvider, testClusterConfig, awsEC2Configs)
 	case "RKE2":
 		nodeAndRoles := []provisioninginput.MachinePools{
 			provisioninginput.AllRolesMachinePool,
 		}
 		testClusterConfig.MachinePools = nodeAndRoles
 		testClusterConfig.KubernetesVersion = provisioningConfig.RKE2KubernetesVersions[0]
-
 		steveObject, err = provisioning.CreateProvisioningCustomCluster(client, &externalNodeProvider, testClusterConfig, awsEC2Configs)
 	default:
 		return nil, nil, nil, fmt.Errorf("unsupported cluster type: %s", clusterType)

--- a/validation/rbac/globalrolesv2/globalroles_v2_test.go
+++ b/validation/rbac/globalrolesv2/globalroles_v2_test.go
@@ -168,13 +168,13 @@ func (gr *GlobalRolesV2TestSuite) TestClusterCreationAfterAddingGlobalRoleWithIn
 	actualClusterCount := len(clusterNames)
 	require.Equal(gr.T(), expectedClusterCount, actualClusterCount, "Unexpected number of Clusters: Expected %d, Actual %d", expectedClusterCount, actualClusterCount)
 
-	log.Info("As the new user, create new downstream clusters.")
-	clusterObject, _, testClusterConfig, err := createDownstreamCluster(userClient, "RKE1")
+	log.Info("As the new user, create two new downstream  K3S clusters.")
+	_, firstClusterSteveObject, _, err := createDownstreamCluster(userClient, "K3S")
 	require.NoError(gr.T(), err)
-	provisioning.VerifyRKE1Cluster(gr.T(), userClient, testClusterConfig, clusterObject)
-	_, steveObject, testClusterConfig, err := createDownstreamCluster(userClient, "RKE2")
+	provisioning.VerifyCluster(gr.T(), userClient, firstClusterSteveObject)
+	_, secondClusterSteveObject, _, err := createDownstreamCluster(userClient, "K3S")
 	require.NoError(gr.T(), err)
-	provisioning.VerifyCluster(gr.T(), userClient, steveObject)
+	provisioning.VerifyCluster(gr.T(), userClient, secondClusterSteveObject)
 
 	gr.validateRBACResources(createdUser, createdGlobalRole, inheritedClusterRoles)
 }


### PR DESCRIPTION
Updated the globalrolesv2 createDownstreamCluster function and globalrolesv2_test to provision K3s clusters instead of RKE1.