### PR TITLE
Report results to Hostbusters Slack channel

### DIFF
--- a/.github/actions/report-to-slack/action.yaml
+++ b/.github/actions/report-to-slack/action.yaml
@@ -1,0 +1,40 @@
+---
+name: "Report to Slack"
+description: "Send build status to Slack"
+inputs:
+  job-status:
+    description: "The status of the job"
+    required: true
+  slack-channel:
+    description: "Slack channel"
+    required: true
+  slack-webhook-url:
+    description: "Slack webhook URL"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - id: slack-status
+      shell: bash
+      run: |
+        if [ "${{ inputs.job-status }}" == "success" ]; then
+          echo "emoji=:vcheck1:" >> $GITHUB_OUTPUT
+        elif [ "${{ inputs.job-status }}" == "failure" ]; then
+          echo "emoji=:x:" >> $GITHUB_OUTPUT
+        elif [ "${{ inputs.job-status }}" == "cancelled" ]; then
+          echo "emoji=:warning:" >> $GITHUB_OUTPUT
+        else
+          echo "emoji=:help:" >> $GITHUB_OUTPUT
+        fi
+
+    - uses: slackapi/slack-github-action@v2.1.1
+      with:
+        webhook: ${{ inputs.slack-webhook-url }}
+        webhook-type: incoming-webhook
+        payload: |
+          text: "*GitHub Action build result*: ${{ job.status }}\nWorkflow: ${{ github.workflow }}\nJob: ${{ github.job }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+          blocks:
+            - type: "section"
+              text:
+                type: "mrkdwn"
+                text: "${{ steps.slack-status.outputs.emoji }} *${{ github.repository }} - ${{ github.workflow }}* — `${{ inputs.job-status }}`\n*Job:* `${{ github.job }}` • <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Action Run>"

--- a/.github/workflows/daily-cluster-provisioning.yml
+++ b/.github/workflows/daily-cluster-provisioning.yml
@@ -307,6 +307,14 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-daily-provisioning
 
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
+
       - name: Cleanup Infrastructure
         if: always()
         working-directory: tfp-automation/modules/sanity/aws
@@ -598,6 +606,14 @@ jobs:
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-daily-provisioning
+
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -898,6 +914,14 @@ jobs:
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-daily-provisioning
+
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/daily-dualstack-cluster-provisioning.yml
+++ b/.github/workflows/daily-dualstack-cluster-provisioning.yml
@@ -285,6 +285,14 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-daily-dualstack-provisioning
 
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
+
       - name: Cleanup Infrastructure
         if: always()
         working-directory: tfp-automation/modules/dualstack/aws

--- a/.github/workflows/daily-dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/daily-dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -288,6 +288,14 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-daily-ipv6-provisioning
 
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
+
       - name: Cleanup Infrastructure
         if: always()
         working-directory: tfp-automation/modules/dualstack/aws

--- a/.github/workflows/daily-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/daily-ipv6-cluster-provisioning.yml
@@ -290,6 +290,14 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-daily-ipv6-provisioning
 
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
+
       - name: Cleanup Infrastructure
         if: always()
         working-directory: tfp-automation/modules/ipv6/aws

--- a/.github/workflows/daily-rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/daily-rancher-upgrade-cluster-provisioning.yml
@@ -311,6 +311,14 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-daily-provisioning
 
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
+
       - name: Cleanup Infrastructure
         if: always()
         working-directory: tfp-automation/modules/sanity/aws
@@ -607,6 +615,14 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-daily-provisioning
 
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
+
       - name: Cleanup Infrastructure
         if: always()
         working-directory: tfp-automation/modules/sanity/aws
@@ -901,6 +917,14 @@ jobs:
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-daily-provisioning
+
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -295,6 +295,14 @@ jobs:
           suite: ${{ matrix.suite }}
         uses: ./.github/actions/run-hostbusters-dualstack-test-suites
 
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
+
       - name: Cleanup Infrastructure
         if: always()
         working-directory: tfp-automation/modules/dualstack/aws

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -300,6 +300,14 @@ jobs:
           suite: ${{ matrix.suite }}
         uses: ./.github/actions/run-hostbusters-ipv6-test-suites
 
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
+
       - name: Cleanup Infrastructure
         if: always()
         working-directory: tfp-automation/modules/ipv6/aws

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -312,6 +312,14 @@ jobs:
           suite: ${{ matrix.suite }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
+
       - name: Cleanup Infrastructure
         if: always()
         working-directory: tfp-automation/modules/sanity/aws
@@ -608,6 +616,14 @@ jobs:
         with:
           suite: ${{ matrix.suite }}
         uses: ./.github/actions/run-hostbusters-test-suites
+
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -912,6 +928,14 @@ jobs:
         with:
           suite: ${{ matrix.suite }}
         uses: ./.github/actions/run-hostbusters-test-suites
+
+      - name: Reporting Results to Slack
+        if: always()
+        uses: ./.github/actions/report-to-slack
+        with:
+          job-status: ${{ job.status }}
+          slack-channel: ${{ secrets.HB_SLACK_CHANNEL }}
+          slack-webhook-url: ${{ secrets.HB_SLACK_WEBHOOK_URL }}
 
       - name: Cleanup Infrastructure
         if: always()


### PR DESCRIPTION
### Description
Now that we have finally received our approval for our channel Slack channel, we are able to report the results of our GHA workflows to our slack channel. This PR adds that functionality to the Hostbusters workflows.