### PR TITLE
Update Hostbusters GHA workflows to not run against RCs

### DIFF
--- a/.github/actions/run-hostbusters-daily-provisioning/action.yaml
+++ b/.github/actions/run-hostbusters-daily-provisioning/action.yaml
@@ -31,17 +31,21 @@ runs:
       continue-on-error: true
 
     - name: Show failed tests
-      if: steps.k3s.outcome == 'failure' || steps.rke2.outcome == 'failure'
       run: |
+        failed=0
         if [ "$k3s_exit" -ne 0 ]; then
           echo "Failed K3S tests:"
           jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' results.json
+          failed=1
         fi
 
         if [ "$rke2_exit" -ne 0 ]; then
           echo "Failed RKE2 tests:"
           jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' results.json
+          failed=1
         fi
 
-        exit 1
+        if [ "$failed" -eq 1 ]; then
+          exit 1
+        fi
       shell: bash

--- a/.github/actions/run-hostbusters-test-suites/action.yaml
+++ b/.github/actions/run-hostbusters-test-suites/action.yaml
@@ -111,7 +111,6 @@
        continue-on-error: true
 
      - name: Show failed tests
-       if: steps.run-tests.outcome == 'failure'
        run: |
          declare -A suites=(
            [cert_exit]="Cert Rotation"
@@ -136,9 +135,7 @@
              echo "Failed ${suites[$exit_code]} tests:"
              jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' results.json
              echo ""
+             exit 1
            fi
          done
-
-         echo "One or more test suites failed. Failing workflow."
-         exit 1
        shell: bash

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -324,7 +324,7 @@ jobs:
   v2-12:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && contains(inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
@@ -613,7 +613,7 @@ jobs:
   v2-11:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && contains(inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
@@ -909,7 +909,7 @@ jobs:
   v2-10:
     if: |
       github.event_name == 'schedule' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10')) ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.10')) && contains(inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.10.')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
The Hostbusters GHA workflows in this repo should not run against RCs or released versions. This PR addresses that and tries again to fix the reporting issue we have been seeing when tests fail.