### PR TITLE
Add rancherAgentImage parameter for 2.11 jobs

### DIFF
--- a/.github/workflows/daily-cluster-provisioning.yml
+++ b/.github/workflows/daily-cluster-provisioning.yml
@@ -261,6 +261,7 @@ jobs:
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
+              rancherAgentImage: "${{ env.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"

--- a/.github/workflows/daily-rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/daily-rancher-upgrade-cluster-provisioning.yml
@@ -120,13 +120,11 @@ jobs:
             echo "PREFIX_LIST_ID=${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}" >> $GITHUB_ENV
             echo "SECURITY_GROUPS=${{ secrets.AWS_SECURITY_GROUPS }}" >> $GITHUB_ENV
             echo "SECURITY_GROUP_NAMES=${{ secrets.AWS_SECURITY_GROUP_NAMES }}" >> $GITHUB_ENV
-            echo "RANCHER_AGENT_IMAGE=" >> $GITHUB_ENV
             echo "UPGRADED_RANCHER_AGENT_IMAGE=" >> $GITHUB_ENV
           elif [ "${{ matrix.environment }}" == "staging" ]; then
             echo "PREFIX_LIST_ID=${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}" >> $GITHUB_ENV
             echo "SECURITY_GROUPS=${{ secrets.AWS_SECURITY_GROUPS_PRIME }}" >> $GITHUB_ENV
             echo "SECURITY_GROUP_NAMES=${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}" >> $GITHUB_ENV
-            echo "RANCHER_AGENT_IMAGE=${{ secrets.RANCHER_AGENT_IMAGE }}" >> $GITHUB_ENV
             echo "UPGRADED_RANCHER_AGENT_IMAGE=${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}" >> $GITHUB_ENV
           fi
 
@@ -280,6 +278,7 @@ jobs:
               registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ matrix.rke2_version }}"
+              upgradedRancherAgentImage: "${{ env.UPGRADED_RANCHER_AGENT_IMAGE }}"
               upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -258,6 +258,7 @@ jobs:
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
+              rancherAgentImage: "${{ env.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"


### PR DESCRIPTION
### Description
Noted that with the recent GHA refactor that `rancherAgentImage` was accidentally omitted in the config. This PR adds it back.