### PR TITLE
Update recurring runs test timeout to 5h

### DIFF
--- a/.github/actions/run-hostbusters-dualstack-test-suites/action.yaml
+++ b/.github/actions/run-hostbusters-dualstack-test-suites/action.yaml
@@ -15,7 +15,7 @@
          case "${{ inputs.suite }}" in
            rancher-server-one)
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/certificates/dualstack \
-               --junitfile results.xml --jsonfile results_cert.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_cert.json -- -timeout=5h -tags=recurring -v;
              cert_exit=$?;
              echo "cert_exit=$cert_exit" >> $GITHUB_ENV;
              cp results_cert.json results.json
@@ -23,7 +23,7 @@
              ./validation/reporter
 
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/dualstack \
-               --junitfile results.xml --jsonfile results_delete.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_delete.json -- -timeout=5h -tags=recurring -v;
              delete_exit=$?;
              echo "delete_exit=$delete_exit" >> $GITHUB_ENV;
              cp results_delete.json results.json
@@ -31,7 +31,7 @@
              ./validation/reporter
 
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/dualstack \
-               --junitfile results.xml --jsonfile results_node_scale.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_node_scale.json -- -timeout=5h -tags=recurring -v;
              node_scale_exit=$?;
              echo "node_scale_exit=$node_scale_exit" >> $GITHUB_ENV;
              cp results_node_scale.json results.json
@@ -40,7 +40,7 @@
              ;;
            rancher-server-two)
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/dualstack \
-               --junitfile results.xml --jsonfile results_prov.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_prov.json -- -timeout=5h -tags=recurring -v;
              prov_exit=$?;
              echo "prov_exit=$prov_exit" >> $GITHUB_ENV;
              cp results_prov.json results.json
@@ -48,7 +48,7 @@
              ./validation/reporter
 
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/dualstack \
-               --junitfile results.xml --jsonfile results_snapshot.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_snapshot.json -- -timeout=5h -tags=recurring -v;
              snap_restore_exit=$?;
              echo "snap_restore_exit=$snap_restore_exit" >> $GITHUB_ENV;
              cp results_snapshot.json results.json
@@ -56,7 +56,7 @@
              ./validation/reporter
 
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/dualstack \
-               --junitfile results.xml --jsonfile results_upgrade.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_upgrade.json -- -timeout=5h -tags=recurring -v;
              upgrade_exit=$?;
              echo "upgrade_exit=$upgrade_exit" >> $GITHUB_ENV;
              cp results_upgrade.json results.json

--- a/.github/actions/run-hostbusters-ipv6-test-suites/action.yaml
+++ b/.github/actions/run-hostbusters-ipv6-test-suites/action.yaml
@@ -15,7 +15,7 @@
          case "${{ inputs.suite }}" in
            rancher-server-one)
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/certificates/ipv6 \
-               --junitfile results.xml --jsonfile results_cert.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_cert.json -- -timeout=5h -tags=recurring -v;
              cert_exit=$?;
              echo "cert_exit=$cert_exit" >> $GITHUB_ENV;
              cp results_cert.json results.json
@@ -23,7 +23,7 @@
              ./validation/reporter
              
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/ipv6 \
-               --junitfile results.xml --jsonfile results_delete.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_delete.json -- -timeout=5h -tags=recurring -v;
              delete_exit=$?;
              echo "delete_exit=$delete_exit" >> $GITHUB_ENV;
              cp results_delete.json results.json
@@ -31,7 +31,7 @@
              ./validation/reporter
 
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/ipv6 \
-               --junitfile results.xml --jsonfile results_node_scale.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_node_scale.json -- -timeout=5h -tags=recurring -v;
              node_scale_exit=$?;
              echo "node_scale_exit=$node_scale_exit" >> $GITHUB_ENV;
              cp results_node_scale.json results.json
@@ -40,7 +40,7 @@
              ;;
            rancher-server-two)
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/ipv6 \
-               --junitfile results.xml --jsonfile results_prov.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_prov.json -- -timeout=5h -tags=recurring -v;
              prov_exit=$?;
              echo "prov_exit=$prov_exit" >> $GITHUB_ENV;
              cp results_prov.json results.json
