### PR TITLE
Update ACE test and skip invalid agent tests

### DIFF
--- a/validation/provisioning/k3s/README.md
+++ b/validation/provisioning/k3s/README.md
@@ -12,6 +12,22 @@
 ## Test Cases
 All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults)
 
+### ACE Test
+
+#### Description: 
+ACE(Authorized Cluster Endpoint) test verifies that a node driver cluster can be provisioned with ACE enabled
+
+#### Required Configurations: 
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `K3S_ACE`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestACE -timeout=1h -v`
+
 ### Custom Test
 
 #### Description: 

--- a/validation/provisioning/k3s/schemas/hostbusters_schemas.yaml
+++ b/validation/provisioning/k3s/schemas/hostbusters_schemas.yaml
@@ -462,6 +462,36 @@
 - projects:
   - RRT
   - RM
+  suite: Go Automation/Provisioning/K3S/ACE
+  cases:
+  - description: Provisions a 3etcd/2cp/2worker node driver cluster with ACE enabled
+    title: K3S_ACE
+    priority: 5
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Provision a k3s cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+- projects:
+  - RRT
+  - RM
   suite: Go Automation/Provisioning/K3S/DataDirectories
   cases:
   - description: Provisions a 3 node split roles cluster with custom data directories

--- a/validation/provisioning/rke2/README.md
+++ b/validation/provisioning/rke2/README.md
@@ -23,7 +23,7 @@ ACE(Authorized Cluster Endpoint) test verifies that a node driver cluster can be
 3. [Machine Config](#machine-config)
 
 #### Table Tests:
-1. `ACE|etcd|3_cp|worker`
+1. `RKE2_ACE`
 
 #### Run Commands:
 1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestACE -timeout=1h -v`

--- a/validation/provisioning/rke2/agent_customization_test.go
+++ b/validation/provisioning/rke2/agent_customization_test.go
@@ -161,6 +161,7 @@ func TestAgentCustomization(t *testing.T) {
 }
 
 func TestAgentCustomizationFailure(t *testing.T) {
+	t.Skip("Skipping test due to GH issue https://github.com/rancher/rancher/issues/52035")
 	t.Parallel()
 	r := agentCustomizationSetup(t)
 

--- a/validation/provisioning/rke2/schemas/hostbusters_schemas.yaml
+++ b/validation/provisioning/rke2/schemas/hostbusters_schemas.yaml
@@ -543,7 +543,7 @@
   suite: Go Automation/Provisioning/RKE2/ACE
   cases:
   - description: Provisions a 3etcd/2cp/2worker node driver cluster with ACE enabled
-    title: ACE|etcd|3_cp|worker
+    title: RKE2_ACE
     priority: 5
     type: 8
     is_flaky: 0


### PR DESCRIPTION
### Description
This PR serves a couple of purposes:
- Skips the invalid cluster/fleet agent customization test cases due to know GH issue
- Adds ACE test to K3s as only RKE2 had it
- Updates the ACE test to use 3 etcd, 2 cp, 3 worker cluster configuration