### PR TITLE
Fix cascading errors

### DIFF
--- a/actions/provisioning/verify.go
+++ b/actions/provisioning/verify.go
@@ -72,12 +72,12 @@ func VerifyRKE1Cluster(t *testing.T, client *rancher.Client, clustersConfig *clu
 	err = wait.WatchWait(watchInterface, checkFunc)
 	require.NoError(t, err)
 
-	assert.Equal(t, clustersConfig.KubernetesVersion, cluster.RancherKubernetesEngineConfig.Version)
+	require.Equal(t, clustersConfig.KubernetesVersion, cluster.RancherKubernetesEngineConfig.Version)
 
 	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, cluster.Name)
 	reports.TimeoutRKEReport(cluster, err)
 	require.NoError(t, err)
-	assert.NotEmpty(t, clusterToken)
+	require.NotEmpty(t, clusterToken)
 
 	err = nodestat.AllManagementNodeReady(client, cluster.ID, defaults.ThirtyMinuteTimeout)
 	reports.TimeoutRKEReport(cluster, err)
@@ -96,7 +96,7 @@ func VerifyRKE1Cluster(t *testing.T, client *rancher.Client, clustersConfig *clu
 				havePrefix, err := registries.CheckAllClusterPodsForRegistryPrefix(client, cluster.ID, registry.URL)
 				reports.TimeoutRKEReport(cluster, err)
 				require.NoError(t, err)
-				assert.True(t, havePrefix)
+				require.True(t, havePrefix)
 			}
 		}
 	}
@@ -141,22 +141,22 @@ func VerifyClusterReady(t *testing.T, client *rancher.Client, cluster *steveV1.S
 		checkFunc := shepherdclusters.IsProvisioningClusterReady
 		err = wait.WatchWait(watchInterface, checkFunc)
 		if err != nil {
-			logrus.Warningf("Unable to get cluster status (%s): %v . Retrying", cluster.Name, err)
+			logrus.Warningf("Unable to get cluster status (%s): %v. Retrying", cluster.Name, err)
 			return false, nil
 		}
 
 		return true, nil
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	logrus.Debugf("Waiting for all machines to be ready on cluster (%s)", cluster.Name)
 	err = nodestat.AllMachineReady(client, cluster.ID, defaults.FiveMinuteTimeout)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	logrus.Debugf("Verifying cluster token (%s)", cluster.Name)
 	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, cluster.Name)
