### PR TITLE
Add debugging to provisioning.

### DIFF
--- a/validation/provisioning/k3s/defaults/defaults.yaml
+++ b/validation/provisioning/k3s/defaults/defaults.yaml
@@ -82,3 +82,6 @@ templateTest:
       insecureSkipTLSVerify: true
   templateProvider: "aws"
   templateName: "<required>"
+
+logging:
+   level: "debug"

--- a/validation/provisioning/rke2/defaults/defaults.yaml
+++ b/validation/provisioning/rke2/defaults/defaults.yaml
@@ -84,3 +84,6 @@ templateTest:
       insecureSkipTLSVerify: true
   templateProvider: "aws"
   templateName: "<required>"
+
+logging:
+   level: "debug"


### PR DESCRIPTION
Add debug logging to provisioning and set debugging on by default to help debug flakiness in recurring runs.