### PR TITLE
Remove RCs in get Qase ID custom action

### DIFF
--- a/.github/actions/get-qase-id/action.yaml
+++ b/.github/actions/get-qase-id/action.yaml
@@ -5,9 +5,6 @@ inputs:
   triggered_tag:
     description: "Rancher server tag version from triggered action"
     required: true
-  qase_rc_id:
-    description: "Qase ID for the RC test run"
-    required: false
   qase_recurring_id:
     description: "Qase ID for the recurring test run"
     required: true
@@ -26,11 +23,7 @@ runs:
         QASE_ID=""
 
         if [[ -n "$TRIGGERED_TAG" ]]; then
-          if [[ "$TRIGGERED_TAG" == *"-rc"* ]]; then
-            QASE_ID="${{ inputs.qase_rc_id }}"
-          else
             QASE_ID="${{ inputs.qase_recurring_id }}"
-          fi
         else
           QASE_ID="${{ inputs.qase_recurring_id }}"
         fi

--- a/.github/workflows/daily-cluster-provisioning.yml
+++ b/.github/workflows/daily-cluster-provisioning.yml
@@ -125,7 +125,6 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_13 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
 
       - name: Create config.yaml
@@ -411,7 +410,6 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_12 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_12 }}
 
       - name: Create config.yaml
@@ -704,7 +702,6 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_11 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_11 }}
 
       - name: Create config.yaml
@@ -997,7 +994,6 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_10 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_10 }}
 
       - name: Create config.yaml

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -133,7 +133,6 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_13 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
 
       - name: Create config.yaml
@@ -423,7 +422,6 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_12 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_12 }}
 
       - name: Create config.yaml
@@ -720,7 +718,6 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_11 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_11 }}
 
       - name: Create config.yaml
@@ -1017,7 +1014,6 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_rc_id: ${{ vars.HB_QASE_RC_TEST_RUN_ID_2_10 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_10 }}
 
       - name: Create config.yaml


### PR DESCRIPTION
### Description
Small PR to remove  `qase_rc_id` in the `get-qase-id` custom action. We only wish to run our sanity tests over in `rancher/tfp-automation` when RCs are cut. So we can update the custom action in this repo to reflect that.