### PR TITLE
Add daily Rancher upgrade cluster provisioning workflow

### DIFF
--- a/.github/workflows/daily-rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/daily-rancher-upgrade-cluster-provisioning.yml
@@ -1,0 +1,902 @@
+---
+name: Hostbusters Daily Upgraded Rancher Cluster Provisioning
+
+on:
+  schedule:
+    - cron: "0 10 * * 1-5"  
+  workflow_dispatch:
+    inputs:
+      rancher_version:
+        description: "Rancher tag version"
+      rancher_chart_version:
+        description: "Rancher chart version"
+  workflow_call:
+    inputs:
+      rancher_version:
+        description: "Rancher tag version provided from check-rancher-tag workflow"
+        required: true
+        type: string
+      rancher_chart_version:
+        description: "Rancher chart version provided from check-rancher-tag workflow"
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  CLOUD_PROVIDER_VERSION: "5.95.0"
+  HOSTNAME_PREFIX: "gha-prov"
+
+jobs:
+  head:
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
+    name: head
+    runs-on: ubuntu-latest
+    environment: latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Checkout tfp-automation repository
+        uses: actions/checkout@v4
+        with:
+          repository: rancher/tfp-automation
+          path: tfp-automation
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: "Fetch and Set DockerHub Credentials"
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Mask Dockerhub Credentials
+        run: |
+          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
+          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set upgraded Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_HEAD) 
+            }}
+
+      - name: Set upgraded Rancher chart version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_CHART_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_12)
+            }}
+
+      - name: Set upgraded Rancher repo
+        uses: ./.github/actions/set-rancher-repo
+        with:
+          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_recurring_id: "${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}"
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+            cleanup: true
+          terraform:
+            cni: "${{ secrets.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ secrets.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ secrets.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
+              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
+              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
+              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              certType: "${{ vars.CERT_TYPE }}"
+              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_12 }}"
+              osUser: "${{ secrets.OS_USER }}"
+              osGroup: "${{ secrets.OS_GROUP }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_12 }}"
+              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_12 }}"
+              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
+
+          clusterConfig:
+            cni: "${{ secrets.CNI }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            nodeProvider: "ec2"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            compliance: true
+            registries:
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ secrets.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ secrets.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ secrets.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+
+          awsEC2Configs:
+            region: "${{ secrets.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_AMI }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "hb-daily-provisioning"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
+                awsUser: "${{ secrets.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "hb-daily-provisioning-windows"
+                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["windows"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+
+          templateTest:
+            repo:
+              metadata:
+                name: "test"
+              spec:
+                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+                gitBranch: main
+                insecureSkipTLSVerify: true
+            templateProvider: "aws"
+            templateName: "cluster-template1"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/go-build.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/upgradeRancherServer.go
+
+      - name: Run Daily Provisioning tests
+        env:
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
+          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
+          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        uses: ./.github/actions/run-hostbusters-daily-provisioning
+
+      - name: Cleanup Infrastructure
+        if: always()
+        working-directory: tfp-automation/modules/sanity/aws
+        run: terraform destroy -auto-approve > /dev/null 2>&1
+
+      - name: Refresh AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+  v2-12:
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ github.event.inputs.rancher_version }}
+    runs-on: ubuntu-latest
+    environment: latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Checkout tfp-automation repository
+        uses: actions/checkout@v4
+        with:
+          repository: rancher/tfp-automation
+          path: tfp-automation
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: "Fetch and Set DockerHub Credentials"
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Mask Dockerhub Credentials
+        run: |
+          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
+          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set upgraded Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_12_HEAD) 
+            }}
+
+      - name: Set upgraded Rancher chart version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_CHART_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_12)
+            }}
+
+      - name: Set upgraded Rancher repo
+        uses: ./.github/actions/set-rancher-repo
+        with:
+          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_12 }}
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+            cleanup: true
+          terraform:
+            cni: "${{ secrets.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ secrets.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ secrets.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
+              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
+              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
+              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              certType: "${{ vars.CERT_TYPE }}"
+              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_12 }}"
+              osUser: "${{ secrets.OS_USER }}"
+              osGroup: "${{ secrets.OS_GROUP }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_12 }}"
+              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_12 }}"
+              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
+
+          clusterConfig:
+            cni: "${{ secrets.CNI }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            nodeProvider: "ec2"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            compliance: true
+            registries:
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ secrets.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ secrets.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ secrets.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+
+          awsEC2Configs:
+            region: "${{ secrets.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_AMI }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "hb-daily-provisioning"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
+                awsUser: "${{ secrets.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "hb-daily-provisioning-windows"
+                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["windows"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+
+          templateTest:
+            repo:
+              metadata:
+                name: "test"
+              spec:
+                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+                gitBranch: main
+                insecureSkipTLSVerify: true
+            templateProvider: "aws"
+            templateName: "cluster-template1"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/go-build.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/createRancherServer.go
+
+      - name: Run Daily Provisioning tests
+        env:
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
+          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
+          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        uses: ./.github/actions/run-hostbusters-daily-provisioning
+
+      - name: Cleanup Infrastructure
+        if: always()
+        working-directory: tfp-automation/modules/sanity/aws
+        run: terraform destroy -auto-approve > /dev/null 2>&1
+
+      - name: Refresh AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ secrets.AWS_REGION }}"
+
+  v2-11:
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11.')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ github.event.inputs.rancher_version }}
+    runs-on: ubuntu-latest
+    environment: staging
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Checkout tfp-automation repository
+        uses: actions/checkout@v4
+        with:
+          repository: rancher/tfp-automation
+          path: tfp-automation
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: "Fetch and Set DockerHub Credentials"
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Mask Dockerhub Credentials
+        run: |
+          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
+          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
+          region: "${{ secrets.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set upgraded Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_11_HEAD) 
+            }}
+
+      - name: Set upgraded Rancher chart version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_CHART_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_11)
+            }}
+
+      - name: Set upgraded Rancher repo
+        uses: ./.github/actions/set-rancher-repo
+        with:
+          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_11 }}
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+            cleanup: true
+          terraform:
+            cni: "${{ secrets.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ secrets.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ secrets.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
+              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
+              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
+              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              certType: "${{ vars.CERT_TYPE }}"
+              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_11 }}"
+              osUser: "${{ secrets.OS_USER }}"
+              osGroup: "${{ secrets.OS_GROUP }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_11 }}"
+              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
+              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
+
+          clusterConfig:
+            cni: "${{ secrets.CNI }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            nodeProvider: "ec2"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            registries:
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ secrets.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ secrets.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ secrets.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
+
+          awsEC2Configs:
+            region: "${{ secrets.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_AMI }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "hb-daily-provisioning"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
+                awsUser: "${{ secrets.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "hb-daily-provisioning-windows"
+                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["windows"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+
+          templateTest:
+            repo:
+              metadata:
+                name: "test"
+              spec:
+                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
+                gitBranch: main
+                insecureSkipTLSVerify: true
+            templateProvider: "aws"
+            templateName: "cluster-template1"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/go-build.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/createRancherServer.go
+
+      - name: Run Daily Provisioning tests
+        env:
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
+          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
+          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        uses: ./.github/actions/run-hostbusters-daily-provisioning
+
+      - name: Cleanup Infrastructure
+        if: always()
+        working-directory: tfp-automation/modules/sanity/aws
+        run: terraform destroy -auto-approve > /dev/null 2>&1
+
+      - name: Refresh AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
+          region: "${{ secrets.AWS_REGION }}"

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 )
 
 require (
+	github.com/gruntwork-io/terratest v0.49.0
 	github.com/mattn/go-sqlite3 v1.14.28
 	github.com/rancher/rancher v0.0.0-20250806201723-9a7af3779b9d
 	github.com/rancher/shepherd v0.0.0-20250930150356-0687c0e2375d
@@ -163,7 +164,6 @@ require (
 	github.com/containerd/cgroups/v3 v3.0.2 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
-	github.com/gruntwork-io/terratest v0.49.0 // indirect
 	github.com/harvester/harvester v1.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-getter/v2 v2.2.3 // indirect

--- a/validation/recurring/infrastructure/upgraderancher/upgradeRancherServer.go
+++ b/validation/recurring/infrastructure/upgraderancher/upgradeRancherServer.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/config"
+	shepherdConfig "github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	"github.com/rancher/shepherd/pkg/session"
+	infraConfig "github.com/rancher/tests/validation/recurring/infrastructure/config"
+	tfpConfig "github.com/rancher/tfp-automation/config"
+	"github.com/rancher/tfp-automation/defaults/keypath"
+	"github.com/rancher/tfp-automation/tests/infrastructure"
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	var client *rancher.Client
+	var err error
+
+	t := &testing.T{}
+
+	cattleConfig := shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
+	_, _, _, _ = tfpConfig.LoadTFPConfigs(cattleConfig)
+
+	switch {
+	default:
+		client, err = upgradeRancher(t)
+		if err != nil {
+			logrus.Fatalf("Failed to setup Rancher: %v", err)
+		}
+	}
+
+	_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, client.RancherConfig.AdminToken, cattleConfig)
+	if err != nil {
+		logrus.Fatalf("Failed to replace admin token: %v", err)
+	}
+
+	infraConfig.WriteConfigToFile(os.Getenv(config.ConfigEnvironmentKey), cattleConfig)
+}
+
+func upgradeRancher(t *testing.T) (*rancher.Client, error) {
+	testSession := session.NewSession()
+
+	client, serverNodeOne, _, _, cattleConfig := infrastructure.SetupRancher(t, testSession, keypath.SanityKeyPath)
+	client, _, _, _ = infrastructure.UpgradeRancher(t, client, serverNodeOne, testSession, cattleConfig)
+
+	return client, nil
+
+}


### PR DESCRIPTION
### Description
This PR adds a GHA workflow to test daily cluster provisioning after a Rancher upgrade. The workflow looks like this:
- Setup previously released version of Rancher
- Upgrade Rancher to latest `v2.x-head` commit
- Run cluster provisioning tests

`rancher/tfp-automation` currently handles keeping provisioning clusters pre-upgrade, upgrading Rancher and then provisioning new clusters. As such, that use-case is handled, so do not want to overload this workflow with that as there are much more clusters that get provisioned.