### PR TITLE
Fail entire workflow on test failure and shorten run name

### DIFF
--- a/.github/workflows/platform-qa-package-runner.yml
+++ b/.github/workflows/platform-qa-package-runner.yml
@@ -104,8 +104,7 @@ jobs:
           )
 
           echo "🚀 Triggering workflow for pkg=${{ steps.parse.outputs.current_pkg }}..."
-          gh workflow run "Platform QA Test Runner with Qase Reporting" \
-            --ref main "${INPUTS[@]}"
+          gh workflow run "Platform QA Test Runner with Qase Reporting" --ref main "${INPUTS[@]}"
 
           sleep 10
           for i in {1..30}; do  
@@ -127,7 +126,10 @@ jobs:
           fi
 
           echo "⏳ Waiting for run $RUN_ID (cluster=$RANCHER_HOST, pkg=$PKG) to complete..."
-          gh run watch "$RUN_ID" --interval 60 --exit-status
+          gh run watch "$RUN_ID" --interval 60
+
+          STATUS=$(gh run view "$RUN_ID" --json status,conclusion --jq '.conclusion')
+          echo "Platform QA Test Runner $RUN_ID completed with status: $STATUS"
 
       - name: Call Dispatcher for remaining packages
         if: ${{ steps.parse.outputs.remaining_packages }}

--- a/.github/workflows/platform-qa-test-runner.yml
+++ b/.github/workflows/platform-qa-test-runner.yml
@@ -1,5 +1,5 @@
 name: Platform QA Test Runner with Qase Reporting
-run-name: Platform QA Test Runner - Cluster ${{ github.event.inputs.rancher_host }} - Package ${{ github.event.inputs.test_package }}
+run-name: "Cluster ${{ github.event.inputs.rancher_host }} - Pkg ${{ github.event.inputs.test_package }}"
 
 on:
   workflow_dispatch:
@@ -194,14 +194,17 @@ jobs:
           echo "$(date +'%T') — 🚀 Running tests in package $PACKAGE"
           echo "   Test Files: $FILTERED_TEST_FILES"
           echo "   With tags: $TAGS"
-
+          set +e
           stdbuf -oL gotestsum \
             --format=standard-verbose \
             --junitfile "$GITHUB_WORKSPACE/results-${PACKAGE//\//-}.xml" \
             --jsonfile "$GITHUB_WORKSPACE/results-${PACKAGE//\//-}.json" \
-            -- -v -tags="$TAGS" -timeout 6h $FILES_TO_COMPILE_AND_RUN || echo "$(date +'%T') ⚠️ Test failed in $PACKAGE"
+            -- -v -tags="$TAGS" -timeout 6h $FILES_TO_COMPILE_AND_RUN 
 
-          echo "✅ Finished tests for package $PACKAGE on cluster $RANCHER_HOST"
+          TEST_EXIT_CODE=$?
+          echo "TEST_EXIT_CODE=$TEST_EXIT_CODE" >> $GITHUB_ENV
+          set -e
+          echo "✅ Finished executing tests for package $PACKAGE on cluster $RANCHER_HOST"
           echo "   Results: $GITHUB_WORKSPACE/results-${PACKAGE//\//-}.json"
           
       - name: Run single test with selector
@@ -219,15 +222,19 @@ jobs:
           fi
           
           echo "▶ Running selector: '$TEST_SELECTOR' with tags: $TAGS for package: $PACKAGE"
-
+          set +e
           stdbuf -oL gotestsum \
             --format=standard-verbose \
             --junitfile "$GITHUB_WORKSPACE/results-${PACKAGE//\//-}.xml" \
             --jsonfile "$GITHUB_WORKSPACE/results-${PACKAGE//\//-}.json" \
             --packages="github.com/rancher/tests/$PACKAGE" \
-            -- -v -tags="$TAGS" -timeout 6h -run "$TEST_SELECTOR" || echo "$(date +'%T')  ⚠️ Test failed in $PACKAGE"
+            -- -v -tags="$TAGS" -timeout 6h -run "$TEST_SELECTOR" 
 
-          echo "✅ Finished tests for package $PACKAGE on cluster $RANCHER_HOST"
+          TEST_EXIT_CODE=$?
+          echo "TEST_EXIT_CODE=$TEST_EXIT_CODE" >> $GITHUB_ENV
+          set -e
+
+          echo "✅ Finished executing tests for package $PACKAGE on cluster $RANCHER_HOST"
           echo "   Results: $GITHUB_WORKSPACE/results-${PACKAGE//\//-}.json"
           
       - name: Report results to Qase
@@ -244,3 +251,11 @@ jobs:
             "$PACKAGE" \
             "$QASE_TEST_RUN_ID" \
             "$QASE_AUTOMATION_TOKEN"
+
+      - name: Fail workflow if any test failed
+        run: |
+          TEST_EXIT_CODE=${TEST_EXIT_CODE:-0}
+          if [ "${TEST_EXIT_CODE}" != "0" ]; then
+            echo "❌ One or more tests failed in package $TEST_PACKAGE"
+            exit 1
+          fi


### PR DESCRIPTION
This PR updates GitHub workflows with the following changes:
- Fail the Platform QA Test Runner workflow if any test in a package fails.
- Shorten the workflow run name in the Platform QA Test Runner for better visibility in the GitHub Actions UI.