### PR TITLE
Harden recurring runs

### DIFF
--- a/.github/workflows/daily-cluster-provisioning.yml
+++ b/.github/workflows/daily-cluster-provisioning.yml
@@ -227,11 +227,13 @@ jobs:
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
               securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"
@@ -517,11 +519,13 @@ jobs:
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
               securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"
@@ -814,11 +818,14 @@ jobs:
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
               securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
+
 
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -230,11 +230,13 @@ jobs:
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
               securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"
@@ -525,11 +527,13 @@ jobs:
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
               securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"
@@ -827,11 +831,13 @@ jobs:
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
               securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"

--- a/actions/certificates/certificates.go
+++ b/actions/certificates/certificates.go
@@ -1,0 +1,15 @@
+package certificates
+
+import (
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/shepherd/pkg/wait"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// CertRotationCompleteCheckFunc returns a watch check function that checks if the certificate rotation is complete
+func CertRotationCompleteCheckFunc(generation int64) wait.WatchCheckFunc {
+	return func(event watch.Event) (bool, error) {
+		controlPlane := event.Object.(*rkev1.RKEControlPlane)
+		return controlPlane.Status.CertificateRotationGeneration == generation, nil
+	}
+}

--- a/actions/provisioning/permutations/permutations.go
+++ b/actions/provisioning/permutations/permutations.go
@@ -19,6 +19,8 @@ import (
 	"github.com/rancher/tests/actions/reports"
 	"github.com/rancher/tests/actions/rke1/componentchecks"
 	"github.com/rancher/tests/actions/rke1/nodetemplates"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -84,7 +86,14 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						reports.TimeoutClusterReport(clusterObject, err)
 						require.NoError(s.T(), err)
 
-						provisioning.VerifyCluster(s.T(), client, clusterObject)
+						logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
+						provisioning.VerifyClusterReady(s.T(), client, clusterObject)
+
+						logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
+						pods.VerifyClusterPods(s.T(), client, clusterObject)
+
+						logrus.Infof("Verifying cluster features (%s)", clusterObject.Name)
+						provisioning.VerifyDynamicCluster(s.T(), client, clusterObject)
 
 					case RKE1ProvisionCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
@@ -112,7 +121,14 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						reports.TimeoutClusterReport(clusterObject, err)
 						require.NoError(s.T(), err)
 
-						provisioning.VerifyCluster(s.T(), client, clusterObject)
+						logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
+						provisioning.VerifyClusterReady(s.T(), client, clusterObject)
+
+						logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
+						pods.VerifyClusterPods(s.T(), client, clusterObject)
+
+						logrus.Infof("Verifying cluster features (%s)", clusterObject.Name)
+						provisioning.VerifyDynamicCluster(s.T(), client, clusterObject)
 
 					case RKE1CustomCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
@@ -141,7 +157,14 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						reports.TimeoutClusterReport(clusterObject, err)
 						require.NoError(s.T(), err)
 
-						provisioning.VerifyCluster(s.T(), client, clusterObject)
+						logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
+						provisioning.VerifyClusterReady(s.T(), client, clusterObject)
+
+						logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
+						pods.VerifyClusterPods(s.T(), client, clusterObject)
+
+						logrus.Infof("Verifying cluster features (%s)", clusterObject.Name)
+						provisioning.VerifyDynamicCluster(s.T(), client, clusterObject)
 
 					case RKE1AirgapCluster:
 						testClusterConfig.KubernetesVersion = kubeVersion
@@ -161,7 +184,7 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						s.T().Fatalf("Invalid cluster type: %s", clusterType)
 					}
 
-					cloudprovider.VerifyCloudProvider(s.T(), client, clusterType, nodeTemplate, testClusterConfig, clusterObject, rke1ClusterObject)
+					cloudprovider.VerifyCloudProvider(s.T(), client, clusterType, testClusterConfig, clusterObject, rke1ClusterObject)
 				})
 			}
 		}

--- a/actions/services/verify.go
+++ b/actions/services/verify.go
@@ -108,7 +108,7 @@ func VerifyHarvesterLoadBalancer(t *testing.T, client *rancher.Client, serviceLB
 
 	lbHostname := ""
 	err = kwait.PollUntilContextTimeout(context.TODO(), 5*time.Second, extdefault.OneMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
-		updateService, err := steveclient.SteveType("service").ByID(serviceLB.ID)
+		updateService, err := steveclient.SteveType(stevetypes.Service).ByID(serviceLB.ID)
 		if err != nil {
 			return false, nil
 		}

--- a/actions/workloads/pods/verify.go
+++ b/actions/workloads/pods/verify.go
@@ -1,17 +1,25 @@
 package pods
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
+	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	"github.com/rancher/shepherd/extensions/workloads/pods"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 // VerifyReadyDaemonsetPods tries to poll the Steve API to verify the expected number of daemonset pods are in the Ready
@@ -50,4 +58,50 @@ func VerifyReadyDaemonsetPods(t *testing.T, client *rancher.Client, cluster *v1.
 	}
 
 	assert.Truef(t, daemonsetequals, "Ready Daemonset Pods didn't match expected")
+}
+
+// VerifyClusterPods validates that all pods (excluding the helm pods) are in a good state.
+func VerifyClusterPods(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIObject) {
+	status := &provv1.ClusterStatus{}
+	err := steveV1.ConvertToK8sType(cluster.Status, status)
+	assert.NoError(t, err)
+
+	downstreamClient, err := client.Steve.ProxyDownstream(status.ClusterName)
+	assert.NoError(t, err)
+	assert.NotNil(t, downstreamClient)
+
+	var podErrors []error
+	steveClient := downstreamClient.SteveType(stevetypes.Pod)
+	err = kwait.PollUntilContextTimeout(context.TODO(), 5*time.Second, defaults.TenMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
+		podErrors = []error{}
+
+		clusterPods, err := steveClient.List(nil)
+		if err != nil {
+			return false, nil
+		}
+
+		for _, pod := range clusterPods.Data {
+			isReady, err := pods.IsPodReady(&pod)
+			if !isReady {
+				return false, nil
+			}
+
+			if err != nil {
+				if !strings.Contains(pod.Name, "helm") {
+					podErrors = append(podErrors, err)
+				} else {
+					logrus.Warningf("Helm pod: %s is not ready", pod.Name)
+				}
+			}
+		}
+		return true, nil
+	})
+
+	if len(podErrors) > 0 {
+		for _, err := range podErrors {
+			logrus.Error(err)
+		}
+	}
+
+	assert.Empty(t, podErrors, "Pod error list is not empty")
 }

