### PR TITLE
Fix configs for IPv6 and dual-stack workflows

### DIFF
--- a/.github/workflows/daily-dualstack-cluster-provisioning.yml
+++ b/.github/workflows/daily-dualstack-cluster-provisioning.yml
@@ -202,6 +202,7 @@ jobs:
             networking:
               clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
             registries:
               rke2Registries:
                 mirrors:
@@ -223,6 +224,10 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
+              enablePrimaryIPv6: true
+              httpProtocolIpv6: "enabled"
+              ipv6AddressOnly: true
+              ipv6AddressCount: "1"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"

--- a/.github/workflows/daily-dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/daily-dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -202,6 +202,7 @@ jobs:
             networking:
               clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
+              stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             registries:
               rke2Registries:
                 mirrors:

--- a/.github/workflows/daily-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/daily-ipv6-cluster-provisioning.yml
@@ -204,6 +204,7 @@ jobs:
             networking:
               clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
+              stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             registries:
               rke2Registries:
                 mirrors:

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -211,6 +211,7 @@ jobs:
             networking:
               clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
             registries:
               rke2Registries:
                 mirrors:
@@ -232,6 +233,10 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
+              enablePrimaryIPv6: true
+              httpProtocolIpv6: "enabled"
+              ipv6AddressOnly: true
+              ipv6AddressCount: "1"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ secrets.AWS_USER }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -213,6 +213,7 @@ jobs:
             networking:
               clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
+              stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             registries:
               rke2Registries:
                 mirrors:
@@ -246,6 +247,7 @@ jobs:
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
               securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              subnetId: "${{ secrets.AWS_IPV6_SUBNET_ID }}"
 
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"


### PR DESCRIPTION
### Description
In the recent revert of strategy matrix, the dual-stack and IPv6 workflows accidentally removed key parameters in the config to get the tests to pass. This PR fixes that.