@@ -48,7 +48,7 @@
              ./validation/reporter
 
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/ipv6 \
-               --junitfile results.xml --jsonfile results_snapshot.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_snapshot.json -- -timeout=5h -tags=recurring -v;
              snap_restore_exit=$?;
              echo "snap_restore_exit=$snap_restore_exit" >> $GITHUB_ENV;
              cp results_snapshot.json results.json
@@ -56,7 +56,7 @@
              ./validation/reporter
 
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/ipv6 \
-               --junitfile results.xml --jsonfile results_upgrade.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_upgrade.json -- -timeout=5h -tags=recurring -v;
              upgrade_exit=$?;
              echo "upgrade_exit=$upgrade_exit" >> $GITHUB_ENV;
              cp results_upgrade.json results.json

--- a/.github/actions/run-hostbusters-test-suites/action.yaml
+++ b/.github/actions/run-hostbusters-test-suites/action.yaml
@@ -15,7 +15,7 @@
          case "${{ inputs.suite }}" in
            rancher-server-one)
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/certificates/rke2k3s \
-               --junitfile results.xml --jsonfile results_cert.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_cert.json -- -timeout=5h -tags=recurring -v;
              cert_exit=$?;
              echo "cert_exit=$cert_exit" >> $GITHUB_ENV;
              cp results_cert.json results.json
@@ -23,7 +23,7 @@
              ./validation/reporter
 
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/rke2k3s \
-               --junitfile results.xml --jsonfile results_delete.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_delete.json -- -timeout=5h -tags=recurring -v;
              delete_exit=$?;
              echo "delete_exit=$delete_exit" >> $GITHUB_ENV;
              cp results_delete.json results.json
@@ -31,7 +31,7 @@
              ./validation/reporter
 
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/rke2k3s \
-               --junitfile results.xml --jsonfile results_node_scale.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_node_scale.json -- -timeout=5h -tags=recurring -v;
              nodescaling_exit=$?;
              echo "nodescaling_exit=$nodescaling_exit" >> $GITHUB_ENV;
              cp results_node_scale.json results.json
@@ -40,7 +40,7 @@
              ;;
            rancher-server-two)
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s \
-               --junitfile results.xml --jsonfile results_k3s.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_k3s.json -- -timeout=5h -tags=recurring -v;
              k3s_exit=$?;
              echo "k3s_exit=$k3s_exit" >> $GITHUB_ENV;
              cp results_k3s.json results.json
@@ -48,7 +48,7 @@
              ./validation/reporter
 
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 \
-               --junitfile results.xml --jsonfile results_rke2.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_rke2.json -- -timeout=5h -tags=recurring -v;
              rke2_exit=$?;
              echo "rke2_exit=$rke2_exit" >> $GITHUB_ENV;
              cp results_rke2.json results.json
@@ -56,7 +56,7 @@
              ./validation/reporter
 
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/rke2k3s \
-               --junitfile results.xml --jsonfile results_snapshot.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_snapshot.json -- -timeout=5h -tags=recurring -v;
              snapshot_exit=$?;
              echo "snapshot_exit=$snapshot_exit" >> $GITHUB_ENV;
              cp results_snapshot.json results.json
@@ -64,7 +64,7 @@
              ./validation/reporter
 
              gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/rke2k3s \
-               --junitfile results.xml --jsonfile results_upgrade.json -- -timeout=3h -tags=recurring -v;
+               --junitfile results.xml --jsonfile results_upgrade.json -- -timeout=5h -tags=recurring -v;
              upgrade_exit=$?;
              echo "upgrade_exit=$upgrade_exit" >> $GITHUB_ENV;
              cp results_upgrade.json results.json


### PR DESCRIPTION
### Description
Reviewing over some of the recurring runs logs, noted some snapshot tests passed, but hit a 3h timeout. Bumping it to 5h just to give an extra cushion to ensure tests properly get reported.