--- a/validation/auth/kubeconfigs/kubeconfigs_test.go
+++ b/validation/auth/kubeconfigs/kubeconfigs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rancher/shepherd/extensions/users"
 	"github.com/rancher/shepherd/pkg/session"
 	kubeconfigapi "github.com/rancher/tests/actions/kubeconfigs"
+	"github.com/rancher/tests/actions/workloads/pods"
 
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/rbac"
@@ -71,17 +72,23 @@ func (kc *KubeconfigTestSuite) SetupSuite() {
 	cluster2ID, err := clusters.GetClusterIDByName(kc.client, clusterObject2.Name)
 	require.NoError(kc.T(), err)
 
-	provisioning.VerifyCluster(kc.T(), kc.client, aceClusterObject1)
+	provisioning.VerifyClusterReady(kc.T(), client, clusterObject2)
+	pods.VerifyClusterPods(kc.T(), client, clusterObject2)
+	provisioning.VerifyDynamicCluster(kc.T(), client, clusterObject2)
 	kc.aceCluster1, err = kc.client.Management.Cluster.ByID(aceCluster1ID)
 	require.NoError(kc.T(), err)
 	log.Infof("ACE-enabled cluster created: %s (%s)", kc.aceCluster1.Name, aceCluster1ID)
 
-	provisioning.VerifyCluster(kc.T(), kc.client, aceClusterObject2)
+	provisioning.VerifyClusterReady(kc.T(), client, clusterObject2)
+	pods.VerifyClusterPods(kc.T(), client, clusterObject2)
+	provisioning.VerifyDynamicCluster(kc.T(), client, clusterObject2)
 	kc.aceCluster2, err = kc.client.Management.Cluster.ByID(aceCluster2ID)
 	require.NoError(kc.T(), err)
 	log.Infof("ACE-enabled cluster created: %s (%s)", kc.aceCluster2.Name, aceCluster2ID)
 
-	provisioning.VerifyCluster(kc.T(), kc.client, clusterObject2)
+	provisioning.VerifyClusterReady(kc.T(), client, clusterObject2)
+	pods.VerifyClusterPods(kc.T(), client, clusterObject2)
+	provisioning.VerifyDynamicCluster(kc.T(), client, clusterObject2)
 	kc.cluster2, err = kc.client.Management.Cluster.ByID(cluster2ID)
 	require.NoError(kc.T(), err)
 	log.Infof("ACE-disabled cluster created: %s (%s)", kc.cluster2.Name, cluster2ID)

--- a/validation/certificates/cert_rotation.go
+++ b/validation/certificates/cert_rotation.go
@@ -21,7 +21,7 @@ import (
 	"github.com/rancher/shepherd/extensions/sshkeys"
 	"github.com/rancher/shepherd/pkg/nodes"
 	"github.com/rancher/shepherd/pkg/wait"
-	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/certificates"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -116,7 +116,7 @@ func RotateCerts(client *rancher.Client, clusterName string) error {
 		return err
 	}
 
-	checkFunc := provisioning.CertRotationCompleteCheckFunc(generation)
+	checkFunc := certificates.CertRotationCompleteCheckFunc(generation)
 	err = wait.WatchWait(result, checkFunc)
 	if err != nil {
 		return err

--- a/validation/certificates/dualstack/cert_rotation_test.go
+++ b/validation/certificates/dualstack/cert_rotation_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/certificates"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -142,8 +143,11 @@ func (c *CertRotationDualstackTestSuite) TestCertRotationDualstack() {
 			logrus.Infof("Rotating certificates on cluster (%s)", cluster.Name)
 			require.NoError(c.T(), certificates.RotateCerts(c.client, cluster.Name))
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(c.T(), c.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(c.T(), c.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(c.T(), c.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(c.client, c.cattleConfig)

--- a/validation/certificates/rke2k3s/cert_rotation_test.go
+++ b/validation/certificates/rke2k3s/cert_rotation_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/certificates"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -109,8 +110,11 @@ func (c *CertRotationTestSuite) TestCertRotation() {
 			logrus.Infof("Rotating certificates on cluster (%s)", cluster.Name)
 			require.NoError(c.T(), certificates.RotateCerts(c.client, cluster.Name))
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(c.T(), c.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(c.T(), c.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(c.T(), c.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(c.client, c.cattleConfig)

--- a/validation/certificates/rke2k3s/cert_rotation_wins_test.go
+++ b/validation/certificates/rke2k3s/cert_rotation_wins_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/certificates"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -105,8 +106,11 @@ func (c *CertRotationWindowsTestSuite) TestCertRotationWindows() {
 			logrus.Infof("Rotating certificates on cluster (%s)", cluster.Name)
 			require.NoError(c.T(), certificates.RotateCerts(c.client, cluster.Name))
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(c.T(), c.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(c.T(), c.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(c.T(), c.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(c.client, c.cattleConfig)

--- a/validation/charts/backup_restore/backup_restore.go
+++ b/validation/charts/backup_restore/backup_restore.go
@@ -14,6 +14,7 @@ import (
 	actionscharts "github.com/rancher/tests/actions/charts"
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/secrets"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/interoperability/charts"
 
 	shepClusters "github.com/rancher/shepherd/extensions/clusters"
@@ -314,7 +315,14 @@ func createRKE2dsCluster(t *testing.T, client *rancher.Client) (*v1.SteveAPIObje
 		return nil, nil, err
 	}
 
-	provisioning.VerifyCluster(t, client, steveObject)
+	logrus.Infof("Verifying the cluster is ready (%s)", steveObject.Name)
+	provisioning.VerifyClusterReady(t, client, steveObject)
+
+	logrus.Infof("Verifying cluster pods (%s)", steveObject.Name)
+	pods.VerifyClusterPods(t, client, steveObject)
+
+	logrus.Infof("Verifying cluster features (%s)", steveObject.Name)
+	provisioning.VerifyDynamicCluster(t, client, steveObject)
 
 	return steveObject, testClusterConfig, nil
 }

--- a/validation/charts/backup_restore/backup_restore_test.go
+++ b/validation/charts/backup_restore/backup_restore_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/interoperability/charts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -113,7 +114,15 @@ func (b *BackupTestSuite) TestS3InPlaceRestore() {
 
 	logrus.Info("Validating downstream clusters are in an Active status...")
 	provisioning.VerifyRKE1Cluster(b.T(), b.client, rke1ClusterConfig, rke1ClusterObj)
-	provisioning.VerifyCluster(b.T(), b.client, rke2SteveObj)
+
+	logrus.Infof("Verifying the cluster is ready (%s)", rke2SteveObj.Name)
+	provisioning.VerifyClusterReady(b.T(), b.client, rke2SteveObj)
+
+	logrus.Infof("Verifying cluster pods (%s)", rke2SteveObj.Name)
+	pods.VerifyClusterPods(b.T(), b.client, rke2SteveObj)
+
+	logrus.Infof("Verifying cluster pods (%s)", rke2SteveObj.Name)
+	provisioning.VerifyDynamicCluster(b.T(), b.client, rke2SteveObj)
 }
 
 func TestBackupTestSuite(t *testing.T) {

--- a/validation/deleting/rke2k3s/delete_init_machine_test.go
+++ b/validation/deleting/rke2k3s/delete_init_machine_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -108,8 +109,11 @@ func (d *DeleteInitMachineTestSuite) TestDeleteInitMachine() {
 			err := deleteInitMachine(d.client, tt.clusterID)
 			require.NoError(d.T(), err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(d.T(), d.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(d.T(), d.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(d.T(), d.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(d.client, d.cattleConfig)

--- a/validation/fleet/provisioning/airgap/fleet_in_airgap_test.go
+++ b/validation/fleet/provisioning/airgap/fleet_in_airgap_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning/permutations"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/reports"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/interoperability/fleet"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -176,7 +177,14 @@ func (a *AirGapRKE2CustomClusterTestSuite) TestCustomClusterWithGitRepo() {
 		reports.TimeoutClusterReport(clusterObject, err)
 		require.NoError(a.T(), err)
 
-		provisioning.VerifyCluster(a.T(), a.standardClient, clusterObject)
+		logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
+		provisioning.VerifyClusterReady(a.T(), a.standardClient, clusterObject)
+
+		logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
+		pods.VerifyClusterPods(a.T(), a.standardClient, clusterObject)
+
+		logrus.Infof("Verifying cluster features (%s)", clusterObject.Name)
+		provisioning.VerifyDynamicCluster(a.T(), a.standardClient, clusterObject)
 
 		status := &apisV1.ClusterStatus{}
 		err = steveV1.ConvertToK8sType(clusterObject.Status, status)

--- a/validation/fleet/provisioning/new_cluster_existing_gitrepo_test.go
+++ b/validation/fleet/provisioning/new_cluster_existing_gitrepo_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning/permutations"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/reports"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/interoperability/fleet"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -181,7 +182,14 @@ func (f *FleetWithProvisioningTestSuite) TestHardenedAfterAddedGitRepo() {
 			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(f.T(), err)
 
-			provisioning.VerifyCluster(f.T(), tt.client, clusterObject)
+			logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
+			provisioning.VerifyClusterReady(f.T(), tt.client, clusterObject)
+
+			logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
+			pods.VerifyClusterPods(f.T(), tt.client, clusterObject)
+
+			logrus.Infof("Verifying cluster features (%s)", clusterObject.Name)
+			provisioning.VerifyDynamicCluster(f.T(), tt.client, clusterObject)
 
 			status := &provv1.ClusterStatus{}
 			err = steveV1.ConvertToK8sType(clusterObject.Status, status)
@@ -268,7 +276,14 @@ func (f *FleetWithProvisioningTestSuite) TestWindowsAfterAddedGitRepo() {
 			reports.TimeoutClusterReport(clusterObject, err)
 			require.NoError(f.T(), err)
 
-			provisioning.VerifyCluster(f.T(), tt.client, clusterObject)
+			logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
+			provisioning.VerifyClusterReady(f.T(), tt.client, clusterObject)
+
+			logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
+			pods.VerifyClusterPods(f.T(), tt.client, clusterObject)
+
+			logrus.Infof("Verifying cluster features (%s)", clusterObject.Name)
+			provisioning.VerifyDynamicCluster(f.T(), tt.client, clusterObject)
 
 			status := &provv1.ClusterStatus{}
 			err = steveV1.ConvertToK8sType(clusterObject.Status, status)

--- a/validation/nodescaling/dualstack/scaling_node_driver_test.go
+++ b/validation/nodescaling/dualstack/scaling_node_driver_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/nodescaling"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -167,8 +168,11 @@ func (s *NodeScalingDualstackTestSuite) TestScalingDualstackNodePools() {
 		s.Run(tt.name, func() {
 			nodescaling.ScalingRKE2K3SNodePools(s.T(), s.client, tt.clusterID, tt.nodeRoles)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(s.T(), s.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(s.T(), s.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(s.client, s.cattleConfig)

--- a/validation/nodescaling/ipv6/scaling_custom_cluster_test.go
+++ b/validation/nodescaling/ipv6/scaling_custom_cluster_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/scalinginput"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/nodescaling"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -142,8 +143,11 @@ func (s *CustomIPv6ClusterNodeScalingTestSuite) TestScalingCustomIPv6ClusterNode
 			operations.LoadObjectFromMap(ec2.ConfigurationFileKey, s.cattleConfig, awsEC2Configs)
 			nodescaling.ScalingRKE2K3SCustomClusterPools(s.T(), s.client, tt.clusterID, s.scalingConfig.NodeProvider, tt.nodeRoles, awsEC2Configs, tt.clusterConfig)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(s.T(), s.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(s.T(), s.client, cluster)
 		})
 
 		params := provisioning.GetCustomSchemaParams(s.client, s.cattleConfig)

--- a/validation/nodescaling/rke2k3s/auto_replace_test.go
+++ b/validation/nodescaling/rke2k3s/auto_replace_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/scalinginput"
+	"github.com/rancher/tests/actions/workloads/pods"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -108,8 +109,11 @@ func (s *AutoReplaceSuite) TestAutoReplace() {
 			err := scalinginput.AutoReplaceFirstNodeWithRole(s.client, cluster.Name, tt.role)
 			require.NoError(s.T(), err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(s.T(), s.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(s.T(), s.client, cluster)
 		})
 	}
 }

--- a/validation/nodescaling/rke2k3s/scale_replace_test.go
+++ b/validation/nodescaling/rke2k3s/scale_replace_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/scalinginput"
+	"github.com/rancher/tests/actions/workloads/pods"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -130,8 +131,11 @@ func (s *NodeReplacingTestSuite) TestReplacingNodes() {
 			err := scalinginput.ReplaceNodes(s.client, cluster.Name, tt.nodeRoles.Etcd, tt.nodeRoles.ControlPlane, tt.nodeRoles.Worker)
 			require.NoError(s.T(), err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(s.T(), s.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(s.T(), s.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(s.client, s.cattleConfig)

--- a/validation/nodescaling/rke2k3s/scaling_custom_cluster_test.go
+++ b/validation/nodescaling/rke2k3s/scaling_custom_cluster_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/scalinginput"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/nodescaling"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -152,8 +153,11 @@ func (s *CustomClusterNodeScalingTestSuite) TestScalingCustomClusterNodes() {
 			operations.LoadObjectFromMap(ec2.ConfigurationFileKey, s.cattleConfig, awsEC2Configs)
 			nodescaling.ScalingRKE2K3SCustomClusterPools(s.T(), s.client, tt.clusterID, s.scalingConfig.NodeProvider, tt.nodeRoles, awsEC2Configs, tt.clusterConfig)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(s.T(), s.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(s.T(), s.client, cluster)
 		})
 
 		params := provisioning.GetCustomSchemaParams(s.client, s.cattleConfig)

--- a/validation/nodescaling/rke2k3s/scaling_node_driver_test.go
+++ b/validation/nodescaling/rke2k3s/scaling_node_driver_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/scalinginput"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/nodescaling"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -145,8 +146,11 @@ func (s *NodeScalingTestSuite) TestScalingNodePools() {
 
 			nodescaling.ScalingRKE2K3SNodePools(s.T(), s.client, tt.clusterID, tt.nodeRoles)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(s.T(), s.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(s.T(), s.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(s.client, s.cattleConfig)

--- a/validation/provisioning/dualstack/k3s_custom_test.go
+++ b/validation/provisioning/dualstack/k3s_custom_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -126,8 +127,11 @@ func TestCustomK3SDualstack(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
 		})
 
 		params := provisioning.GetCustomSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/dualstack/k3s_node_driver_test.go
+++ b/validation/provisioning/dualstack/k3s_node_driver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -134,8 +135,11 @@ func TestNodeDriverK3S(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/dualstack/rke2_custom_test.go
+++ b/validation/provisioning/dualstack/rke2_custom_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -125,8 +126,11 @@ func TestCustomRKE2Dualstack(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
 		})
 
 		params := provisioning.GetCustomSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/dualstack/rke2_node_driver_test.go
+++ b/validation/provisioning/dualstack/rke2_node_driver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -132,8 +133,11 @@ func TestNodeDriverRKE2(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/ipv6/k3s_custom_test.go
+++ b/validation/provisioning/ipv6/k3s_custom_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -132,8 +133,11 @@ func TestCustomK3SIPv6(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
 		})
 
 		params := provisioning.GetCustomSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/ipv6/k3s_node_driver_test.go
+++ b/validation/provisioning/ipv6/k3s_node_driver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -119,8 +120,11 @@ func TestNodeDriverK3SIPv6(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/ipv6/rke2_custom_test.go
+++ b/validation/provisioning/ipv6/rke2_custom_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -131,8 +132,11 @@ func TestCustomRKE2IPv6(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
 		})
 
 		params := provisioning.GetCustomSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/ipv6/rke2_node_driver_test.go
+++ b/validation/provisioning/ipv6/rke2_node_driver_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -117,8 +118,11 @@ func TestNodeDriverRKE2IPv6(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/k3s/ace_test.go
+++ b/validation/provisioning/k3s/ace_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -110,8 +111,11 @@ func TestACE(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			require.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, k.cattleConfig)

--- a/validation/provisioning/k3s/custom_test.go
+++ b/validation/provisioning/k3s/custom_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -105,8 +106,11 @@ func TestCustom(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
 		})
 
 		params := provisioning.GetCustomSchemaParams(tt.client, k.cattleConfig)

--- a/validation/provisioning/k3s/data_directories_test.go
+++ b/validation/provisioning/k3s/data_directories_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -110,10 +111,13 @@ func TestDataDirectories(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
 
-			logrus.Infof("Verifying cluster (%s) data directories", cluster.Name)
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster data directories (%s)", cluster.Name)
 			provisioning.VerifyDataDirectories(t, k.client, clusterConfig, machineConfigSpec, cluster)
 		})
 

--- a/validation/provisioning/k3s/dynamic_custom_test.go
+++ b/validation/provisioning/k3s/dynamic_custom_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/reports"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -104,11 +105,17 @@ func TestDynamicCustom(t *testing.T) {
 				reports.TimeoutClusterReport(cluster, err)
 				require.NoError(t, err)
 
-				logrus.Infof("Verifying cluster (%s)", cluster.Name)
-				provisioning.VerifyCluster(t, tt.client, cluster)
+				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+				provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+				logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+				pods.VerifyClusterPods(t, tt.client, cluster)
 
 				logrus.Infof("Verifying cloud provider %s", cluster.Name)
-				cloudprovider.VerifyCloudProvider(t, tt.client, "k3s", nil, clusterConfig, cluster, nil)
+				cloudprovider.VerifyCloudProvider(t, tt.client, defaults.K3S, clusterConfig, cluster, nil)
+
+				logrus.Infof("Verifying cluster features (%s)", cluster.Name)
+				provisioning.VerifyDynamicCluster(t, tt.client, cluster)
 			}
 		})
 	}

--- a/validation/provisioning/k3s/dynamic_node_driver_test.go
+++ b/validation/provisioning/k3s/dynamic_node_driver_test.go
@@ -12,12 +12,14 @@ import (
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/config/operations/permutations"
 	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/cloudprovider"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/config/permutationdata"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -99,8 +101,17 @@ func TestDynamicNodeDriver(t *testing.T) {
 				cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 				assert.NoError(t, err)
 
-				logrus.Infof("Verifying cluster (%s)", cluster.Name)
-				provisioning.VerifyCluster(t, tt.client, cluster)
+				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+				provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+				logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+				pods.VerifyClusterPods(t, tt.client, cluster)
+
+				logrus.Infof("Verifying cloud provider %s", cluster.Name)
+				cloudprovider.VerifyCloudProvider(t, tt.client, defaults.K3S, clusterConfig, cluster, nil)
+
+				logrus.Infof("Verifying cluster features (%s)", cluster.Name)
+				provisioning.VerifyDynamicCluster(t, tt.client, cluster)
 			}
 		})
 	}

--- a/validation/provisioning/k3s/hardened_test.go
+++ b/validation/provisioning/k3s/hardened_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/reports"
+	"github.com/rancher/tests/actions/workloads/pods"
 	cis "github.com/rancher/tests/validation/provisioning/resources/cisbenchmark"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -111,8 +112,11 @@ func TestHardened(t *testing.T) {
 			reports.TimeoutClusterReport(cluster, err)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
 
 			chartName := charts.CISBenchmarkName
 			chartNamespace := charts.CISBenchmarkNamespace

--- a/validation/provisioning/k3s/hostname_truncation_test.go
+++ b/validation/provisioning/k3s/hostname_truncation_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -110,10 +111,13 @@ func TestHostnameTruncation(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, hostnamePools)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
 
-			logrus.Infof("Verifying hostname truncation on %s", cluster.Name)
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
+
+			logrus.Infof("Verifying hostname truncation (%s)", cluster.Name)
 			provisioning.VerifyHostnameLength(t, k.client, cluster)
 		})
 

--- a/validation/provisioning/k3s/node_driver_test.go
+++ b/validation/provisioning/k3s/node_driver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -106,8 +107,11 @@ func TestNodeDriver(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, k.cattleConfig)

--- a/validation/provisioning/k3s/psact_test.go
+++ b/validation/provisioning/k3s/psact_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -104,8 +105,11 @@ func TestPSACT(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, tt.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, k.cattleConfig)

--- a/validation/provisioning/k3s/template_test.go
+++ b/validation/provisioning/k3s/template_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -116,8 +117,11 @@ func TestTemplate(t *testing.T) {
 			_, cluster, err := clusters.GetProvisioningClusterByName(k.client, clusterName, namespaces.FleetDefault)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, k.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, k.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, k.client, cluster)
 		})
 	}
 }

--- a/validation/provisioning/registries/registry_test.go
+++ b/validation/provisioning/registries/registry_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/registries"
 	"github.com/rancher/tests/actions/reports"
+	actionspods "github.com/rancher/tests/actions/workloads/pods"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -346,7 +347,11 @@ func (rt *RegistryTestSuite) TestRegistriesK3S() {
 				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(rt.T(), err)
 
-				provisioning.VerifyCluster(rt.T(), subClient, clusterObject)
+				logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
+				provisioning.VerifyClusterReady(rt.T(), subClient, clusterObject)
+
+				logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
+				actionspods.VerifyClusterPods(rt.T(), subClient, clusterObject)
 			})
 		}
 	}
@@ -369,7 +374,11 @@ func (rt *RegistryTestSuite) TestRegistriesK3S() {
 				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(rt.T(), err)
 
-				provisioning.VerifyCluster(rt.T(), subClient, clusterObject)
+				logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
+				provisioning.VerifyClusterReady(rt.T(), subClient, clusterObject)
+
+				logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
+				actionspods.VerifyClusterPods(rt.T(), subClient, clusterObject)
 			})
 		}
 	}
@@ -418,7 +427,11 @@ func (rt *RegistryTestSuite) TestRegistriesRKE2() {
 				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(rt.T(), err)
 
-				provisioning.VerifyCluster(rt.T(), subClient, clusterObject)
+				logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
+				provisioning.VerifyClusterReady(rt.T(), subClient, clusterObject)
+
+				logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
+				actionspods.VerifyClusterPods(rt.T(), subClient, clusterObject)
 			})
 		}
 	}
@@ -439,7 +452,11 @@ func (rt *RegistryTestSuite) TestRegistriesRKE2() {
 				reports.TimeoutClusterReport(clusterObject, err)
 				require.NoError(rt.T(), err)
 
-				provisioning.VerifyCluster(rt.T(), subClient, clusterObject)
+				logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
+				provisioning.VerifyClusterReady(rt.T(), subClient, clusterObject)
+
+				logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
+				actionspods.VerifyClusterPods(rt.T(), subClient, clusterObject)
 			})
 		}
 	}

--- a/validation/provisioning/resources/provisioncluster/provision_cluster.go
+++ b/validation/provisioning/resources/provisioncluster/provision_cluster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,7 +47,8 @@ func ProvisionRKE2K3SCluster(t *testing.T, client *rancher.Client, clusterType s
 		clusterObject, err = provisioning.CreateProvisioningCustomCluster(client, &externalNodeProvider, clusterConfig, ec2Configs)
 		require.NoError(t, err)
 
-		provisioning.VerifyCluster(t, client, clusterObject)
+		provisioning.VerifyClusterReady(t, client, clusterObject)
+		pods.VerifyClusterPods(t, client, clusterObject)
 	} else {
 		provider := provisioning.CreateProvider(clusterConfig.Provider)
 		credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
@@ -55,7 +57,8 @@ func ProvisionRKE2K3SCluster(t *testing.T, client *rancher.Client, clusterType s
 		clusterObject, err = provisioning.CreateProvisioningCluster(client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 		require.NoError(t, err)
 
-		provisioning.VerifyCluster(t, client, clusterObject)
+		provisioning.VerifyClusterReady(t, client, clusterObject)
+		pods.VerifyClusterPods(t, client, clusterObject)
 	}
 
 	return clusterObject.ID, nil

--- a/validation/provisioning/rke2/ace_test.go
+++ b/validation/provisioning/rke2/ace_test.go
@@ -1,4 +1,4 @@
-//go:build validation || recurring
+//go:build validation
 
 package rke2
 
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -110,8 +111,14 @@ func TestACE(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			require.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, r.client, cluster)
+
+			logrus.Infof("Verifying ACE (%s)", cluster.Name)
+			provisioning.VerifyACE(t, r.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/rke2/agent_customization_test.go
+++ b/validation/provisioning/rke2/agent_customization_test.go
@@ -1,4 +1,4 @@
-//go:build validation || recurring
+//go:build validation
 
 package rke2
 
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -148,8 +149,11 @@ func TestAgentCustomization(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, r.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/rke2/cloud_provider_test.go
+++ b/validation/provisioning/rke2/cloud_provider_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
-	"github.com/rancher/tests/actions/cloudprovider"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/logging"
@@ -20,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -95,7 +95,7 @@ func TestAWSCloudProvider(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			clusterConfig.Provider = providers.AWS
+			clusterConfig.CloudProvider = providers.AWS
 			clusterConfig.MachinePools = tt.machinePools
 
 			provider := provisioning.CreateProvider(clusterConfig.Provider)
@@ -106,11 +106,14 @@ func TestAWSCloudProvider(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, r.client, cluster)
 
-			logrus.Infof("Verifying cloud provider on cluster (%s)", cluster.Name)
-			cloudprovider.VerifyCloudProvider(t, tt.client, defaults.RKE2, nil, clusterConfig, cluster, nil)
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, r.client, cluster)
+
+			logrus.Infof("Verifying cloud provider (%s)", cluster.Name)
+			provider.VerifyCloudProviderFunc(t, r.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)
@@ -164,11 +167,14 @@ func TestVSphereCloudProvider(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, r.client, cluster)
 
-			logrus.Infof("Verifying cloud provider %s", cluster.Name)
-			cloudprovider.VerifyCloudProvider(t, tt.client, "rke2", nil, clusterConfig, cluster, nil)
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, r.client, cluster)
+
+			logrus.Infof("Verifying cloud provider (%s)", cluster.Name)
+			provider.VerifyCloudProviderFunc(t, r.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/rke2/custom_test.go
+++ b/validation/provisioning/rke2/custom_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -113,8 +114,11 @@ func TestCustom(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, r.client, cluster)
 		})
 
 		params := provisioning.GetCustomSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/rke2/data_directories_test.go
+++ b/validation/provisioning/rke2/data_directories_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -110,10 +111,13 @@ func TestDataDirectories(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, r.client, cluster)
 
-			logrus.Infof("Verifying cluster (%s) data directories", cluster.Name)
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster data directories (%s)", cluster.Name)
 			provisioning.VerifyDataDirectories(t, r.client, clusterConfig, machineConfigSpec, cluster)
 		})
 

--- a/validation/provisioning/rke2/dynamic_custom_test.go
+++ b/validation/provisioning/rke2/dynamic_custom_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/reports"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -108,11 +109,17 @@ func TestDynamicCustom(t *testing.T) {
 				reports.TimeoutClusterReport(cluster, err)
 				require.NoError(t, err)
 
-				logrus.Infof("Verifying cluster (%s)", cluster.Name)
-				provisioning.VerifyCluster(t, tt.client, cluster)
+				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+				provisioning.VerifyClusterReady(t, r.client, cluster)
+
+				logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+				pods.VerifyClusterPods(t, r.client, cluster)
 
 				logrus.Infof("Verifying cloud provider on cluster (%s)", cluster.Name)
-				cloudprovider.VerifyCloudProvider(t, tt.client, defaults.RKE2, nil, clusterConfig, cluster, nil)
+				cloudprovider.VerifyCloudProvider(t, tt.client, defaults.RKE2, clusterConfig, cluster, nil)
+
+				logrus.Infof("Verifying cluster features (%s)", cluster.Name)
+				provisioning.VerifyDynamicCluster(t, r.client, cluster)
 			}
 		})
 	}

