### PR TITLE
Remove unneeded Windows tests in dualstack nodescaling

### DIFF
--- a/validation/nodescaling/dualstack/scaling_node_driver_test.go
+++ b/validation/nodescaling/dualstack/scaling_node_driver_test.go
@@ -32,7 +32,6 @@ type NodeScalingDualstackTestSuite struct {
 	client                 *rancher.Client
 	session                *session.Session
 	cattleConfig           map[string]any
-	rke2ClusterConfig      *clusters.ClusterConfig
 	rke2IPv4ClusterID      string
 	rke2DualstackClusterID string
 	k3sIPv4ClusterID       string
@@ -141,11 +140,6 @@ func (s *NodeScalingDualstackTestSuite) TestScalingDualstackNodePools() {
 		Quantity: 1,
 	}
 
-	nodeRolesWindows := machinepools.NodeRoles{
-		Windows:  true,
-		Quantity: 1,
-	}
-
 	tests := []struct {
 		name      string
 		nodeRoles machinepools.NodeRoles
@@ -155,11 +149,9 @@ func (s *NodeScalingDualstackTestSuite) TestScalingDualstackNodePools() {
 		{"RKE2_IPv4_Node_Driver_Scale_Control_Plane", nodeRolesControlPlane, s.rke2IPv4ClusterID, false},
 		{"RKE2_IPv4_Node_Driver_Scale_ETCD", nodeRolesEtcd, s.rke2IPv4ClusterID, false},
 		{"RKE2_IPv4_Node_Driver_Scale_Worker", nodeRolesWorker, s.rke2IPv4ClusterID, false},
-		{"RKE2_IPv4_Node_Driver_Scale_Windows", nodeRolesWindows, s.rke2IPv4ClusterID, true},
 		{"RKE2_Dualstack_Node_Driver_Scale_Control_Plane", nodeRolesControlPlane, s.rke2DualstackClusterID, false},
 		{"RKE2_Dualstack_Node_Driver_Scale_ETCD", nodeRolesEtcd, s.rke2DualstackClusterID, false},
 		{"RKE2_Dualstack_Node_Driver_Scale_Worker", nodeRolesWorker, s.rke2DualstackClusterID, false},
-		{"RKE2_Dualstack_Node_Driver_Scale_Windows", nodeRolesWindows, s.rke2DualstackClusterID, true},
 		{"K3S_IPv4_Node_Driver_Scale_Control_Plane", nodeRolesControlPlane, s.k3sIPv4ClusterID, false},
 		{"K3S_IPv4_Node_Driver_Scale_ETCD", nodeRolesEtcd, s.k3sIPv4ClusterID, false},
 		{"K3S_IPv4_Node_Driver_Scale_Worker", nodeRolesWorker, s.k3sIPv4ClusterID, false},
@@ -173,10 +165,6 @@ func (s *NodeScalingDualstackTestSuite) TestScalingDualstackNodePools() {
 		require.NoError(s.T(), err)
 
 		s.Run(tt.name, func() {
-			if s.rke2ClusterConfig.Provider != "vsphere" && tt.isWindows {
-				s.T().Skip("Windows test requires access to vSphere")
-			}
-
 			nodescaling.ScalingRKE2K3SNodePools(s.T(), s.client, tt.clusterID, tt.nodeRoles)
 
 			logrus.Infof("Verifying cluster (%s)", cluster.Name)

--- a/validation/nodescaling/dualstack/schemas/hostbusters_schemas.yaml
+++ b/validation/nodescaling/dualstack/schemas/hostbusters_schemas.yaml
@@ -94,37 +94,6 @@
       "14": Validation
       "18": Hostbusters
 
-  - description: Scales up/down the Windows node pools of an existing cluster
-    title: RKE2_IPv4_Node_Driver_Scale_Windows
-    priority: 4
-    type: 8
-    is_flaky: 0
-    automation: 2
-    steps:
-    - action: Scale up the Windows node pools by 1
-      expectedresult: ""
-      data: ""
-      position: 1
-      attachments: []
-    - action: Verify cluster state
-      expectedresult: ""
-      data: ""
-      position: 2
-      attachments: []
-    - action: Scale down up the Windows node pools by 1
-      expectedresult: ""
-      data: ""
-      position: 3
-      attachments: []
-    - action: Verify cluster state
-      expectedresult: ""
-      data: ""
-      position: 4
-      attachments: []
-    custom_field:
-      "14": Validation
-      "18": Hostbusters
-
   - description: Scales up/down the control plane node pools of an existing cluster
     title: RKE2_Dualstack_Node_Driver_Scale_Control_Plane
     priority: 4
@@ -205,37 +174,6 @@
       position: 2
       attachments: []
     - action: Scale down up the worker node pools by 1
-      expectedresult: ""
-      data: ""
-      position: 3
-      attachments: []
-    - action: Verify cluster state
-      expectedresult: ""
-      data: ""
-      position: 4
-      attachments: []
-    custom_field:
-      "14": Validation
-      "18": Hostbusters
-
-  - description: Scales up/down the Windows node pools of an existing cluster
-    title: RKE2_Dualstack_Node_Driver_Scale_Windows
-    priority: 4
-    type: 8
-    is_flaky: 0
-    automation: 2
-    steps:
-    - action: Scale up the Windows node pools by 1
-      expectedresult: ""
-      data: ""
-      position: 1
-      attachments: []
-    - action: Verify cluster state
-      expectedresult: ""
-      data: ""
-      position: 2
-      attachments: []
-    - action: Scale down up the Windows node pools by 1
       expectedresult: ""
       data: ""
       position: 3


### PR DESCRIPTION
### Description
In running latest dualstack recurring tests, it was noted there still exists Windows test in the `nodescaling` package. This PR removes that and updates the schema to reflect this change.