### PR TITLE
Modify GRV2 test cluster creation 

### DIFF
--- a/actions/kubeconfigs/kubeconfigs.go
+++ b/actions/kubeconfigs/kubeconfigs.go
@@ -139,9 +139,9 @@ func GetBackingTokensForKubeconfigName(client *rancher.Client, kubeconfigName st
 }
 
 // CreateDownstreamCluster creates a ACE enabled or disabled downstream cluster
-func CreateDownstreamCluster(client *rancher.Client, isACE bool) (*v1.SteveAPIObject, *clusters.ClusterConfig, error) {
+func CreateDownstreamCluster(client *rancher.Client, isACE bool, k8sDistro string) (*v1.SteveAPIObject, *clusters.ClusterConfig, error) {
 	cattleConfig := config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
-	cattleConfig, err := configDefaults.SetK8sDefault(client, configDefaults.K3S, cattleConfig)
+	cattleConfig, err := configDefaults.SetK8sDefault(client, k8sDistro, cattleConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to set k8s default to k3s: %w", err)
 	}

--- a/validation/auth/kubeconfigs/kubeconfigs_test.go
+++ b/validation/auth/kubeconfigs/kubeconfigs_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/users"
 	"github.com/rancher/shepherd/pkg/session"
+	configDefaults "github.com/rancher/tests/actions/config/defaults"
 	kubeconfigapi "github.com/rancher/tests/actions/kubeconfigs"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/rbac"
 	"github.com/rancher/tests/actions/settings"
 	"github.com/rancher/tests/actions/workloads/pods"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -51,21 +53,21 @@ func (kc *ExtKubeconfigTestSuite) SetupSuite() {
 	require.NoError(kc.T(), err)
 
 	log.Infof("Creating additional clusters - ACE-enabled and non-ACE clusters")
-	aceClusterObject1, aceClusterConfig1, err := kubeconfigapi.CreateDownstreamCluster(kc.client, true)
+	aceClusterObject1, aceClusterConfig1, err := kubeconfigapi.CreateDownstreamCluster(kc.client, true, configDefaults.K3S)
 	require.NoError(kc.T(), err)
 	require.NotNil(kc.T(), aceClusterObject1)
 	require.NotNil(kc.T(), aceClusterConfig1)
 	aceCluster1ID, err := clusters.GetClusterIDByName(kc.client, aceClusterObject1.Name)
 	require.NoError(kc.T(), err)
 
-	aceClusterObject2, aceClusterConfig2, err := kubeconfigapi.CreateDownstreamCluster(kc.client, true)
+	aceClusterObject2, aceClusterConfig2, err := kubeconfigapi.CreateDownstreamCluster(kc.client, true, configDefaults.K3S)
 	require.NoError(kc.T(), err)
 	require.NotNil(kc.T(), aceClusterObject2)
 	require.NotNil(kc.T(), aceClusterConfig2)
 	aceCluster2ID, err := clusters.GetClusterIDByName(kc.client, aceClusterObject2.Name)
 	require.NoError(kc.T(), err)
 
-	clusterObject2, clusterConfig2, err := kubeconfigapi.CreateDownstreamCluster(kc.client, false)
+	clusterObject2, clusterConfig2, err := kubeconfigapi.CreateDownstreamCluster(kc.client, false, configDefaults.K3S)
 	require.NoError(kc.T(), err)
 	require.NotNil(kc.T(), clusterObject2)
 	require.NotNil(kc.T(), clusterConfig2)


### PR DESCRIPTION
This PR modifies the grv2 tests to use the kubeconfig.CreateDownstreamCluster func. 