### PR TITLE
Add back correct dual stack AMI in workflow

### DIFF
--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -246,7 +246,7 @@ jobs:
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
               - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
+                awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"


### PR DESCRIPTION
### Description
The last PR accidentally changed back the `dualstack-cluster-provisioning.yml` to not use the correct AMI for downstream clusters.