### PR TITLE
Update agent_customization_test.go

### DIFF
--- a/validation/provisioning/rke2/agent_customization_test.go
+++ b/validation/provisioning/rke2/agent_customization_test.go
@@ -220,11 +220,8 @@ func TestAgentCustomizationFailure(t *testing.T) {
 			machineConfigSpec := machinepools.LoadMachineConfigs(string(provider.Name))
 
 			logrus.Info("Provisioning cluster")
-			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
-
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			_, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
+			assert.Error(t, err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)


### PR DESCRIPTION
Update agent customization test to have the correct assertion and remove the verification of the cluster because they aren't supposed to come active.  