### PR TITLE
Update IPv6/dualstack GHA workflows

### DIFF
--- a/.github/workflows/daily-dualstack-cluster-provisioning.yml
+++ b/.github/workflows/daily-dualstack-cluster-provisioning.yml
@@ -217,6 +217,7 @@ jobs:
               ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"

--- a/.github/workflows/daily-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/daily-ipv6-cluster-provisioning.yml
@@ -217,11 +217,15 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              enablePrimaryIPv6: true
+              httpProtocolIpv6: "enabled"
+              ipv6AddressOnly: true
+              ipv6AddressCount: "1"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
               securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -226,6 +226,7 @@ jobs:
               ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -226,11 +226,15 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              enablePrimaryIPv6: true
+              httpProtocolIpv6: "enabled"
+              ipv6AddressOnly: true
+              ipv6AddressCount: "1"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
               securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]

--- a/validation/provisioning/dualstack/k3s_node_driver_test.go
+++ b/validation/provisioning/dualstack/k3s_node_driver_test.go
@@ -60,6 +60,7 @@ func nodeDriverK3SSetup(t *testing.T) nodeDriverK3STest {
 }
 
 func TestNodeDriverK3S(t *testing.T) {
+	t.Skip("This test is temporarily disabled. See https://github.com/rancher/rancher/issues/51844.")
 	t.Parallel()
 	r := nodeDriverK3SSetup(t)
 

--- a/validation/provisioning/dualstack/rke2_node_driver_test.go
+++ b/validation/provisioning/dualstack/rke2_node_driver_test.go
@@ -60,6 +60,7 @@ func nodeDriverRKE2Setup(t *testing.T) nodeDriverRKE2Test {
 }
 
 func TestNodeDriverRKE2(t *testing.T) {
+	t.Skip("This test is temporarily disabled. See https://github.com/rancher/rancher/issues/51844.")
 	t.Parallel()
 	r := nodeDriverRKE2Setup(t)
 


### PR DESCRIPTION
### Description
While we are waiting for node drivers to be testable in IPv6/dualstack, still preparing the configs to be good to go. Adding missed parameters that need to be present for that.

Additionally, dualstack did not temporarily skip the tests like IPv6 does; addressing that.