### PR TITLE
Update auto_scaling_test.go

### DIFF
--- a/validation/nodescaling/rke2k3s/auto_scaling_test.go
+++ b/validation/nodescaling/rke2k3s/auto_scaling_test.go
@@ -1,4 +1,4 @@
-//go:build validation || recurring
+//go:build validation
 
 //nolint:forbidigo
 package rke2k3s


### PR DESCRIPTION
Remove auto scaling from recurring runs as it was added by mistake and will cause failures due to an autoscaler bug that causes scaling to take longer then expected by the automation.