### PR TITLE
Fix broken YAML in pit_schemas.yaml

### DIFF
--- a/.github/workflows/qase.yml
+++ b/.github/workflows/qase.yml
@@ -10,7 +10,6 @@ jobs:
   run-script:
     name: update-qase
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/validation/upgrade/schemas/pit_schemas.yaml
+++ b/validation/upgrade/schemas/pit_schemas.yaml
@@ -17,7 +17,7 @@
       position: 3
     custom_field:
       "15": "TestWorkloadPreUpgrade"
-   - title: "Post-Upgrading cluster"
+  - title: "Post-Upgrading cluster"
     description: "Validate upgrading a downstream cluster to a higher specified K8s version in Rancher"
     automation: 2
     steps:


### PR DESCRIPTION
### Description
The recent post release Prime UI checks did not share the test results. Looking into it, the Qase schema is broken because of recent changes in `schemas/pit_schemas.yaml`. In fixing that and manually running the schema upload, this worked.