### PR TITLE
Add K3s IPv6 test cases

### DIFF
--- a/validation/provisioning/dualstack/k3s_custom_test.go
+++ b/validation/provisioning/dualstack/k3s_custom_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/ec2"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/pkg/config"
@@ -120,6 +121,18 @@ func TestCustomK3SDualstack(t *testing.T) {
 
 		clusterConfig.MachinePools = tt.machinePools
 		clusterConfig.Networking = tt.networking
+
+		if clusterConfig.Advanced == nil {
+			clusterConfig.Advanced = &provisioninginput.Advanced{}
+		}
+
+		if clusterConfig.Advanced.MachineGlobalConfig == nil {
+			clusterConfig.Advanced.MachineGlobalConfig = &rkev1.GenericMap{
+				Data: map[string]any{},
+			}
+		}
+
+		clusterConfig.Advanced.MachineGlobalConfig.Data["flannel-ipv6-masq"] = true
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/validation/provisioning/dualstack/k3s_node_driver_test.go
+++ b/validation/provisioning/dualstack/k3s_node_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
 	"github.com/rancher/shepherd/pkg/config"
@@ -60,7 +61,6 @@ func nodeDriverK3SSetup(t *testing.T) nodeDriverK3STest {
 }
 
 func TestNodeDriverK3S(t *testing.T) {
-	t.Skip("This test is temporarily disabled. See https://github.com/rancher/rancher/issues/51844.")
 	t.Parallel()
 	k := nodeDriverK3SSetup(t)
 
@@ -109,6 +109,18 @@ func TestNodeDriverK3S(t *testing.T) {
 
 			clusterConfig.MachinePools = tt.machinePools
 			clusterConfig.Networking = tt.networking
+
+			if clusterConfig.Advanced == nil {
+				clusterConfig.Advanced = &provisioninginput.Advanced{}
+			}
+
+			if clusterConfig.Advanced.MachineGlobalConfig == nil {
+				clusterConfig.Advanced.MachineGlobalConfig = &rkev1.GenericMap{
+					Data: map[string]any{},
+				}
+			}
+
+			clusterConfig.Advanced.MachineGlobalConfig.Data["flannel-ipv6-masq"] = true
 
 			provider := provisioning.CreateProvider(clusterConfig.Provider)
 			credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))

--- a/validation/provisioning/ipv6/k3s_custom_test.go
+++ b/validation/provisioning/ipv6/k3s_custom_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/ec2"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/pkg/config"
@@ -62,7 +63,6 @@ func customK3SIPv6Setup(t *testing.T) customK3SIPv6Test {
 }
 
 func TestCustomK3SIPv6(t *testing.T) {
-	t.Skip("This test is temporarily disabled. See https://github.com/rancher/rancher/issues/51990.")
 	t.Parallel()
 	r := customK3SIPv6Setup(t)
 
@@ -120,6 +120,18 @@ func TestCustomK3SIPv6(t *testing.T) {
 			clusterConfig.MachinePools[i].SpecifyCustomPublicIP = true
 			clusterConfig.MachinePools[i].SpecifyCustomPrivateIP = true
 		}
+
+		if clusterConfig.Advanced == nil {
+			clusterConfig.Advanced = &provisioninginput.Advanced{}
+		}
+
+		if clusterConfig.Advanced.MachineGlobalConfig == nil {
+			clusterConfig.Advanced.MachineGlobalConfig = &rkev1.GenericMap{
+				Data: map[string]any{},
+			}
+		}
+
+		clusterConfig.Advanced.MachineGlobalConfig.Data["flannel-ipv6-masq"] = true
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/validation/provisioning/ipv6/k3s_node_driver_test.go
+++ b/validation/provisioning/ipv6/k3s_node_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
 	"github.com/rancher/shepherd/pkg/config"
@@ -61,7 +62,6 @@ func nodeDriverK3SIPv6Setup(t *testing.T) nodeDriverK3SIPv6Test {
 }
 
 func TestNodeDriverK3SIPv6(t *testing.T) {
-	t.Skip("This test is temporarily disabled. See https://github.com/rancher/rancher/issues/51990.")
 	t.Parallel()
 	r := nodeDriverK3SIPv6Setup(t)
 
@@ -114,6 +114,18 @@ func TestNodeDriverK3SIPv6(t *testing.T) {
 
 		clusterConfig.MachinePools = tt.machinePools
 		clusterConfig.Networking = tt.networking
+
+		if clusterConfig.Advanced == nil {
+			clusterConfig.Advanced = &provisioninginput.Advanced{}
+		}
+
+		if clusterConfig.Advanced.MachineGlobalConfig == nil {
+			clusterConfig.Advanced.MachineGlobalConfig = &rkev1.GenericMap{
+				Data: map[string]any{},
+			}
+		}
+
+		clusterConfig.Advanced.MachineGlobalConfig.Data["flannel-ipv6-masq"] = true
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
### Description
With recent changes, K3s provisioning (node driver and custom cluster) is now supported in v2.13. As such, creating a PR to add the necessary modifications to the existing IPv6/dual-stack test cases for K3s.