### PR TITLE
fix variable quoting to resolve config-related issues

### DIFF
--- a/.github/scripts/platform-qa-create-cattle-config.sh
+++ b/.github/scripts/platform-qa-create-cattle-config.sh
@@ -81,7 +81,7 @@ awsMachineConfigs:
     zone: "${AWS_ZONE_LETTER}"
     retries: "5"
     rootSize: "${AWS_ROOT_SIZE}"
-    securityGroup: ${AWS_SECURITY_GROUP_NAMES}
+    securityGroup: "${AWS_SECURITY_GROUP_NAMES}"
 
 awsEC2Configs:
   region: "${AWS_REGION}"
@@ -91,7 +91,7 @@ awsEC2Configs:
     - instanceType: "${AWS_INSTANCE_TYPE}"
       awsRegionAZ: "${AWS_REGION}${AWS_ZONE_LETTER}"
       awsAMI: "${AWS_AMI}"
-      awsSecurityGroups: ${AWS_SECURITY_GROUPS}
+      awsSecurityGroups: "${AWS_SECURITY_GROUPS}"
       awsSubnetID: "${AWS_SUBNET_ID}"
       awsSSHKeyName: "${SSH_PRIVATE_KEY_NAME}.pem"
       awsCICDInstanceTag: "platform-qa"


### PR DESCRIPTION
Missing quotes in the config may be causing failures in some tests provisioning downstream clusters. This PR addresses that issue