### PR TITLE
Update Qase results for alpha/RC test runs

### DIFF
--- a/.github/actions/get-qase-id/action.yaml
+++ b/.github/actions/get-qase-id/action.yaml
@@ -5,6 +5,9 @@ inputs:
   triggered_tag:
     description: "Rancher server tag version from triggered action"
     required: true
+  qase_release_id:
+    description: "Qase ID for the release test run (alpha or rc)"
+    required: false
   qase_recurring_id:
     description: "Qase ID for the recurring test run"
     required: true
@@ -23,7 +26,11 @@ runs:
         QASE_ID=""
 
         if [[ -n "$TRIGGERED_TAG" ]]; then
+          if [[ "$TRIGGERED_TAG" == *"-rc"* || "$TRIGGERED_TAG" == *"-alpha"* ]]; then
+            QASE_ID="${{ inputs.qase_release_id }}"
+          else
             QASE_ID="${{ inputs.qase_recurring_id }}"
+          fi
         else
           QASE_ID="${{ inputs.qase_recurring_id }}"
         fi

--- a/.github/workflows/daily-cluster-provisioning.yml
+++ b/.github/workflows/daily-cluster-provisioning.yml
@@ -3,7 +3,7 @@ name: Daily Cluster Provisioning
 
 on:
   schedule:
-    - cron: "0 10 * * 1-5"
+    - cron: "0 10 * * 1,3,4,5"
   workflow_dispatch:
     inputs:
       rancher_version:

--- a/.github/workflows/daily-dualstack-cluster-provisioning.yml
+++ b/.github/workflows/daily-dualstack-cluster-provisioning.yml
@@ -3,7 +3,7 @@ name: Daily Dualstack Cluster Provisioning
 
 on:
   schedule:
-    - cron: "0 10 * * 1-5"
+    - cron: "0 9 * * 1"
   workflow_dispatch:
     inputs:
       rancher_version:

--- a/.github/workflows/daily-dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/daily-dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -3,7 +3,7 @@ name: Daily Dualstack Rancher IPv6 Cluster Provisioning
 
 on:
   schedule:
-    - cron: "0 10 * * 1-5"
+    - cron: "0 9 * * 1"
   workflow_dispatch:
     inputs:
       rancher_version:

--- a/.github/workflows/daily-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/daily-ipv6-cluster-provisioning.yml
@@ -3,7 +3,7 @@ name: Daily IPv6 Cluster Provisioning
 
 on:
   schedule:
-    - cron: "0 10 * * 1-5"
+    - cron: "0 8 * * 1"
   workflow_dispatch:
     inputs:
       rancher_version:

--- a/.github/workflows/daily-rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/daily-rancher-upgrade-cluster-provisioning.yml
@@ -3,7 +3,7 @@ name: Daily Upgraded Rancher Cluster Provisioning
 
 on:
   schedule:
-    - cron: "0 10 * * 1-5"  
+    - cron: "0 10 * * 1,2,4,5"  
   workflow_dispatch:
     inputs:
       rancher_version:

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -3,7 +3,7 @@ name: Dualstack Recurring Runs
 
 on:
   schedule:
-    - cron: "0 11 * * 1"
+    - cron: "0 11 * * 5"
   workflow_dispatch:
     inputs:
       rancher_version:
@@ -139,6 +139,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
 
       - name: Create config.yaml

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -3,7 +3,7 @@ name: IPv6 Recurring Runs
 
 on:
   schedule:
-    - cron: "0 11 * * 1"
+    - cron: "0 11 * * 5"
   workflow_dispatch:
     inputs:
       rancher_version:
@@ -139,6 +139,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
 
       - name: Create config.yaml

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -3,7 +3,7 @@ name: Recurring Runs
 
 on:
   schedule:
-    - cron: "0 11 * * 1"
+    - cron: "0 9 * * 2"
   workflow_dispatch:
     inputs:
       rancher_version:
@@ -139,6 +139,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
 
       - name: Create config.yaml

--- a/.github/workflows/turtles-cluster-provisioning.yml
+++ b/.github/workflows/turtles-cluster-provisioning.yml
@@ -3,7 +3,7 @@ name: Turtles Cluster Provisioning
 
 on:
   schedule:
-    - cron: "0 12 * * 1-5"
+    - cron: "0 12 * * 2"
   workflow_dispatch:
     inputs:
       rancher_version:
@@ -450,7 +450,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_12 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
@@ -3,7 +3,7 @@ name: Turtles Upgraded Rancher Cluster Provisioning
 
 on:
   schedule:
-    - cron: "0 12 * * 1-5"  
+    - cron: "0 12 * * 3"  
   workflow_dispatch:
     inputs:
       rancher_version:
@@ -456,7 +456,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_12 }}
+          qase_recurring_id: "${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}"
 
       - name: Create config.yaml
         run: |

--- a/.github/workflows/turtles-recurring-tests.yml
+++ b/.github/workflows/turtles-recurring-tests.yml
@@ -149,6 +149,7 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
 
       - name: Create config.yaml
@@ -461,7 +462,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_12 }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
 
       - name: Create config.yaml
         run: |
@@ -773,7 +775,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_12 }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
 
       - name: Create config.yaml
         run: |
@@ -1085,7 +1088,8 @@ jobs:
         uses: ./.github/actions/get-qase-id
         with:
           triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_12 }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
 
       - name: Create config.yaml
         run: |


### PR DESCRIPTION
### Description
As discussed offline, we are now moving back towards having a separate RC/alpha Qase test run. As such, the GHA workflows and Qase action needs to be updated to account for this.