### PR TITLE
Reset settings to default values in UserRetention tests

### DIFF
--- a/actions/settings/settings.go
+++ b/actions/settings/settings.go
@@ -52,3 +52,30 @@ func SetGlobalSetting(client *rancher.Client, settingID, value string) error {
 
 	return err
 }
+
+// ResetGlobalSettingToDefaultValue is a helper function to reset a global setting by name to it's default value
+func ResetGlobalSettingToDefaultValue(client *rancher.Client, settingName string) (error) {
+	setting, err := client.WranglerContext.Mgmt.Setting().Get(settingName, metav1.GetOptions{})
+	if err != nil {
+		return  err
+	}
+
+	setting.Value = setting.Default
+
+	_, err = client.WranglerContext.Mgmt.Setting().Update(setting)
+	if err != nil {
+		return err
+	}
+
+	updatedSetting, err := client.WranglerContext.Mgmt.Setting().Get(settingName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if updatedSetting.Value != updatedSetting.Default {
+		return fmt.Errorf("failed to reset setting %q to default value; got: %s, expected: %s", 
+			settingName, updatedSetting.Value, updatedSetting.Default)
+	}
+
+	return nil
+}

--- a/validation/auth/userretention/userretention.go
+++ b/validation/auth/userretention/userretention.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/users"
 	"github.com/rancher/tests/actions/auth"
+	"github.com/rancher/tests/actions/settings"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -51,6 +52,41 @@ func setupUserRetentionSettings(client *rancher.Client, disableAfterValue string
 		return fmt.Errorf("failed to update user-retention-dry-run setting: %w", err)
 	}
 	logrus.Info("User retention settings setup completed")
+	return nil
+}
+
+func resetUserRetentionSettings(client *rancher.Client) error {
+	logrus.Infof("Resetting %s to default value", disableInactiveUserAfter)
+	err := settings.ResetGlobalSettingToDefaultValue(client, disableInactiveUserAfter)
+	if err != nil {
+		return fmt.Errorf("failed to update disable-inactive-user-after setting: %w", err)
+	}
+
+	logrus.Infof("Resetting %s to default value", deleteInactiveUserAfter)
+	err = settings.ResetGlobalSettingToDefaultValue(client, deleteInactiveUserAfter)
+	if err != nil {
+		return fmt.Errorf("failed to update delete-inactive-user-after setting: %w", err)
+	}
+
+	logrus.Infof("Resetting %s to default value", userRetentionCron)
+	err = settings.ResetGlobalSettingToDefaultValue(client, userRetentionCron)
+	if err != nil {
+		return fmt.Errorf("failed to update user-retention-cron setting: %w", err)
+	}
+
+	logrus.Infof("Resetting %s to default value", userRetentionDryRun)
+	err = settings.ResetGlobalSettingToDefaultValue(client, userRetentionDryRun)
+	if err != nil {
+		return fmt.Errorf("failed to update user-retention-dry-run setting: %w", err)
+	}
+
+	logrus.Infof("Resetting %s to default value", authUserSessionTTLMinutes)
+	err = settings.ResetGlobalSettingToDefaultValue(client, authUserSessionTTLMinutes)
+	if err != nil {
+		return fmt.Errorf("failed to update auth-user-session-ttl-minutes setting: %w", err)
+	}
+
+	logrus.Info("User retention settings reset to default values successfully")
 	return nil
 }
 

--- a/validation/auth/userretention/userretention_delete_user_test.go
+++ b/validation/auth/userretention/userretention_delete_user_test.go
@@ -38,8 +38,7 @@ func (ur *URDeleteTestSuite) SetupSuite() {
 }
 
 func (ur *URDeleteTestSuite) TearDownSuite() {
-	logrus.Info("Resetting user session settings")
-	err := updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, "0")
+	err := resetUserRetentionSettings(ur.client)
 	require.NoError(ur.T(), err)
 
 	ur.session.Cleanup()

--- a/validation/auth/userretention/userretention_disable_user_test.go
+++ b/validation/auth/userretention/userretention_disable_user_test.go
@@ -48,8 +48,7 @@ func (ur *URDisableTestSuite) TearDownSuite() {
 		}
 	}
 