--- a/validation/provisioning/rke2/dynamic_node_driver_test.go
+++ b/validation/provisioning/rke2/dynamic_node_driver_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/config/operations/permutations"
 	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/cloudprovider"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/config/permutationdata"
@@ -19,6 +20,7 @@ import (
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -103,8 +105,17 @@ func TestDynamicNodeDriver(t *testing.T) {
 				cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 				assert.NoError(t, err)
 
-				logrus.Infof("Verifying cluster (%s)", cluster.Name)
-				provisioning.VerifyCluster(t, tt.client, cluster)
+				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+				provisioning.VerifyClusterReady(t, r.client, cluster)
+
+				logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+				pods.VerifyClusterPods(t, r.client, cluster)
+
+				logrus.Infof("Verifying cloud provider on cluster (%s)", cluster.Name)
+				cloudprovider.VerifyCloudProvider(t, tt.client, defaults.RKE2, clusterConfig, cluster, nil)
+
+				logrus.Infof("Verifying cluster features (%s)", cluster.Name)
+				provisioning.VerifyDynamicCluster(t, r.client, cluster)
 			}
 		})
 	}

--- a/validation/provisioning/rke2/hardened_test.go
+++ b/validation/provisioning/rke2/hardened_test.go
@@ -1,4 +1,4 @@
-//go:build validation || recurring
+//go:build validation
 
 package rke2
 
