### PR TITLE
Fix cloud provider test

### DIFF
--- a/.github/workflows/daily-cluster-provisioning.yml
+++ b/.github/workflows/daily-cluster-provisioning.yml
@@ -232,7 +232,6 @@ jobs:
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
@@ -532,7 +531,6 @@ jobs:
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
@@ -839,7 +837,6 @@ jobs:
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
 

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -235,7 +235,6 @@ jobs:
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
@@ -540,7 +539,6 @@ jobs:
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
@@ -852,7 +850,6 @@ jobs:
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:


### PR DESCRIPTION
Removed security groups from the awsMachineConfig since it is not needed and causes a tag to not be set properly by the cloud provider test