### PR TITLE
update project cdl tests to remove strict regex check

### DIFF
--- a/validation/projects/projects_container_default_resource_limit_test.go
+++ b/validation/projects/projects_container_default_resource_limit_test.go
@@ -4,7 +4,6 @@ package projects
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/rancher/shepherd/clients/rancher"
@@ -78,8 +77,8 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestCpuAndMemoryLimitLessTh
 
 	_, _, err := createProjectAndNamespaceWithLimits(standardUserClient, pcrl.cluster.ID, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.Error(pcrl.T(), err)
-	pattern := fmt.Sprintf(`admission webhook "rancher.cattle.io.projects.management.cattle.io" denied the request: project.spec.containerDefaultResourceLimit: Invalid value: v3.ContainerResourceLimit{RequestsCPU:"%s", RequestsMemory:"%s", LimitsCPU:"%s", LimitsMemory:"%s"}: requested CPU %s is greater than limit %s\nproject.spec.containerDefaultResourceLimit: Invalid value: v3.ContainerResourceLimit{RequestsCPU:"%s", RequestsMemory:"%s", LimitsCPU:"%s", LimitsMemory:"%s"}: requested memory %s is greater than limit %s`, cpuReservation, memoryReservation, cpuLimit, memoryLimit, cpuReservation, cpuLimit, cpuReservation, memoryReservation, cpuLimit, memoryLimit, memoryReservation, memoryLimit)
-	require.Regexp(pcrl.T(), regexp.MustCompile(pattern), err.Error())
+	require.Contains(pcrl.T(), err.Error(), fmt.Sprintf("requested CPU %s is greater than limit %s", cpuReservation, cpuLimit))
+	require.Contains(pcrl.T(), err.Error(), fmt.Sprintf("requested memory %s is greater than limit %s", memoryReservation, memoryLimit))
 }
 
 func (pcrl *ProjectsContainerResourceLimitTestSuite) TestCpuLimitLessThanRequest() {
@@ -96,8 +95,7 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestCpuLimitLessThanRequest
 
 	_, _, err := createProjectAndNamespaceWithLimits(standardUserClient, pcrl.cluster.ID, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.Error(pcrl.T(), err)
-	pattern := fmt.Sprintf(`admission webhook "rancher.cattle.io.projects.management.cattle.io" denied the request: project.spec.containerDefaultResourceLimit: Invalid value: v3.ContainerResourceLimit{RequestsCPU:"%s", RequestsMemory:"%s", LimitsCPU:"%s", LimitsMemory:"%s"}: requested CPU %s is greater than limit %s`, cpuReservation, memoryReservation, cpuLimit, memoryLimit, cpuReservation, cpuLimit)
-	require.Regexp(pcrl.T(), regexp.MustCompile(pattern), err.Error())
+	require.Contains(pcrl.T(), err.Error(), fmt.Sprintf("requested CPU %s is greater than limit %s", cpuReservation, cpuLimit))
 }
 
 func (pcrl *ProjectsContainerResourceLimitTestSuite) TestMemoryLimitLessThanRequest() {
@@ -114,8 +112,7 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestMemoryLimitLessThanRequ
 
 	_, _, err := createProjectAndNamespaceWithLimits(standardUserClient, pcrl.cluster.ID, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.Error(pcrl.T(), err)
-	pattern := fmt.Sprintf(`admission webhook "rancher.cattle.io.projects.management.cattle.io" denied the request: project.spec.containerDefaultResourceLimit: Invalid value: v3.ContainerResourceLimit{RequestsCPU:"%s", RequestsMemory:"%s", LimitsCPU:"%s", LimitsMemory:"%s"}: requested memory %s is greater than limit %s`, cpuReservation, memoryReservation, cpuLimit, memoryLimit, memoryReservation, memoryLimit)
-	require.Regexp(pcrl.T(), regexp.MustCompile(pattern), err.Error())
+	require.Contains(pcrl.T(), err.Error(), fmt.Sprintf("requested memory %s is greater than limit %s", memoryReservation, memoryLimit))
 }
 
 func (pcrl *ProjectsContainerResourceLimitTestSuite) TestValidCpuLimitButMemoryLimitLessThanRequest() {
@@ -132,8 +129,7 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestValidCpuLimitButMemoryL
 
 	_, _, err := createProjectAndNamespaceWithLimits(standardUserClient, pcrl.cluster.ID, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.Error(pcrl.T(), err)
-	pattern := fmt.Sprintf(`admission webhook "rancher.cattle.io.projects.management.cattle.io" denied the request: project.spec.containerDefaultResourceLimit: Invalid value: v3.ContainerResourceLimit{RequestsCPU:"%s", RequestsMemory:"%s", LimitsCPU:"%s", LimitsMemory:"%s"}: requested memory %s is greater than limit %s`, cpuReservation, memoryReservation, cpuLimit, memoryLimit, memoryReservation, memoryLimit)
-	require.Regexp(pcrl.T(), regexp.MustCompile(pattern), err.Error())
+	require.Contains(pcrl.T(), err.Error(), fmt.Sprintf("requested memory %s is greater than limit %s", memoryReservation, memoryLimit))
 }
 
 func (pcrl *ProjectsContainerResourceLimitTestSuite) TestCpuAndMemoryLimitEqualToRequest() {
@@ -247,8 +243,8 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestUpdateProjectWithCpuAnd
 	memoryReservation = "64Mi"
 	_, err = updateProjectContainerResourceLimit(standardUserClient, createdProject, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.Error(pcrl.T(), err)
-	pattern := fmt.Sprintf(`admission webhook "rancher.cattle.io.projects.management.cattle.io" denied the request: project.spec.containerDefaultResourceLimit: Invalid value: v3.ContainerResourceLimit{RequestsCPU:"%s", RequestsMemory:"%s", LimitsCPU:"%s", LimitsMemory:"%s"}: requested CPU %s is greater than limit %s\nproject.spec.containerDefaultResourceLimit: Invalid value: v3.ContainerResourceLimit{RequestsCPU:"%s", RequestsMemory:"%s", LimitsCPU:"%s", LimitsMemory:"%s"}: requested memory %s is greater than limit %s`, cpuReservation, memoryReservation, cpuLimit, memoryLimit, cpuReservation, cpuLimit, cpuReservation, memoryReservation, cpuLimit, memoryLimit, memoryReservation, memoryLimit)
-	require.Regexp(pcrl.T(), regexp.MustCompile(pattern), err.Error())
+	require.Contains(pcrl.T(), err.Error(), fmt.Sprintf("requested CPU %s is greater than limit %s", cpuReservation, cpuLimit))
+	require.Contains(pcrl.T(), err.Error(), fmt.Sprintf("requested memory %s is greater than limit %s", memoryReservation, memoryLimit))
 }
 
 func (pcrl *ProjectsContainerResourceLimitTestSuite) TestUpdateProjectWithCpuLimitLessThanRequest() {
@@ -284,8 +280,7 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestUpdateProjectWithCpuLim
 	memoryReservation = ""
 	_, err = updateProjectContainerResourceLimit(standardUserClient, createdProject, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.Error(pcrl.T(), err)
-	pattern := fmt.Sprintf(`admission webhook "rancher.cattle.io.projects.management.cattle.io" denied the request: project.spec.containerDefaultResourceLimit: Invalid value: v3.ContainerResourceLimit{RequestsCPU:"%s", RequestsMemory:"%s", LimitsCPU:"%s", LimitsMemory:"%s"}: requested CPU %s is greater than limit %s`, cpuReservation, memoryReservation, cpuLimit, memoryLimit, cpuReservation, cpuLimit)
-	require.Regexp(pcrl.T(), regexp.MustCompile(pattern), err.Error())
+	require.Contains(pcrl.T(), err.Error(), fmt.Sprintf("requested CPU %s is greater than limit %s", cpuReservation, cpuLimit))
 }
 
 func (pcrl *ProjectsContainerResourceLimitTestSuite) TestUpdateProjectWithMemoryLimitLessThanRequest() {
@@ -321,8 +316,7 @@ func (pcrl *ProjectsContainerResourceLimitTestSuite) TestUpdateProjectWithMemory
 	memoryReservation = "64Mi"
 	_, err = updateProjectContainerResourceLimit(standardUserClient, createdProject, cpuLimit, cpuReservation, memoryLimit, memoryReservation)
 	require.Error(pcrl.T(), err)
-	pattern := fmt.Sprintf(`admission webhook "rancher.cattle.io.projects.management.cattle.io" denied the request: project.spec.containerDefaultResourceLimit: Invalid value: v3.ContainerResourceLimit{RequestsCPU:"%s", RequestsMemory:"%s", LimitsCPU:"%s", LimitsMemory:"%s"}: requested memory %s is greater than limit %s`, cpuReservation, memoryReservation, cpuLimit, memoryLimit, memoryReservation, memoryLimit)
-	require.Regexp(pcrl.T(), regexp.MustCompile(pattern), err.Error())
+	require.Contains(pcrl.T(), err.Error(), fmt.Sprintf("requested memory %s is greater than limit %s", memoryReservation, memoryLimit))
 }
 
 func (pcrl *ProjectsContainerResourceLimitTestSuite) TestLimitDeletionPropagationToExistingNamespaces() {

--- a/validation/projects/projects_resource_quota_test.go
+++ b/validation/projects/projects_resource_quota_test.go
@@ -377,9 +377,11 @@ func (prq *ProjectsResourceQuotaTestSuite) TestOverrideQuotaInNamespace() {
 	require.NoError(prq.T(), err)
 
 	log.Info("Increase the number of replicas in the deployment from 2 to 3. Verify that the deployment is in Active state.")
-	replicas := int32(3)
-	currentDeployment, err := getAndConvertDeployment(standardUserClient, prq.cluster.ID, createdDeployment)
+	standardUserContext, err := clusterapi.GetClusterWranglerContext(standardUserClient, prq.cluster.ID)
 	require.NoError(prq.T(), err)
+	currentDeployment, err := standardUserContext.Apps.Deployment().Get(updatedNamespace.Name, createdDeployment.Name, metav1.GetOptions{})
+	require.NoError(prq.T(), err)
+	replicas := int32(3)
 	currentDeployment.Spec.Replicas = &replicas
 	_, err = deployment.UpdateDeployment(standardUserClient, prq.cluster.ID, updatedNamespace.Name, currentDeployment, true)
 	require.NoError(prq.T(), err)
@@ -464,9 +466,11 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceFromNoQuotaToQuotaPr
 	require.NoError(prq.T(), err)
 
 	log.Info("Verify that increasing the replicas to 3 in the deployment fails with exceeded quota error.")
-	replicas := int32(3)
-	currentDeployment, err := getAndConvertDeployment(standardUserClient, prq.cluster.ID, createdDeployment)
+	standardUserContext, err := clusterapi.GetClusterWranglerContext(standardUserClient, prq.cluster.ID)
 	require.NoError(prq.T(), err)
+	currentDeployment, err := standardUserContext.Apps.Deployment().Get(updatedNamespace.Name, createdDeployment.Name, metav1.GetOptions{})
+	require.NoError(prq.T(), err)
+	replicas := int32(3)
 	currentDeployment.Spec.Replicas = &replicas
 	updatedDeployment, err := deployment.UpdateDeployment(standardUserClient, prq.cluster.ID, updatedNamespace.Name, currentDeployment, false)
 	require.NoError(prq.T(), err)
@@ -545,9 +549,11 @@ func (prq *ProjectsResourceQuotaTestSuite) TestMoveNamespaceFromQuotaToNoQuotaPr
 	require.Error(prq.T(), err)
 
 	log.Info("Increase the replica count of deployment to 10. Verify that there are 10 pods created in the deployment and they are in Running state.")
-	replicas := int32(10)
-	currentDeployment, err := getAndConvertDeployment(standardUserClient, prq.cluster.ID, createdDeployment)
+	standardUserContext, err := clusterapi.GetClusterWranglerContext(standardUserClient, prq.cluster.ID)
 	require.NoError(prq.T(), err)
+	currentDeployment, err := standardUserContext.Apps.Deployment().Get(movedNamespace.Name, createdDeployment.Name, metav1.GetOptions{})
+	require.NoError(prq.T(), err)
+	replicas := int32(10)
 	currentDeployment.Spec.Replicas = &replicas
 	_, err = deployment.UpdateDeployment(standardUserClient, prq.cluster.ID, movedNamespace.Name, currentDeployment, true)
 	require.NoError(prq.T(), err)


### PR DESCRIPTION
The "Project Container Default Limit" tests previously used strict regex checks on error messages, which led to intermittent test failures due to minor variations in formatting.
This PR removes the regex-based validations and replaces them with require.Contains assertions to make the tests more resilient while still validating the presence of key error messages.