-	assert.NoError(t, err)
-	assert.Equal(t, true, clusterToken)
+	require.NoError(t, err)
+	require.Equal(t, true, clusterToken)
 }
 
 func VerifyPSACT(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIObject) {
@@ -166,28 +166,28 @@ func VerifyPSACT(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPI
 
 	clusterSpec := &provv1.ClusterSpec{}
 	err = steveV1.ConvertToK8sType(cluster.Spec, clusterSpec)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, clusterSpec.DefaultPodSecurityAdmissionConfigurationTemplateName)
 
 	err = psadeploy.CreateNginxDeployment(client, status.ClusterName, clusterSpec.DefaultPodSecurityAdmissionConfigurationTemplateName)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 // VerifyCluster validates that a non-rke1 cluster and its resources are in a good state, matching a given config.
 func VerifyDynamicCluster(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIObject) {
 	client, err := client.ReLogin()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	status := &provv1.ClusterStatus{}
 	err = steveV1.ConvertToK8sType(cluster.Status, status)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	clusterSpec := &provv1.ClusterSpec{}
 	err = steveV1.ConvertToK8sType(cluster.Spec, clusterSpec)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	isRancherPrivilaged := clusterSpec.DefaultPodSecurityAdmissionConfigurationTemplateName == string(provisioninginput.RancherPrivileged)
 	isRancherRestricted := clusterSpec.DefaultPodSecurityAdmissionConfigurationTemplateName == string(provisioninginput.RancherRestricted)
@@ -199,8 +199,8 @@ func VerifyDynamicCluster(t *testing.T, client *rancher.Client, cluster *steveV1
 	if clusterSpec.RKEConfig.Registries != nil {
 		for registryName := range clusterSpec.RKEConfig.Registries.Configs {
 			havePrefix, err := registries.CheckAllClusterPodsForRegistryPrefix(client, status.ClusterName, registryName)
-			assert.NoError(t, err)
-			assert.True(t, havePrefix)
+			require.NoError(t, err)
+			require.True(t, havePrefix)
 		}
 	}
 
@@ -233,7 +233,7 @@ func VerifyHostedCluster(t *testing.T, client *rancher.Client, cluster *manageme
 	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, cluster.Name)
 	reports.TimeoutRKEReport(cluster, err)
 	require.NoError(t, err)
-	assert.NotEmpty(t, clusterToken)
+	require.NotEmpty(t, clusterToken)
 
 	err = nodestat.AllManagementNodeReady(client, cluster.ID, defaults.ThirtyMinuteTimeout)
 	reports.TimeoutRKEReport(cluster, err)
@@ -300,22 +300,22 @@ func VerifyDeleteRKE2K3SCluster(t *testing.T, client *rancher.Client, clusterID 
 func VerifyACE(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIObject) {
 	status := &provv1.ClusterStatus{}
 	err := steveV1.ConvertToK8sType(cluster.Status, status)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	clusterObject, err := client.Management.Cluster.ByID(status.ClusterName)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	client, err = client.ReLogin()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	kubeConfig, err := kubeconfig.GetKubeconfig(client, clusterObject.ID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	original, err := client.SwitchContext(clusterObject.Name, kubeConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	originalResp, err := original.Resource(corev1.SchemeGroupVersion.WithResource("pods")).Namespace("").List(context.TODO(), metav1.ListOptions{})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, pod := range originalResp.Items {
 		logrus.Debugf("Pod %v", pod.GetName())
@@ -323,7 +323,7 @@ func VerifyACE(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIOb
 
 	// each control plane has a context. For ACE, we should check these contexts
 	contexts, err := kubeconfig.GetContexts(kubeConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var contextNames []string
 	for context := range contexts {
@@ -334,10 +334,10 @@ func VerifyACE(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIOb
 
 	for _, contextName := range contextNames {
 		dynamic, err := client.SwitchContext(contextName, kubeConfig)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		resp, err := dynamic.Resource(corev1.SchemeGroupVersion.WithResource("pods")).Namespace("").List(context.TODO(), metav1.ListOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		logrus.Infof("Switched Context to %v", contextName)
 		for _, pod := range resp.Items {
@@ -350,13 +350,13 @@ func VerifyACE(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIOb
 func VerifyHostnameLength(t *testing.T, client *rancher.Client, clusterObject *steveV1.SteveAPIObject) {
 	clusterSpec := &provv1.ClusterSpec{}
 	err := steveV1.ConvertToK8sType(clusterObject.Spec, clusterSpec)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, mp := range clusterSpec.RKEConfig.MachinePools {
 		machineName := wranglername.SafeConcatName(clusterObject.Name, mp.Name)
 
 		machineResp, err := client.Steve.SteveType(stevetypes.Machine).List(nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		var machinePool *steveV1.SteveAPIObject
 		for _, machine := range machineResp.Data {
@@ -364,18 +364,18 @@ func VerifyHostnameLength(t *testing.T, client *rancher.Client, clusterObject *s
 				machinePool = &machine
 			}
 		}
-		assert.NotNil(t, machinePool)
+		require.NotNil(t, machinePool)
 
 		capiMachine := capi.Machine{}
 		err = steveV1.ConvertToK8sType(machinePool.JSONResp, &capiMachine)
-		assert.NoError(t, err)
-		assert.NotNil(t, capiMachine.Status.NodeRef)
+		require.NoError(t, err)
+		require.NotNil(t, capiMachine.Status.NodeRef)
 
 		dynamic, err := client.GetRancherDynamicClient()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		gv, err := schema.ParseGroupVersion(capiMachine.Spec.InfrastructureRef.APIVersion)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		gvr := schema.GroupVersionResource{
 			Group:    gv.Group,
@@ -384,7 +384,7 @@ func VerifyHostnameLength(t *testing.T, client *rancher.Client, clusterObject *s
 		}
 
 		ustr, err := dynamic.Resource(gvr).Namespace(capiMachine.Namespace).Get(context.TODO(), capiMachine.Spec.InfrastructureRef.Name, metav1.GetOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		limit := hostnameLimit
 		if mp.HostnameLengthLimit != 0 {
@@ -393,9 +393,9 @@ func VerifyHostnameLength(t *testing.T, client *rancher.Client, clusterObject *s
 			limit = clusterSpec.RKEConfig.MachinePoolDefaults.HostnameLengthLimit
 		}
 
-		assert.True(t, len(capiMachine.Status.NodeRef.Name) <= limit)
+		require.True(t, len(capiMachine.Status.NodeRef.Name) <= limit)
 		if len(ustr.GetName()) < limit {
-			assert.True(t, capiMachine.Status.NodeRef.Name == ustr.GetName())
+			require.True(t, capiMachine.Status.NodeRef.Name == ustr.GetName())
 		}
 
 		logrus.Debugf("Hostname: %s, HostnameLimit: %v", capiMachine.Status.NodeRef.Name, limit)
@@ -418,25 +418,25 @@ func VerifyUpgrade(t *testing.T, updatedCluster *bundledclusters.BundledCluster,
 func VerifyDataDirectories(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIObject) {
 	clusterSpec := &provv1.ClusterSpec{}
 	err := steveV1.ConvertToK8sType(cluster.Spec, clusterSpec)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, clusterSpec.RKEConfig.DataDirectories)
 
 	client, err = client.ReLogin()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	status := &provv1.ClusterStatus{}
 	err = steveV1.ConvertToK8sType(cluster.Status, status)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	steveClient, err := client.Steve.ProxyDownstream(status.ClusterName)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	nodesSteveObjList, err := steveClient.SteveType(stevetypes.Node).List(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for _, machine := range nodesSteveObjList.Data {
 		clusterNode, err := sshkeys.GetSSHNodeFromMachine(client, &machine)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		_, err = clusterNode.ExecuteCommand(fmt.Sprintf("sudo ls %s", clusterSpec.RKEConfig.DataDirectories.K8sDistro))
 		assert.NoError(t, err)

--- a/actions/scaling/verify.go
+++ b/actions/scaling/verify.go
@@ -7,39 +7,39 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appv1 "k8s.io/api/apps/v1"
 )
 
 const (
 	autoscalerDeployment       = "cluster-autoscaler-clusterapi-kubernetes-cluster-autoscaler"
 	autoscalerPausedAnnotation = "provisioning.cattle.io/cluster-autoscaler-paused"
-	kubeSystemNamespace        = "kube-system"
 )
 
 func VerifyAutoscaler(t *testing.T, client *rancher.Client, cluster *v1.SteveAPIObject) {
 	status := &provv1.ClusterStatus{}
 	err := steveV1.ConvertToK8sType(cluster.Status, status)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	downstreamClient, err := client.Steve.ProxyDownstream(status.ClusterName)
-	assert.NoError(t, err)
-	assert.NotNil(t, downstreamClient)
+	require.NoError(t, err)
+	require.NotNil(t, downstreamClient)
 
 	deploymentClient := downstreamClient.SteveType(stevetypes.Deployment)
 
-	autoscalerDeployment, err := deploymentClient.ByID(kubeSystemNamespace + "/" + autoscalerDeployment)
-	assert.NoError(t, err)
+	autoscalerDeployment, err := deploymentClient.ByID(namespaces.KubeSystem + "/" + autoscalerDeployment)
+	require.NoError(t, err)
 
 	deployment := &appv1.Deployment{}
 	err = steveV1.ConvertToK8sType(autoscalerDeployment.JSONResp, deployment)
-	assert.NoError(t, err)
-	assert.Equal(t, *deployment.Spec.Replicas, deployment.Status.AvailableReplicas)
+	require.NoError(t, err)
+	require.Equal(t, *deployment.Spec.Replicas, deployment.Status.AvailableReplicas)
 
 	if cluster.Annotations[autoscalerPausedAnnotation] == "true" {
-		assert.Zero(t, *deployment.Spec.Replicas)
+		require.Zero(t, *deployment.Spec.Replicas)
 	} else {
-		assert.NotZero(t, *deployment.Spec.Replicas)
+		require.NotZero(t, *deployment.Spec.Replicas)
 	}
 }

--- a/actions/workloads/pods/verify.go
+++ b/actions/workloads/pods/verify.go
@@ -73,11 +73,11 @@ func VerifyReadyDaemonsetPods(t *testing.T, client *rancher.Client, cluster *v1.
 func VerifyClusterPods(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIObject) {
 	status := &provv1.ClusterStatus{}
 	err := steveV1.ConvertToK8sType(cluster.Status, status)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	downstreamClient, err := client.Steve.ProxyDownstream(status.ClusterName)
-	assert.NoError(t, err)
-	assert.NotNil(t, downstreamClient)
+	require.NoError(t, err)
+	require.NotNil(t, downstreamClient)
 
 	var podErrors []error
 	steveClient := downstreamClient.SteveType(stevetypes.Pod)
@@ -131,5 +131,5 @@ func VerifyClusterPods(t *testing.T, client *rancher.Client, cluster *steveV1.St
 		}
 	}
 
-	assert.Empty(t, podErrors, "Pod error list is not empty")
+	require.Empty(t, podErrors, "Pod error list is not empty")
 }

--- a/validation/provisioning/dualstack/k3s_custom_test.go
+++ b/validation/provisioning/dualstack/k3s_custom_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type customK3SDualstackTest struct {
@@ -37,26 +37,26 @@ func customK3SDualstackSetup(t *testing.T) customK3SDualstackTest {
 	k.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.client = client
 
 	k.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	k.cattleConfig, err = defaults.LoadPackageDefaults(k.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, k.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.cattleConfig, err = defaults.SetK8sDefault(k.client, defaults.K3S, k.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return k
 }
@@ -131,7 +131,7 @@ func TestCustomK3SDualstack(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/dualstack/k3s_node_driver_test.go
+++ b/validation/provisioning/dualstack/k3s_node_driver_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type nodeDriverK3STest struct {
@@ -37,25 +37,25 @@ func nodeDriverK3SSetup(t *testing.T) nodeDriverK3STest {
 	k.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	k.client = client
 
 	k.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	k.cattleConfig, err = defaults.LoadPackageDefaults(k.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, k.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.cattleConfig, err = defaults.SetK8sDefault(k.client, defaults.K3S, k.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return k
 }
@@ -117,7 +117,7 @@ func TestNodeDriverK3S(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/dualstack/rke2_custom_test.go
+++ b/validation/provisioning/dualstack/rke2_custom_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type customRKE2DualstackTest struct {
@@ -37,26 +37,26 @@ func customRKE2DualstackSetup(t *testing.T) customRKE2DualstackTest {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.client = client
 
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -130,7 +130,7 @@ func TestCustomRKE2Dualstack(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/dualstack/rke2_node_driver_test.go
+++ b/validation/provisioning/dualstack/rke2_node_driver_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type nodeDriverRKE2Test struct {
@@ -37,25 +37,25 @@ func nodeDriverRKE2Setup(t *testing.T) nodeDriverRKE2Test {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	r.client = client
 
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -116,7 +116,7 @@ func TestNodeDriverRKE2(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/ipv6/k3s_custom_test.go
+++ b/validation/provisioning/ipv6/k3s_custom_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type customK3SIPv6Test struct {
@@ -37,26 +37,26 @@ func customK3SIPv6Setup(t *testing.T) customK3SIPv6Test {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.client = client
 
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.K3S, r.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -131,7 +131,7 @@ func TestCustomK3SIPv6(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/ipv6/k3s_node_driver_test.go
+++ b/validation/provisioning/ipv6/k3s_node_driver_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type nodeDriverK3SIPv6Test struct {
@@ -38,25 +38,25 @@ func nodeDriverK3SIPv6Setup(t *testing.T) nodeDriverK3SIPv6Test {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	r.client = client
 
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.K3S, r.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -125,7 +125,7 @@ func TestNodeDriverK3SIPv6(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/ipv6/rke2_custom_test.go
+++ b/validation/provisioning/ipv6/rke2_custom_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type customRKE2IPv6Test struct {
@@ -37,26 +37,26 @@ func customRKE2IPv6Setup(t *testing.T) customRKE2IPv6Test {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.client = client
 
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -130,7 +130,7 @@ func TestCustomRKE2IPv6(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/ipv6/rke2_node_driver_test.go
+++ b/validation/provisioning/ipv6/rke2_node_driver_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type nodeDriverRKE2IPv6Test struct {
@@ -38,25 +38,25 @@ func nodeDriverRKE2IPv6Setup(t *testing.T) nodeDriverRKE2IPv6Test {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	r.client = client
 
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -124,7 +124,7 @@ func TestNodeDriverRKE2IPv6(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/k3s/ace_test.go
+++ b/validation/provisioning/k3s/ace_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,19 +45,19 @@ func aceSetup(t *testing.T) aceTest {
 	k.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	k.cattleConfig, err = defaults.LoadPackageDefaults(k.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, k.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.cattleConfig, err = defaults.SetK8sDefault(client, defaults.K3S, k.cattleConfig)
 	require.NoError(t, err)
 
 	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return k
 }

--- a/validation/provisioning/k3s/custom_test.go
+++ b/validation/provisioning/k3s/custom_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type customTest struct {
@@ -36,26 +36,26 @@ func customSetup(t *testing.T) customTest {
 	k.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.client = client
 
 	k.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	k.cattleConfig, err = defaults.LoadPackageDefaults(k.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, k.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.cattleConfig, err = defaults.SetK8sDefault(k.client, defaults.K3S, k.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return k
 }
@@ -104,7 +104,7 @@ func TestCustom(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/k3s/data_directories_test.go
+++ b/validation/provisioning/k3s/data_directories_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type dataDirectoriesTest struct {
@@ -38,25 +38,25 @@ func dataDirectoriesSetup(t *testing.T) dataDirectoriesTest {
 	k.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	k.client = client
 
 	k.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	k.cattleConfig, err = defaults.LoadPackageDefaults(k.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, k.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.cattleConfig, err = defaults.SetK8sDefault(k.client, defaults.K3S, k.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return k
 }
@@ -109,7 +109,7 @@ func TestDataDirectories(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/k3s/dynamic_custom_test.go
+++ b/validation/provisioning/k3s/dynamic_custom_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,7 +38,7 @@ func dynamicCustomSetup(t *testing.T) dynamicCustomTest {
 	k.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	k.client = client
 
 	cattleConfig := config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
@@ -48,21 +47,21 @@ func dynamicCustomSetup(t *testing.T) dynamicCustomTest {
 	operations.LoadObjectFromMap(logging.LoggingKey, cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	providerPermutation, err := permutationdata.CreateProviderPermutation(cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k8sPermutation, err := permutationdata.CreateK8sPermutation(k.client, defaults.K3S, cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	permutedConfigs, err := permutations.Permute([]permutations.Permutation{*k8sPermutation, *providerPermutation}, cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.cattleConfigs = append(k.cattleConfigs, permutedConfigs...)
 
 	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return k
 }

--- a/validation/provisioning/k3s/dynamic_node_driver_test.go
+++ b/validation/provisioning/k3s/dynamic_node_driver_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type DynamicNodeDriverTest struct {
@@ -38,7 +38,7 @@ func dynamicNodeDriverSetup(t *testing.T) DynamicNodeDriverTest {
 	k.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	k.client = client
 
 	cattleConfig := config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
@@ -47,21 +47,21 @@ func dynamicNodeDriverSetup(t *testing.T) DynamicNodeDriverTest {
 	operations.LoadObjectFromMap(logging.LoggingKey, cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	providerPermutation, err := permutationdata.CreateProviderPermutation(cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k8sPermutation, err := permutationdata.CreateK8sPermutation(k.client, defaults.K3S, cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	permutedConfigs, err := permutations.Permute([]permutations.Permutation{*k8sPermutation, *providerPermutation}, cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.cattleConfigs = append(k.cattleConfigs, permutedConfigs...)
 
 	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return k
 }
@@ -99,7 +99,7 @@ func TestDynamicNodeDriver(t *testing.T) {
 
 				logrus.Info("Provisioning cluster")
 				cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 				provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/k3s/hardened_test.go
+++ b/validation/provisioning/k3s/hardened_test.go
@@ -27,7 +27,6 @@ import (
 	cis "github.com/rancher/tests/validation/provisioning/resources/cisbenchmark"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,26 +45,26 @@ func hardenedSetup(t *testing.T) hardenedTest {
 	k.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.client = client
 
 	k.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	k.cattleConfig, err = defaults.LoadPackageDefaults(k.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, k.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.cattleConfig, err = defaults.SetK8sDefault(client, defaults.K3S, k.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return k
 }
@@ -110,7 +109,7 @@ func TestHardened(t *testing.T) {
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
 			reports.TimeoutClusterReport(cluster, err)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
@@ -127,14 +126,14 @@ func TestHardened(t *testing.T) {
 
 			clusterMeta, err := extensionscluster.NewClusterMeta(tt.client, cluster.Name)
 			reports.TimeoutClusterReport(cluster, err)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			latestCISBenchmarkVersion, err := tt.client.Catalog.GetLatestChartVersion(chartName, catalog.RancherChartRepo)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			project, err := projects.GetProjectByName(tt.client, clusterMeta.ID, cis.System)
 			reports.TimeoutClusterReport(cluster, err)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			k.project = project
 			require.NotEmpty(t, k.project)

--- a/validation/provisioning/k3s/hostname_truncation_test.go
+++ b/validation/provisioning/k3s/hostname_truncation_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type hostnameTruncationTest struct {
@@ -38,25 +38,25 @@ func hostnameTruncationSetup(t *testing.T) hostnameTruncationTest {
 	k.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	k.client = client
 
 	k.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	k.cattleConfig, err = defaults.LoadPackageDefaults(k.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, k.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.cattleConfig, err = defaults.SetK8sDefault(k.client, defaults.K3S, k.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return k
 }
@@ -109,7 +109,7 @@ func TestHostnameTruncation(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, hostnamePools)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/k3s/node_driver_test.go
+++ b/validation/provisioning/k3s/node_driver_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type nodeDriverTest struct {
@@ -37,25 +37,25 @@ func nodeDriverSetup(t *testing.T) nodeDriverTest {
 	k.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	k.client = client
 
 	k.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	k.cattleConfig, err = defaults.LoadPackageDefaults(k.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, k.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.cattleConfig, err = defaults.SetK8sDefault(k.client, defaults.K3S, k.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return k
 }
@@ -98,14 +98,14 @@ func TestNodeDriver(t *testing.T) {
 			operations.LoadObjectFromMap(defaults.ClusterConfigKey, k.cattleConfig, clusterConfig)
 			clusterConfig.MachinePools = tt.machinePools
 
-			assert.NotNil(t, clusterConfig.Provider)
+			require.NotNil(t, clusterConfig.Provider)
 			provider := provisioning.CreateProvider(clusterConfig.Provider)
 			credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
 			machineConfigSpec := machinepools.LoadMachineConfigs(string(provider.Name))
 
 			logrus.Infof("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/k3s/psact_test.go
+++ b/validation/provisioning/k3s/psact_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type psactTest struct {
@@ -37,26 +37,26 @@ func psactSetup(t *testing.T) psactTest {
 	k.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.client = client
 
 	k.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	k.cattleConfig, err = defaults.LoadPackageDefaults(k.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, k.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.cattleConfig, err = defaults.SetK8sDefault(client, defaults.K3S, k.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return k
 }
@@ -103,7 +103,7 @@ func TestPSACT(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)

--- a/validation/provisioning/k3s/schemas/hostbusters_schemas.yaml
+++ b/validation/provisioning/k3s/schemas/hostbusters_schemas.yaml
@@ -4,553 +4,1052 @@
   suite: Go Automation/Provisioning/K3S/NodeDriver
   cases:
   - description: Provisions a 1 node all roles node driver cluster
+    preconditions: null
+    postconditions: null
     title: K3S_Node_Driver|etcd_cp_worker
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision K3S node driver cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
   - description: Provisions a 2 node stacked roles node driver cluster
+    preconditions: null
+    postconditions: null
     title: K3S_Node_Driver|etcd_cp|worker
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision K3S node driver cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
   - description: Provisions a 3 node split roles node driver cluster
+    preconditions: null
+    postconditions: null
     title: K3S_Node_Driver|etcd|cp|worker
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision K3S node driver cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
   - description: Provisions a 8 node 3etcd/2cp/3worker node driver cluster
+    preconditions: null
+    postconditions: null
     title: K3S_Node_Driver|3_etcd|2_cp|3_worker
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision K3S node driver cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
 - projects:
   - RRT
   - RM
   suite: Go Automation/Provisioning/K3S/Custom
   cases:
   - description: Provisions a 1 node all roles custom cluster
+    preconditions: null
+    postconditions: null
     title: K3S_Custom|etcd_cp_worker
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision a K3S custom cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
   - description: Provisions a 2 node stacked roles custom cluster
+    preconditions: null
+    postconditions: null
     title: K3S_Custom|etcd_cp|worker
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision a K3S custom cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
   - description: Provisions a 3 node split roles custom cluster
+    preconditions: null
+    postconditions: null
     title: K3S_Custom|etcd|cp|worker
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision a K3S custom cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
   - description: Provisions a 8 node 3etcd/2cp/3worker custom cluster
+    preconditions: null
+    postconditions: null
     title: K3S_Custom|3_etcd|2_cp|3_worker
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision a K3S custom cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
 - projects:
   - RRT
   - RM
   suite: Go Automation/Provisioning/K3S/PSACT
   cases:
   - description: Provisions a cluster with psact set to rancher privilaged
+    preconditions: null
+    postconditions: null
     title: K3S_Rancher_Privileged|3_etcd|2_cp|3_worker
+    severity: null
     priority: 5
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision a psact K3S cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
   - description: Provisions a cluster with psact set to rancher restricted
+    preconditions: null
+    postconditions: null
     title: K3S_Rancher_Restricted|3_etcd|2_cp|3_worker
+    severity: null
     priority: 5
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision a psact K3S cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
   - description: Provisions a cluster with psact set to rancher baseline
+    preconditions: null
+    postconditions: null
     title: K3S_Rancher_Baseline|3_etcd|2_cp|3_worker
+    severity: null
     priority: 5
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision a psact k3s cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
 - projects:
   - RRT
   - RM
   suite: Go Automation/Provisioning/K3S/Hardened
   cases:
   - description: Provisions a hardened 3etcd/2cp/3worker custom cluster
+    preconditions: null
+    postconditions: null
     title: K3S_CIS_1.9_Profile|3_etcd|2_cp|3_worker
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision a k3s custom cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Harden the k3s custom cluster
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 4
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
 - projects:
   - RRT
   - RM
   suite: Go Automation/Provisioning/K3S/Template
   cases:
   - description: Provisions a 3 node split roles cluster using an K3S template
+    preconditions: null
+    postconditions: null
     title: K3S_Template|etcd|cp|worker
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision a K3S template cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
-- projects: [RRT, RM]
+    createdat: null
+    updatedat: null
+- projects:
+  - RRT
+  - RM
   suite: Go Automation/Provisioning/K3S/HostnameTruncation
   cases:
-  - description: Provisions a 3 node split roles cluster with hostname truncation enabled
+  - description: Provisions a 3 node split roles cluster with hostname truncation
+      enabled
+    preconditions: null
+    postconditions: null
     title: K3S_Hostname_Truncation|10_Characters
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
-    - action: Provision a cluster with hostname limit set to 10 
+      steps: []
+    - action: Provision a cluster with hostname limit set to 10
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify that the hostname limit is respected
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters:
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: Scheduled Testing
+        values:
+        - ""
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: OS
+        values:
+        - ubuntu-22.04-docker20.10.17-no-workaround
+        - windows-2022-ctw-5-2-22
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: Provider
+        values:
+        - aws
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: K8sVersion
+        values:
+        - v1.34.1+k3s1
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: CNI
+        values:
+        - ""
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    customfield:
       "14": Validation
       "18": Hostbusters
-- projects: [RRT, RM]
+    createdat: null
+    updatedat: null
+- projects:
+  - RRT
+  - RM
   suite: Go Automation/Provisioning/K3S/HostnameTruncation
   cases:
-  - description: Provisions a 3 node split roles cluster with hostname truncation enabled
+  - description: Provisions a 3 node split roles cluster with hostname truncation
+      enabled
+    preconditions: null
+    postconditions: null
     title: K3S_Hostname_Truncation|10_Characters
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
-    - action: Provision a cluster with hostname limit set to 10 
+      steps: []
+    - action: Provision a cluster with hostname limit set to 10
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify that the hostname limit is respected
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters:
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: Scheduled Testing
+        values:
+        - ""
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: OS
+        values:
+        - ubuntu-22.04-docker20.10.17-no-workaround
+        - windows-2022-ctw-5-2-22
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: Provider
+        values:
+        - aws
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: K8sVersion
+        values:
+        - v1.34.1+k3s1
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: CNI
+        values:
+        - ""
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    customfield:
       "14": Validation
       "18": Hostbusters
-  - description: Provisions a 3 node split roles cluster with hostname truncation enabled
+    createdat: null
+    updatedat: null
+  - description: Provisions a 3 node split roles cluster with hostname truncation
+      enabled
+    preconditions: null
+    postconditions: null
     title: K3S_Hostname_Truncation|31_Characters
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
-    - action: Provision a cluster with hostname limit set to 31 
+      steps: []
+    - action: Provision a cluster with hostname limit set to 31
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify that the hostname limit is respected
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters:
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: Scheduled Testing
+        values:
+        - ""
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: OS
+        values:
+        - ubuntu-22.04-docker20.10.17-no-workaround
+        - windows-2022-ctw-5-2-22
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: Provider
+        values:
+        - aws
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: K8sVersion
+        values:
+        - v1.34.1+k3s1
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: CNI
+        values:
+        - ""
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    customfield:
       "14": Validation
       "18": Hostbusters
-  - description: Provisions a 3 node split roles cluster with hostname truncation enabled
+    createdat: null
+    updatedat: null
+  - description: Provisions a 3 node split roles cluster with hostname truncation
+      enabled
+    preconditions: null
+    postconditions: null
     title: K3S_Hostname_Truncation|63_Characters
+    severity: null
     priority: 4
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
-    - action: Provision a cluster with hostname limit set to 63 
+      steps: []
+    - action: Provision a cluster with hostname limit set to 63
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify that the hostname limit is respected
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters:
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: Scheduled Testing
+        values:
+        - ""
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: OS
+        values:
+        - ubuntu-22.04-docker20.10.17-no-workaround
+        - windows-2022-ctw-5-2-22
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: Provider
+        values:
+        - aws
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: K8sVersion
+        values:
+        - v1.34.1+k3s1
+    - parametergroup: null
+      parametershared: null
+      parametersingle:
+        title: CNI
+        values:
+        - ""
+    - parametergroup: null
+      parametershared: null
+      parametersingle: null
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
 - projects:
   - RRT
   - RM
   suite: Go Automation/Provisioning/K3S/ACE
   cases:
   - description: Provisions a 3etcd/2cp/2worker node driver cluster with ACE enabled
+    preconditions: null
+    postconditions: null
     title: K3S_ACE
+    severity: null
     priority: 5
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision a k3s cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
 - projects:
   - RRT
   - RM
   suite: Go Automation/Provisioning/K3S/DataDirectories
   cases:
   - description: Provisions a 3 node split roles cluster with custom data directories
+    preconditions: null
+    postconditions: null
     title: K3S_Split_Data_Directories
+    severity: null
     priority: 5
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision a k3s cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
+      steps: []
     - action: Verify data directories on each node
       expectedresult: ""
       data: ""
       position: 4
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null
   - description: Provisions a 3 node split roles cluster with custom data directories
+    preconditions: null
+    postconditions: null
     title: K3S_Grouped_Data_Directories
+    severity: null
     priority: 5
+    behavior: null
     type: 8
-    is_flaky: 0
+    layer: null
+    isflaky: null
+    suiteid: null
+    milestoneid: null
     automation: 2
+    status: null
+    attachments: []
     steps:
     - action: Create rancher provider credentials
       expectedresult: ""
       data: ""
       position: 1
       attachments: []
+      steps: []
     - action: Provision a k3s cluster
       expectedresult: ""
       data: ""
       position: 2
       attachments: []
+      steps: []
     - action: Verify cluster state
       expectedresult: ""
       data: ""
       position: 3
       attachments: []
+      steps: []
     - action: Verify data directories on each node
       expectedresult: ""
       data: ""
       position: 4
       attachments: []
-    custom_field:
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
       "14": Validation
       "18": Hostbusters
+    createdat: null
+    updatedat: null

--- a/validation/provisioning/rke2/ace_test.go
+++ b/validation/provisioning/rke2/ace_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,19 +45,19 @@ func aceSetup(t *testing.T) aceTest {
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(client, defaults.RKE2, r.cattleConfig)
 	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }

--- a/validation/provisioning/rke2/agent_customization_test.go
+++ b/validation/provisioning/rke2/agent_customization_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type agentCustomizationTest struct {
@@ -38,26 +38,26 @@ func agentCustomizationSetup(t *testing.T) agentCustomizationTest {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.client = client
 
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(client, defaults.RKE2, r.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -147,7 +147,7 @@ func TestAgentCustomization(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
@@ -226,7 +226,7 @@ func TestAgentCustomizationFailure(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			_, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.Error(t, err)
+			require.Error(t, err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/rke2/cloud_provider_test.go
+++ b/validation/provisioning/rke2/cloud_provider_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type cloudProviderTest struct {
@@ -38,26 +38,26 @@ func cloudProviderSetup(t *testing.T) cloudProviderTest {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.client = client
 
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(client, defaults.RKE2, r.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -104,7 +104,7 @@ func TestAWSCloudProvider(t *testing.T) {
 
 			logrus.Infof("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
@@ -165,7 +165,7 @@ func TestVSphereCloudProvider(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
@@ -227,7 +227,7 @@ func TestHarvesterCloudProvider(t *testing.T) {
 
 			logrus.Infof("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)

--- a/validation/provisioning/rke2/custom_test.go
+++ b/validation/provisioning/rke2/custom_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type customTest struct {
@@ -36,26 +36,26 @@ func customSetup(t *testing.T) customTest {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.client = client
 
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -112,7 +112,7 @@ func TestCustom(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)

--- a/validation/provisioning/rke2/data_directories_test.go
+++ b/validation/provisioning/rke2/data_directories_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type dataDirectoriesTest struct {
@@ -38,25 +38,25 @@ func dataDirectoriesSetup(t *testing.T) dataDirectoriesTest {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	r.client = client
 
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -109,7 +109,7 @@ func TestDataDirectories(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)

--- a/validation/provisioning/rke2/dynamic_custom_test.go
+++ b/validation/provisioning/rke2/dynamic_custom_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,7 +39,7 @@ func dynamicCustomSetup(t *testing.T) dynamicCustomTest {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	r.client = client
 
 	cattleConfig := config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
@@ -49,24 +48,24 @@ func dynamicCustomSetup(t *testing.T) dynamicCustomTest {
 	operations.LoadObjectFromMap(logging.LoggingKey, cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	providerPermutation, err := permutationdata.CreateProviderPermutation(cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k8sPermutation, err := permutationdata.CreateK8sPermutation(r.client, defaults.RKE2, cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cniPermutation, err := permutationdata.CreateCNIPermutation(cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	permutedConfigs, err := permutations.Permute([]permutations.Permutation{*k8sPermutation, *providerPermutation, *cniPermutation}, cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfigs = append(r.cattleConfigs, permutedConfigs...)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }

--- a/validation/provisioning/rke2/dynamic_node_driver_test.go
+++ b/validation/provisioning/rke2/dynamic_node_driver_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type DynamicNodeDriverTest struct {
@@ -39,7 +39,7 @@ func dynamicNodeDriverSetup(t *testing.T) DynamicNodeDriverTest {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	r.client = client
 
 	cattleConfig := config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
@@ -48,24 +48,24 @@ func dynamicNodeDriverSetup(t *testing.T) DynamicNodeDriverTest {
 	operations.LoadObjectFromMap(logging.LoggingKey, cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	providerPermutation, err := permutationdata.CreateProviderPermutation(cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	k8sPermutation, err := permutationdata.CreateK8sPermutation(r.client, defaults.RKE2, cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cniPermutation, err := permutationdata.CreateCNIPermutation(cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	permutedConfigs, err := permutations.Permute([]permutations.Permutation{*k8sPermutation, *providerPermutation, *cniPermutation}, cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfigs = append(r.cattleConfigs, permutedConfigs...)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -103,7 +103,7 @@ func TestDynamicNodeDriver(t *testing.T) {
 
 				logrus.Info("Provisioning cluster")
 				cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 				provisioning.VerifyClusterReady(t, r.client, cluster)

--- a/validation/provisioning/rke2/hostname_truncation_test.go
+++ b/validation/provisioning/rke2/hostname_truncation_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type hostnameTruncationTest struct {
@@ -38,24 +38,24 @@ func hostnameTruncationSetup(t *testing.T) hostnameTruncationTest {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	r.client = client
 
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -108,7 +108,7 @@ func TestHostnameTruncation(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, hostnamePools)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)

--- a/validation/provisioning/rke2/node_driver_test.go
+++ b/validation/provisioning/rke2/node_driver_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type nodeDriverTest struct {
@@ -37,25 +37,25 @@ func nodeDriverSetup(t *testing.T) nodeDriverTest {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	r.client = client
 
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -101,7 +101,7 @@ func TestNodeDriver(t *testing.T) {
 			operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
 			clusterConfig.MachinePools = tt.machinePools
 
-			assert.NotNil(t, clusterConfig.Provider)
+			require.NotNil(t, clusterConfig.Provider)
 			if clusterConfig.Provider != "vsphere" && tt.isWindows {
 				t.Skip("Windows test requires access to vsphere")
 			}
@@ -112,7 +112,7 @@ func TestNodeDriver(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)

--- a/validation/provisioning/rke2/psact_test.go
+++ b/validation/provisioning/rke2/psact_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type psactTest struct {
@@ -40,26 +40,26 @@ func psactSetup(t *testing.T) psactTest {
 	r.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.client = client
 
 	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
 	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
 	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.cattleConfig, err = defaults.SetK8sDefault(client, defaults.RKE2, r.cattleConfig)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	return r
 }
@@ -119,7 +119,7 @@ func TestPSACT(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)


### PR DESCRIPTION
While looking into hostname truncation I realized that the current use of assertions is not exactly correct and can cause cascading errors in the case of a failure.  I have gone through and adjusted which error checks use require/assert. 

The largest difference between the two packages is what happens on failure:
Require: exits on failure causing all execution to stop.
Use case: this should be used in the vast majority of cases since it simply ends execution on errors which is the intended behavior for most situations.

Assert: reports an error, fails the test but continues execution.
Use case: This should be used when verifying various different expected outcomes. A good example of this can be found in the VerifyDataDirectories. In this case we would like to fail the test but still do the remainder of the checks so we can get a complete report on what is occurring. 