### PR TITLE
add lambda to tg policy to filter active tgs

### DIFF
--- a/scripts/custodian/aws.yaml
+++ b/scripts/custodian/aws.yaml
@@ -473,7 +473,7 @@ policies:
       op: delete
       # extending by 1 day to avoid deleting before associated resources are cleaned up
       days: 3
-- name: ec2-delete-targetgrpup
+- name: ec2-filter-targetgroup
   resource: app-elb-target-group
   description: |
     Delete any marked targetGroups which have been 
@@ -482,5 +482,23 @@ policies:
       - type: marked-for-op
         tag: ec2_known_user
         op: delete
+  actions:
+    - type: invoke-lambda
+      function: check-targetgroup-in-use
+      batch_size: 50
+      timeout: 75
+- name: ec2-delete-targetgroup-from-lambda
+  resource: app-elb-target-group
+  description: |
+    Delete target groups that have been confirmed unused
+    by the Lambda checker.
+  filters:
+    - type: marked-for-op
+      tag: ec2_known_user
+      op: delete
+    - type: value
+      key: "length(Tags[?Key=='delete-safe'])"
+      value: 1
+      op: eq
   actions:
     - type: delete


### PR DESCRIPTION
some TGs are still associated with an active LB. In the UI, it automagically skips these if deleted. But custodian doesn't do that.

I created a simple lambda function that the custodian now calls to filter out TGs associated with an LB. Custodian then does the final step of deleting safe-to-remove TGs. 