### PR TITLE
Update v2.12 jobs to remove compliance parameter

### DIFF
--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -508,7 +508,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             registries:
               rke2Registries:
                 mirrors:

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -518,7 +518,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             registries:
               rke2Registries:
                 mirrors:

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -517,7 +517,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             registries:
               rke2Registries:
                 mirrors:


### PR DESCRIPTION
### Description
The v2.12 jobs still have `compliance` as a parameter, despite it now being a prime-only release. Removing this so failures related to that are removed.