### PR TITLE
Remove security group names from daily upgrade workflow

### DIFF
--- a/.github/workflows/daily-rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/daily-rancher-upgrade-cluster-provisioning.yml
@@ -237,7 +237,6 @@ jobs:
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
 
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"
@@ -546,7 +545,6 @@ jobs:
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
 
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"
@@ -854,7 +852,6 @@ jobs:
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
 
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"


### PR DESCRIPTION
### Description
The daily upgrade tests have security group names defined in them, causing some failures we saw in the non-daily upgrade tests. Committing the same fix and removing that param.