### PR TITLE
fix typos in dockerfile

### DIFF
--- a/scripts/custodian/Dockerfile
+++ b/scripts/custodian/Dockerfile
@@ -65,11 +65,11 @@ RUN echo "from_address: caleb.warren@suse.com" >> mailer.yml
 
 CMD set -e; \
     for i in *.yaml; do \
-        sed -i "s/USERKEYS/${USER_KEYS}/g" "$i"; \
-        sed -i "s/DONOTDELETEKEYS/${DONOTDELETE_KEYS}/g" "$i"; \
+        sed -i 's/USERKEYS/'"${USER_KEYS}"'/g' "$i"; \
+        sed -i 's/DONOTDELETEKEYS/'"${DONOTDELETE_KEYS}"'/g' "$i"; \
         sed -i "s|SQSURL|${SQS_URL}|g" "$i"; \
         sed -i "s|QAIAMWEBHOOK|${QA_IAM_WEBHOOK}|g" "$i"; \
-        sed -i "s|ROUTE53LONGLIVING|${ROUTE53_LONGLIVING}|g" "$i"; \
+        sed -i 's/ROUTE53LONGLIVING/'"${ROUTE53_LONGLIVING}"'/g' "$i"; \
     done; \
     echo "Using USER_KEYS=${USER_KEYS}"; \
     if [ "$CUSTODIAN_YAML" = "aws.yaml" ] || [ "$CUSTODIAN_YAML" = "untag-to-delete.yaml" ]; then \

--- a/scripts/custodian/Jenkinsfile
+++ b/scripts/custodian/Jenkinsfile
@@ -102,19 +102,19 @@ docker build -t ${imageName} -f Dockerfile . \
             stage('Run Docker Image for Adding Tags') {
               // if a user only wants to run the test using a subset of keys, they can pass in OVERRIDE_REGION
               if ("${env.OVERRIDE_REGION}" != "null" && "${env.OVERRIDE_REGION}" != "") {
-                sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"tag-to-save.yaml\" -e OVERRIDE_REGION=\"${env.OVERRIDE_REGION}\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e QA_IAM_WEBHOOK=\"${QA_IAM_WEBHOOK}\" -e USER_KEYS=\"${TAG_USER_KEYS}\" ${imageName} "
+                sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"tag-to-save.yaml\" -e OVERRIDE_REGION=\"${env.OVERRIDE_REGION}\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e ROUTE53_LONGLIVING=\"${ROUTE53_LONGLIVING}\" -e QA_IAM_WEBHOOK=\"${QA_IAM_WEBHOOK}\" -e USER_KEYS=\"${TAG_USER_KEYS}\" ${imageName} "
               }
             }
 
             stage('Run Docker Image for AWS, Azure, GCP, and Linode') {
               if ("${CUSTODIAN_YAML}" != "${linodeScript}" && "${CUSTODIAN_YAML}" != "${awsMonthly}") {
-                sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"${CUSTODIAN_YAML}\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e QA_IAM_WEBHOOK=\"${QA_IAM_WEBHOOK}\" -e USER_KEYS=\"${USER_KEYS}\" ${imageName}"
+                sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"${CUSTODIAN_YAML}\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e ROUTE53_LONGLIVING=\"${ROUTE53_LONGLIVING}\" -e QA_IAM_WEBHOOK=\"${QA_IAM_WEBHOOK}\" -e USER_KEYS=\"${USER_KEYS}\" ${imageName}"
               } else if ("${CUSTODIAN_YAML}" == "${awsMonthly}") {
                 def today = new Date()
                 def dayOfMonth = today.format('d') as int
                 def dayOfWeek = today.format('u') as int
                 if (dayOfWeek == 6 && dayOfMonth <= 7) {
-                  sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"${awsMonthly}\" -e OVERRIDE_REGION=\"us-east-2\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e QA_IAM_WEBHOOK=\"${QA_IAM_WEBHOOK}\" -e USER_KEYS=\"${USER_KEYS}\" ${imageName} "
+                  sh "docker run --privileged --name ${testContainer} -e CUSTODIAN_YAML=\"${awsMonthly}\" -e OVERRIDE_REGION=\"us-east-2\" -e DONOTDELETE_KEYS=\"${DONOTDELETE_KEYS}\" -e ROUTE53_LONGLIVING=\"${ROUTE53_LONGLIVING}\" -e QA_IAM_WEBHOOK=\"${QA_IAM_WEBHOOK}\" -e USER_KEYS=\"${USER_KEYS}\" ${imageName} "
                 }
               } else {
                 sh ". ${linodeScript}"


### PR DESCRIPTION
some of the sed entries had an issue due to | being used in variables. 