### PR TITLE
Trim machine count

### DIFF
--- a/validation/certificates/defaults/defaults.yaml
+++ b/validation/certificates/defaults/defaults.yaml
@@ -12,17 +12,17 @@ clusterConfig:
       etcd: true
       controlplane: false
       worker: false
-      quantity: 3
+      quantity: 1
   - machinePoolConfig:
       etcd: false
       controlplane: true
       worker: false
-      quantity: 2
+      quantity: 1
   - machinePoolConfig:
       etcd: false
       controlplane: false
       worker: true
-      quantity: 3
+      quantity: 1
   kubernetesVersion: ""
   cni: "calico"
   provider: "aws"

--- a/validation/deleting/defaults/defaults.yaml
+++ b/validation/deleting/defaults/defaults.yaml
@@ -12,17 +12,17 @@ clusterConfig:
       etcd: true
       controlplane: false
       worker: false
-      quantity: 3
+      quantity: 1
   - machinePoolConfig:
       etcd: false
       controlplane: true
       worker: false
-      quantity: 2
+      quantity: 1
   - machinePoolConfig:
       etcd: false
       controlplane: false
       worker: true
-      quantity: 3
+      quantity: 1
   kubernetesVersion: ""
   cni: "calico"
   provider: "aws"

--- a/validation/deleting/dualstack/delete_init_machine_test.go
+++ b/validation/deleting/dualstack/delete_init_machine_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/deleting/rke2k3s"
@@ -64,6 +65,13 @@ func (d *DeleteInitMachineDualstackTestSuite) SetupSuite() {
 
 	clusterConfig := new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, d.cattleConfig, clusterConfig)
+
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
+	clusterConfig.MachinePools = nodeRolesStandard
 
 	provider := provisioning.CreateProvider(clusterConfig.Provider)
 	machineConfigSpec := provider.LoadMachineConfigFunc(d.cattleConfig)

--- a/validation/deleting/ipv6/delete_init_machine_test.go
+++ b/validation/deleting/ipv6/delete_init_machine_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/deleting/rke2k3s"
@@ -64,6 +65,13 @@ func (d *DeleteInitMachineIPv6TestSuite) SetupSuite() {
 
 	clusterConfig := new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, d.cattleConfig, clusterConfig)
+
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
+	clusterConfig.MachinePools = nodeRolesStandard
 
 	provider := provisioning.CreateProvider(clusterConfig.Provider)
 	machineConfigSpec := provider.LoadMachineConfigFunc(d.cattleConfig)

--- a/validation/deleting/rke2k3s/delete_init_machine_test.go
+++ b/validation/deleting/rke2k3s/delete_init_machine_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
@@ -64,6 +65,13 @@ func (d *DeleteInitMachineTestSuite) SetupSuite() {
 
 	clusterConfig := new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, d.cattleConfig, clusterConfig)
+
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
+	clusterConfig.MachinePools = nodeRolesStandard
 
 	provider := provisioning.CreateProvider(clusterConfig.Provider)
 	machineConfigSpec := provider.LoadMachineConfigFunc(d.cattleConfig)

--- a/validation/provisioning/defaults/defaults.yaml
+++ b/validation/provisioning/defaults/defaults.yaml
@@ -12,17 +12,17 @@ clusterConfig:
       etcd: true
       controlplane: false
       worker: false
-      quantity: 3
+      quantity: 1
   - machinePoolConfig:
       etcd: false
       controlplane: true
       worker: false
-      quantity: 2
+      quantity: 1
   - machinePoolConfig:
       etcd: false
       controlplane: false
       worker: true
-      quantity: 3
+      quantity: 1
   kubernetesVersion: ""
   cni: "calico"
   provider: "aws"

--- a/validation/provisioning/k3s/hardened_test.go
+++ b/validation/provisioning/k3s/hardened_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/provisioning"
-	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/reports"
 	"github.com/rancher/tests/actions/workloads/pods"