@@ -23,6 +23,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/reports"
+	"github.com/rancher/tests/actions/workloads/pods"
 	cis "github.com/rancher/tests/validation/provisioning/resources/cisbenchmark"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -110,8 +111,11 @@ func TestHardened(t *testing.T) {
 			reports.TimeoutClusterReport(cluster, err)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, r.client, cluster)
 
 			chartName := charts.CISBenchmarkName
 			chartNamespace := charts.CISBenchmarkNamespace

--- a/validation/provisioning/rke2/hostname_truncation_test.go
+++ b/validation/provisioning/rke2/hostname_truncation_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -109,10 +110,13 @@ func TestHostnameTruncation(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, hostnamePools)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, r.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, r.client, cluster)
 
-			logrus.Infof("Verifying hostname truncation on %s", cluster.Name)
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, r.client, cluster)
+
+			logrus.Infof("Verifying hostname truncation (%s)", cluster.Name)
 			provisioning.VerifyHostnameLength(t, r.client, cluster)
 		})
 

--- a/validation/provisioning/rke2/node_driver_test.go
+++ b/validation/provisioning/rke2/node_driver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -113,8 +114,11 @@ func TestNodeDriver(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, r.client, cluster)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/rke2/psact_test.go
+++ b/validation/provisioning/rke2/psact_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -120,11 +121,16 @@ func TestPSACT(t *testing.T) {
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, tt.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, r.client, cluster)
+
+			logrus.Infof("Verifying PSACT (%s)", cluster.Name)
+			provisioning.VerifyPSACT(t, r.client, cluster)
 
 			r.clusterObjects = append(r.clusterObjects, cluster)
