### PR TITLE
Remove parallelism from hostname truncation

### DIFF
--- a/validation/provisioning/k3s/hostname_truncation_test.go
+++ b/validation/provisioning/k3s/hostname_truncation_test.go
@@ -86,8 +86,6 @@ func TestHostnameTruncation(t *testing.T) {
 		})
 
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			var hostnamePools []machinepools.HostnameTruncation
 			for _, machinePoolLength := range tt.machinePoolLengthLimits {
 				currentTruncationPool := machinepools.HostnameTruncation{

--- a/validation/provisioning/rke2/hostname_truncation_test.go
+++ b/validation/provisioning/rke2/hostname_truncation_test.go
@@ -85,8 +85,6 @@ func TestHostnameTruncation(t *testing.T) {
 		})
 
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			var hostnamePools []machinepools.HostnameTruncation
 			for _, machinePoolLength := range tt.machinePoolLengthLimits {
 				currentTruncationPool := machinepools.HostnameTruncation{


### PR DESCRIPTION
While looking into issues with our recurring runs I came across an issue with hostname truncation that causes it to fail due to the cluster being deleted as soon as it is created. I was unable to reproduce it if I turned off parallelism. Since our other test run in parallel I think it is related to some combo of hostname truncation/parallelism but I couldn't find the root cause and after talking with dev we didn't get a good answer. For now i'm going to disable parallism with this test and we can revisit it at a later date. I suspect there is rancher bug here somewhere but its hard to reproduce and hard to track it in the logs, so I think will tackle it later. 