@@ -72,19 +71,13 @@ func hardenedSetup(t *testing.T) hardenedTest {
 func TestHardened(t *testing.T) {
 	t.Parallel()
 	k := hardenedSetup(t)
-	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
-
-	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
-	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
-	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
 
 	tests := []struct {
 		name            string
 		client          *rancher.Client
-		machinePools    []provisioninginput.MachinePools
 		scanProfileName string
 	}{
-		{"K3S_CIS_1.9_Profile|3_etcd|2_cp|3_worker", k.standardUserClient, nodeRolesStandard, "k3s-cis-1.9-profile"},
+		{"K3S_CIS_1.9_Profile|3_etcd|2_cp|3_worker", k.standardUserClient, "k3s-cis-1.9-profile"},
 	}
 	for _, tt := range tests {
 		t.Cleanup(func() {
@@ -97,8 +90,6 @@ func TestHardened(t *testing.T) {
 
 			clusterConfig := new(clusters.ClusterConfig)
 			operations.LoadObjectFromMap(defaults.ClusterConfigKey, k.cattleConfig, clusterConfig)
-
-			clusterConfig.MachinePools = tt.machinePools
 			clusterConfig.Hardened = true
 
 			externalNodeProvider := provisioning.ExternalNodeProviderSetup(clusterConfig.NodeProvider)

--- a/validation/provisioning/k3s/hostname_truncation_test.go
+++ b/validation/provisioning/k3s/hostname_truncation_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
-	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -65,19 +64,16 @@ func TestHostnameTruncation(t *testing.T) {
 	t.Parallel()
 	k := hostnameTruncationSetup(t)
 
-	nodeRolesDedicated := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
-
 	tests := []struct {
 		name                    string
 		client                  *rancher.Client
-		machinePools            []provisioninginput.MachinePools
 		ClusterNameLength       int
 		ClusterLengthLimit      int
 		machinePoolLengthLimits []int
 	}{
-		{"K3S_Hostname_Truncation|10_Characters", k.standardUserClient, nodeRolesDedicated, 63, 10, []int{10, 31, 63}},
-		{"K3S_Hostname_Truncation|31_Characters", k.standardUserClient, nodeRolesDedicated, 63, 31, []int{10, 31, 63}},
-		{"K3S_Hostname_Truncation|63_Characters", k.standardUserClient, nodeRolesDedicated, 63, 63, []int{10, 31, 63}},
+		{"K3S_Hostname_Truncation|10_Characters", k.standardUserClient, 63, 10, []int{10, 31, 63}},
+		{"K3S_Hostname_Truncation|31_Characters", k.standardUserClient, 63, 31, []int{10, 31, 63}},
+		{"K3S_Hostname_Truncation|63_Characters", k.standardUserClient, 63, 63, []int{10, 31, 63}},
 	}
 	for _, tt := range tests {
 		t.Cleanup(func() {
@@ -99,7 +95,6 @@ func TestHostnameTruncation(t *testing.T) {
 
 			clusterConfig := new(clusters.ClusterConfig)
 			operations.LoadObjectFromMap(defaults.ClusterConfigKey, k.cattleConfig, clusterConfig)
-			clusterConfig.MachinePools = tt.machinePools
 
 			provider := provisioning.CreateProvider(clusterConfig.Provider)
 			credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))

--- a/validation/provisioning/rke2/agent_customization_test.go
+++ b/validation/provisioning/rke2/agent_customization_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
-	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -65,11 +64,6 @@ func TestAgentCustomization(t *testing.T) {
 	t.Parallel()
 	r := agentCustomizationSetup(t)
 
-	productionPool := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
-	productionPool[0].MachinePoolConfig.Quantity = 3
-	productionPool[1].MachinePoolConfig.Quantity = 2
-	productionPool[2].MachinePoolConfig.Quantity = 2
-
 	agentCustomization := management.AgentDeploymentCustomization{
 		AppendTolerations: []management.Toleration{
 			{
@@ -108,13 +102,12 @@ func TestAgentCustomization(t *testing.T) {
 
 	customAgents := []string{"fleet-agent", "cluster-agent"}
 	tests := []struct {
-		name         string
-		machinePools []provisioninginput.MachinePools
-		client       *rancher.Client
-		agent        string
+		name   string
+		client *rancher.Client
+		agent  string
 	}{
-		{"Custom_Fleet_Agent", productionPool, r.standardUserClient, customAgents[0]},
-		{"Custom_Cluster_Agent", productionPool, r.standardUserClient, customAgents[1]},
+		{"Custom_Fleet_Agent", r.standardUserClient, customAgents[0]},
+		{"Custom_Cluster_Agent", r.standardUserClient, customAgents[1]},
 	}
 
 	for _, tt := range tests {
@@ -128,7 +121,6 @@ func TestAgentCustomization(t *testing.T) {
 			t.Parallel()
 			clusterConfig := new(clusters.ClusterConfig)
 			operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
-			clusterConfig.MachinePools = tt.machinePools
 
 			if tt.agent == "fleet-agent" {
 				clusterConfig.FleetAgent = &agentCustomization
@@ -168,11 +160,6 @@ func TestAgentCustomizationFailure(t *testing.T) {
 	t.Parallel()
 	r := agentCustomizationSetup(t)
 
-	productionPool := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
-	productionPool[0].MachinePoolConfig.Quantity = 3
-	productionPool[1].MachinePoolConfig.Quantity = 2
-	productionPool[2].MachinePoolConfig.Quantity = 2
-
 	agentCustomization := management.AgentDeploymentCustomization{
 		AppendTolerations: []management.Toleration{
 			{
@@ -186,13 +173,12 @@ func TestAgentCustomizationFailure(t *testing.T) {
 
 	customAgents := []string{"fleet-agent", "cluster-agent"}
 	tests := []struct {
-		name         string
-		machinePools []provisioninginput.MachinePools
-		client       *rancher.Client
-		agent        string
+		name   string
+		client *rancher.Client
+		agent  string
 	}{
-		{"Invalid_Custom_Fleet_Agent", productionPool, r.standardUserClient, customAgents[0]},
-		{"Invalid_Custom_Cluster_Agent", productionPool, r.standardUserClient, customAgents[1]},
+		{"Invalid_Custom_Fleet_Agent", r.standardUserClient, customAgents[0]},
+		{"Invalid_Custom_Cluster_Agent", r.standardUserClient, customAgents[1]},
 	}
 
 	for _, tt := range tests {
@@ -207,7 +193,6 @@ func TestAgentCustomizationFailure(t *testing.T) {
 
 			clusterConfig := new(clusters.ClusterConfig)
 			operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
-			clusterConfig.MachinePools = tt.machinePools
 
 			if tt.agent == "fleet-agent" {
 				clusterConfig.FleetAgent = &agentCustomization

--- a/validation/provisioning/rke2/hardened_test.go
+++ b/validation/provisioning/rke2/hardened_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/provisioning"
-	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/reports"
 	"github.com/rancher/tests/actions/workloads/pods"
@@ -72,19 +71,13 @@ func hardenedSetup(t *testing.T) hardenedTest {
 func TestHardened(t *testing.T) {
 	t.Parallel()
 	r := hardenedSetup(t)
-	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
-
-	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
-	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
-	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
 
 	tests := []struct {
 		name            string
 		client          *rancher.Client
-		machinePools    []provisioninginput.MachinePools
 		scanProfileName string
 	}{
-		{"RKE2_CIS_1.9_Profile|3_etcd|2_cp|3_worker", r.client, nodeRolesStandard, "rke2-cis-1.9-profile"},
+		{"RKE2_CIS_1.9_Profile|3_etcd|2_cp|3_worker", r.client, "rke2-cis-1.9-profile"},
 	}
 
 	for _, tt := range tests {
@@ -98,7 +91,6 @@ func TestHardened(t *testing.T) {
 
 			clusterConfig := new(clusters.ClusterConfig)
 			operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
-			clusterConfig.MachinePools = tt.machinePools
 			clusterConfig.Hardened = true
 
 			externalNodeProvider := provisioning.ExternalNodeProviderSetup(clusterConfig.NodeProvider)

--- a/validation/provisioning/rke2/hostname_truncation_test.go
+++ b/validation/provisioning/rke2/hostname_truncation_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
-	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -64,19 +63,16 @@ func TestHostnameTruncation(t *testing.T) {
 	t.Parallel()
 	r := hostnameTruncationSetup(t)
 
-	nodeRolesDedicated := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
-
 	tests := []struct {
 		name                    string
 		client                  *rancher.Client
-		machinePools            []provisioninginput.MachinePools
 		ClusterNameLength       int
 		ClusterLengthLimit      int
 		machinePoolLengthLimits []int
 	}{
-		{"RKE2_Hostname_Truncation|10_Characters", r.standardUserClient, nodeRolesDedicated, 63, 10, []int{10, 31, 63}},
-		{"RKE2_Hostname_Truncation|31_Characters", r.standardUserClient, nodeRolesDedicated, 63, 31, []int{10, 31, 63}},
-		{"RKE2_Hostname_Truncation|63_Characters", r.standardUserClient, nodeRolesDedicated, 63, 63, []int{10, 31, 63}},
+		{"RKE2_Hostname_Truncation|10_Characters", r.standardUserClient, 63, 10, []int{10, 31, 63}},
+		{"RKE2_Hostname_Truncation|31_Characters", r.standardUserClient, 63, 31, []int{10, 31, 63}},
+		{"RKE2_Hostname_Truncation|63_Characters", r.standardUserClient, 63, 63, []int{10, 31, 63}},
 	}
 	for _, tt := range tests {
 		t.Cleanup(func() {
@@ -98,7 +94,6 @@ func TestHostnameTruncation(t *testing.T) {
 
 			clusterConfig := new(clusters.ClusterConfig)
 			operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
-			clusterConfig.MachinePools = tt.machinePools
 
 			provider := provisioning.CreateProvider(clusterConfig.Provider)
 			credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))


### PR DESCRIPTION
Description: We are hitting the resource limit due to our recurring runs and increasing testing across the org, this pr should lighten the load caused by our recurring runs by ~70 nodes per run. 
Changes:
* Update a variety of tests that don't need 3/2/3 clusters to utilize 1/1/1 cluster configurations to save space and hopefully not hit the resource limit as quickly.