-
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/rke2/template_test.go
+++ b/validation/provisioning/rke2/template_test.go
@@ -1,4 +1,4 @@
-//go:build validation || recurring
+//go:build validation
 
 package rke2
 
@@ -28,6 +28,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/reports"
+	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -118,8 +119,11 @@ func TestTemplate(t *testing.T) {
 			reports.TimeoutClusterReport(cluster, err)
 			assert.NoError(t, err)
 
-			logrus.Infof("Verifying cluster (%s)", cluster.Name)
-			provisioning.VerifyCluster(t, r.client, cluster)
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			pods.VerifyClusterPods(t, r.client, cluster)
 		})
 	}
 }

--- a/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
+++ b/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
@@ -23,6 +23,7 @@ import (
 	rbac "github.com/rancher/tests/actions/rbac"
 	"github.com/rancher/tests/actions/settings"
 	"github.com/rancher/tests/actions/users"
+	"github.com/rancher/tests/actions/workloads/pods"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -95,7 +96,14 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCre
 	clusterObject, err := provisioning.CreateProvisioningCluster(createdRaReplacementUserClient, provider, credentialSpec, ra.clusterConfig, machineConfigSpec, nil)
 	require.NoError(ra.T(), err)
 
-	provisioning.VerifyCluster(ra.T(), ra.client, clusterObject)
+	log.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
+	provisioning.VerifyClusterReady(ra.T(), ra.client, clusterObject)
+
+	log.Infof("Verifying cluster pods (%s)", clusterObject.Name)
+	pods.VerifyClusterPods(ra.T(), ra.client, clusterObject)
+
+	log.Infof("Verifying cluster features (%s)", clusterObject.Name)
+	provisioning.VerifyDynamicCluster(ra.T(), ra.client, clusterObject)
 }
 
 func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementListGlobalSettings() {

--- a/validation/rbac/globalrolesv2/globalroles_v2_test.go
+++ b/validation/rbac/globalrolesv2/globalroles_v2_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/shepherd/extensions/users"
 	rbacapi "github.com/rancher/tests/actions/kubeapi/rbac"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/workloads/pods"
 
 	"github.com/rancher/tests/actions/rbac"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -171,10 +172,17 @@ func (gr *GlobalRolesV2TestSuite) TestClusterCreationAfterAddingGlobalRoleWithIn
 	log.Info("As the new user, create two new downstream  K3S clusters.")
 	_, firstClusterSteveObject, _, err := createDownstreamCluster(userClient, "K3S")
 	require.NoError(gr.T(), err)
-	provisioning.VerifyCluster(gr.T(), userClient, firstClusterSteveObject)
+
+	provisioning.VerifyClusterReady(gr.T(), userClient, firstClusterSteveObject)
+	pods.VerifyClusterPods(gr.T(), userClient, firstClusterSteveObject)
+	provisioning.VerifyDynamicCluster(gr.T(), userClient, firstClusterSteveObject)
+
 	_, secondClusterSteveObject, _, err := createDownstreamCluster(userClient, "K3S")
 	require.NoError(gr.T(), err)
-	provisioning.VerifyCluster(gr.T(), userClient, secondClusterSteveObject)
+
+	provisioning.VerifyClusterReady(gr.T(), userClient, secondClusterSteveObject)
+	pods.VerifyClusterPods(gr.T(), userClient, secondClusterSteveObject)
+	provisioning.VerifyDynamicCluster(gr.T(), userClient, secondClusterSteveObject)
 
 	gr.validateRBACResources(createdUser, createdGlobalRole, inheritedClusterRoles)
 }
