### PR TITLE
Fix custom package name in GHA workflows

### DIFF
--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -613,12 +613,12 @@ jobs:
       - name: Creating Rancher server
         run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/upgradeRancherServer.go
 
-      - name: Run Daily Provisioning tests
+      - name: Run Provisioning tests
         env:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-daily-provisioning
+        uses: ./.github/actions/run-hostbusters-provisioning
 
       - name: Cleanup Infrastructure
         if: always()
@@ -921,12 +921,12 @@ jobs:
       - name: Creating Rancher server
         run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/upgradeRancherServer.go
 
-      - name: Run Daily Provisioning tests
+      - name: Run Provisioning tests
         env:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-daily-provisioning
+        uses: ./.github/actions/run-hostbusters-provisioning
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/turtles-cluster-provisioning.yml
+++ b/.github/workflows/turtles-cluster-provisioning.yml
@@ -316,7 +316,7 @@ jobs:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-daily-provisioning
+        uses: ./.github/actions/run-hostbusters-provisioning
 
       - name: Cleanup Infrastructure
         if: always()
@@ -623,7 +623,7 @@ jobs:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-daily-provisioning
+        uses: ./.github/actions/run-hostbusters-provisioning
 
       - name: Cleanup Infrastructure
         if: always()
@@ -930,7 +930,7 @@ jobs:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-daily-provisioning
+        uses: ./.github/actions/run-hostbusters-provisioning
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1237,7 +1237,7 @@ jobs:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-daily-provisioning
+        uses: ./.github/actions/run-hostbusters-provisioning
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
@@ -320,7 +320,7 @@ jobs:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-daily-provisioning
+        uses: ./.github/actions/run-hostbusters-provisioning
 
       - name: Cleanup Infrastructure
         if: always()
@@ -631,7 +631,7 @@ jobs:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-daily-provisioning
+        uses: ./.github/actions/run-hostbusters-provisioning
 
       - name: Cleanup Infrastructure
         if: always()
@@ -942,7 +942,7 @@ jobs:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-daily-provisioning
+        uses: ./.github/actions/run-hostbusters-provisioning
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1253,7 +1253,7 @@ jobs:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-daily-provisioning
+        uses: ./.github/actions/run-hostbusters-provisioning
 
       - name: Cleanup Infrastructure
         if: always()


### PR DESCRIPTION
### Description
Small PR to fix package name as a previous PR removed `daily` in the custom action, so these jobs are referencing a non-existent package.