-	logrus.Info("Resetting user session settings")
-	err := updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, "0")
+	err := resetUserRetentionSettings(ur.client)
 	require.NoError(ur.T(), err)
 
 	ur.session.Cleanup()
@@ -63,6 +62,9 @@ func (ur *URDisableTestSuite) assertBindingsEqual(before, after map[string]inter
 }
 
 func (ur *URDisableTestSuite) TestDefaultAdminUserIsNotDisabled() {
+	subSession := ur.session.NewSession()
+	defer subSession.Cleanup()
+
 	logrus.Info("Setting up user retention settings")
 	setupUserRetentionSettings(ur.client, "10s", "", "*/1 * * * *", "false")
 	logrus.Info("Retrieving admin user details")
@@ -85,6 +87,9 @@ func (ur *URDisableTestSuite) TestDefaultAdminUserIsNotDisabled() {
 }
 
 func (ur *URDisableTestSuite) TestAdminUserGetDisabled() {
+	subSession := ur.session.NewSession()
+	defer subSession.Cleanup()
+
 	logrus.Info("Setting up user retention settings")
 	setupUserRetentionSettings(ur.client, "10s", "", "*/1 * * * *", "false")
 
@@ -116,6 +121,9 @@ func (ur *URDisableTestSuite) TestAdminUserGetDisabled() {
 }
 
 func (ur *URDisableTestSuite) TestStandardUserGetDisabled() {
+	subSession := ur.session.NewSession()
+	defer subSession.Cleanup()
+
 	logrus.Info("Setting up user retention settings")
 	setupUserRetentionSettings(ur.client, "10s", "", "*/1 * * * *", "false")
 
@@ -149,6 +157,9 @@ func (ur *URDisableTestSuite) TestStandardUserGetDisabled() {
 }
 
 func (ur *URDisableTestSuite) TestDisabledUserGetEnabled() {
+	subSession := ur.session.NewSession()
+	defer subSession.Cleanup()
+
 	logrus.Info("Setting up user retention settings")
 	setupUserRetentionSettings(ur.client, "10s", "", "*/1 * * * *", "false")
 
@@ -194,6 +205,9 @@ func (ur *URDisableTestSuite) TestDisabledUserGetEnabled() {
 }
 
 func (ur *URDisableTestSuite) TestStandardUserDidNotGetDisabledWithBlankSettings() {
+	subSession := ur.session.NewSession()
+	defer subSession.Cleanup()
+
 	logrus.Info("Setting up user retention settings with blank values")
 	setupUserRetentionSettings(ur.client, "", "", "*/1 * * * *", "false")
 
@@ -214,6 +228,9 @@ func (ur *URDisableTestSuite) TestStandardUserDidNotGetDisabledWithBlankSettings
 }
 
 func (ur *URDisableTestSuite) TestUserDisableByUpdatingUserattributes() {
+	subSession := ur.session.NewSession()
+	defer subSession.Cleanup()
+
 	logrus.Info("Setting up user retention settings")
 	setupUserRetentionSettings(ur.client, "10s", "", "*/1 * * * *", "false")
 
@@ -258,6 +275,9 @@ func (ur *URDisableTestSuite) TestUserDisableByUpdatingUserattributes() {
 }
 
 func (ur *URDisableTestSuite) TestUserIsNotDisabledWithDryRun() {
+	subSession := ur.session.NewSession()
+	defer subSession.Cleanup()
+
 	logrus.Info("Setting up user retention settings with dry run")
 	setupUserRetentionSettings(ur.client, "10s", "", "*/1 * * * *", "true")
 

--- a/validation/auth/userretention/userretention_settings_test.go
+++ b/validation/auth/userretention/userretention_settings_test.go
@@ -33,8 +33,7 @@ func (ur *UserRetentionSettingsTestSuite) SetupSuite() {
 }
 
 func (ur *UserRetentionSettingsTestSuite) TearDownSuite() {
-	logrus.Info("Resetting user session settings")
-	err := updateUserRetentionSettings(ur.client, authUserSessionTTLMinutes, "0")
+	err := resetUserRetentionSettings(ur.client)
 	require.NoError(ur.T(), err)
 
 	ur.session.Cleanup()


### PR DESCRIPTION
This PR modifies the teardown suite in the UserRetention tests to reset the settings that are modified throughout the tests to their default values.