@@ -425,7 +433,10 @@ func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromClu
 	log.Info("Create a RKE2 downstream cluster.")
 	_, rke2SteveObject, _, err := createDownstreamCluster(gr.client, "RKE2")
 	require.NoError(gr.T(), err)
-	provisioning.VerifyCluster(gr.T(), gr.client, rke2SteveObject)
+
+	provisioning.VerifyClusterReady(gr.T(), gr.client, rke2SteveObject)
+	pods.VerifyClusterPods(gr.T(), gr.client, rke2SteveObject)
+	provisioning.VerifyDynamicCluster(gr.T(), gr.client, rke2SteveObject)
 
 	log.Info("Create a global role with inheritedClusterRoles.")
 	inheritedClusterRoles := []string{rbac.ClusterOwner.String()}

--- a/validation/upgrade/kubernetes.go
+++ b/validation/upgrade/kubernetes.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/upgradeinput"
+	"github.com/rancher/tests/actions/workloads/pods"
 
 	kcluster "github.com/rancher/shepherd/extensions/kubeapi/cluster"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
@@ -83,7 +84,11 @@ func DownstreamCluster(u *suite.Suite, testName string, client *rancher.Client, 
 		upgradedCluster, err := upgradeRKE2K3SCluster(u.T(), client, clusterID, testConfig)
 		require.NoError(u.T(), err)
 
-		provisioning.VerifyCluster(u.T(), client, upgradedCluster)
+		logrus.Infof("Verifying the cluster is ready (%s)", upgradedCluster.Name)
+		provisioning.VerifyClusterReady(u.T(), client, upgradedCluster)
+
+		logrus.Infof("Verifying cluster pods (%s)", upgradedCluster.Name)
+		pods.VerifyClusterPods(u.T(), client, upgradedCluster)
 	}
 }
 


### PR DESCRIPTION
Description: Our recurring runs have a lot of timeouts that occur due to api timeouts, failed client relogin and a variety other timeout issues. 
Changes:
- Added retry logic to a variety of different operations in provisioning
- Split some of the verify functions apart into more modular pieces. (I will follow up with more of this in a later PR)
- Fixed an issue with cloud provider test that caused it to not test cloud providers
- Fixed an issue with the cloud provider test that causes the loadbalancer to fail to provision due to the new IPv6 subnets.
- QOL split up some of the cloud provider logic and put it in the provider (The logic needs more QOL but that will be in a later PR)
- Added the new verifies to all tests
- Moved certificates logic out of the provisioning verify