### PR TITLE
Fix panic seen in VerifyClusterReady

### DIFF
--- a/actions/provisioning/verify.go
+++ b/actions/provisioning/verify.go
@@ -137,7 +137,7 @@ func VerifyClusterReady(t *testing.T, client *rancher.Client, cluster *steveV1.S
 		checkFunc := shepherdclusters.IsProvisioningClusterReady
 		err = wait.WatchWait(watchInterface, checkFunc)
 		if err != nil {
-			logrus.Warningf("Unable to get cluster status (%s): %s . Retrying", cluster.Name)
+			logrus.Warningf("Unable to get cluster status (%s): %v . Retrying", cluster.Name, err)
 			return false, err
 		}
 


### PR DESCRIPTION
### Description
When running latest automation, a panic was seen in the `VerifyClusterReady`. Looking closer,  we need to ensure that we have the error code returned when waiting for the cluster to be ready.