### PR TITLE
Add missing recurring tag to RKE2 tests

### DIFF
--- a/validation/provisioning/rke2/ace_test.go
+++ b/validation/provisioning/rke2/ace_test.go
@@ -1,4 +1,4 @@
-//go:build validation
+//go:build validation || recurring
 
 package rke2
 

--- a/validation/provisioning/rke2/hardened_test.go
+++ b/validation/provisioning/rke2/hardened_test.go
@@ -1,4 +1,4 @@
-//go:build validation
+//go:build validation || recurring
 
 package rke2
 

--- a/validation/provisioning/rke2/template_test.go
+++ b/validation/provisioning/rke2/template_test.go
@@ -1,4 +1,4 @@
-//go:build validation
+//go:build validation || recurring
 
 package rke2
 


### PR DESCRIPTION
### Description
Several RKE2 tests are missing the `recurring` tag. Small PR to fix that.