### PR TITLE
Change dual-stack recurring runs from custom to node driver clusters

### DIFF
--- a/validation/deleting/dualstack/delete_cluster_test.go
+++ b/validation/deleting/dualstack/delete_cluster_test.go
@@ -67,11 +67,11 @@ func (d *DeleteDualstackClusterTestSuite) SetupSuite() {
 	machineConfigSpec := provider.LoadMachineConfigFunc(d.cattleConfig)
 
 	logrus.Info("Provisioning RKE2 cluster")
-	d.rke2Cluster, err = resources.ProvisionRKE2K3SCluster(d.T(), standardUserClient, extClusters.RKE2ClusterType.String(), provider, *clusterConfig, machineConfigSpec, nil, true, true)
+	d.rke2Cluster, err = resources.ProvisionRKE2K3SCluster(d.T(), standardUserClient, extClusters.RKE2ClusterType.String(), provider, *clusterConfig, machineConfigSpec, nil, true, false)
 	require.NoError(d.T(), err)
 
 	logrus.Info("Provisioning K3S cluster")
-	d.k3sCluster, err = resources.ProvisionRKE2K3SCluster(d.T(), standardUserClient, extClusters.K3SClusterType.String(), provider, *clusterConfig, machineConfigSpec, nil, true, true)
+	d.k3sCluster, err = resources.ProvisionRKE2K3SCluster(d.T(), standardUserClient, extClusters.K3SClusterType.String(), provider, *clusterConfig, machineConfigSpec, nil, true, false)
 	require.NoError(d.T(), err)
 }
 

--- a/validation/nodescaling/dualstack/scaling_test.go
+++ b/validation/nodescaling/dualstack/scaling_test.go
@@ -74,18 +74,15 @@ func (s *NodeScalingDualstackTestSuite) SetupSuite() {
 	provider := provisioning.CreateProvider(s.clusterConfig.Provider)
 	machineConfigSpec := provider.LoadMachineConfigFunc(s.cattleConfig)
 
-	awsEC2Configs := new(ec2.AWSEC2Configs)
-	operations.LoadObjectFromMap(ec2.ConfigurationFileKey, s.cattleConfig, awsEC2Configs)
-
 	s.scalingConfig = new(scalinginput.Config)
 	config.LoadConfig(scalinginput.ConfigurationFileKey, s.scalingConfig)
 
 	logrus.Info("Provisioning RKE2 cluster")
-	s.rke2Cluster, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.RKE2ClusterType.String(), provider, *s.clusterConfig, machineConfigSpec, awsEC2Configs, true, true)
+	s.rke2Cluster, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.RKE2ClusterType.String(), provider, *s.clusterConfig, machineConfigSpec, nil, true, false)
 	require.NoError(s.T(), err)
 
 	logrus.Info("Provisioning K3S cluster")
-	s.k3sCluster, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.K3SClusterType.String(), provider, *s.clusterConfig, machineConfigSpec, awsEC2Configs, true, true)
+	s.k3sCluster, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.K3SClusterType.String(), provider, *s.clusterConfig, machineConfigSpec, nil, true, false)
 	require.NoError(s.T(), err)
 }
 

--- a/validation/snapshot/dualstack/snapshot_restore_test.go
+++ b/validation/snapshot/dualstack/snapshot_restore_test.go
@@ -73,11 +73,11 @@ func (s *SnapshotDualstackRestoreTestSuite) SetupSuite() {
 	machineConfigSpec := provider.LoadMachineConfigFunc(s.cattleConfig)
 
 	logrus.Info("Provisioning RKE2 cluster")
-	s.rke2Cluster, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.RKE2ClusterType.String(), provider, *clusterConfig, machineConfigSpec, nil, false, true)
+	s.rke2Cluster, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.RKE2ClusterType.String(), provider, *clusterConfig, machineConfigSpec, nil, false, false)
 	require.NoError(s.T(), err)
 
 	logrus.Info("Provisioning K3S cluster")
-	s.k3sCluster, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.K3SClusterType.String(), provider, *clusterConfig, machineConfigSpec, nil, false, true)
+	s.k3sCluster, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.K3SClusterType.String(), provider, *clusterConfig, machineConfigSpec, nil, false, false)
 	require.NoError(s.T(), err)
 }
 

--- a/validation/upgrade/dualstack/kubernetes_test.go
+++ b/validation/upgrade/dualstack/kubernetes_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
-	"github.com/rancher/shepherd/clients/ec2"
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	extClusters "github.com/rancher/shepherd/extensions/clusters"
@@ -73,15 +72,12 @@ func (u *UpgradeDualstackKubernetesTestSuite) SetupSuite() {
 	provider := provisioning.CreateProvider(u.clusterConfig.Provider)
 	machineConfigSpec := provider.LoadMachineConfigFunc(u.cattleConfig)
 
-	awsEC2Configs := new(ec2.AWSEC2Configs)
-	operations.LoadObjectFromMap(ec2.ConfigurationFileKey, u.cattleConfig, awsEC2Configs)
-
 	logrus.Info("Provisioning RKE2 cluster")
-	u.rke2Cluster, err = resources.ProvisionRKE2K3SCluster(u.T(), standardUserClient, extClusters.RKE2ClusterType.String(), provider, *u.clusterConfig, machineConfigSpec, awsEC2Configs, false, true)
+	u.rke2Cluster, err = resources.ProvisionRKE2K3SCluster(u.T(), standardUserClient, extClusters.RKE2ClusterType.String(), provider, *u.clusterConfig, machineConfigSpec, nil, false, false)
 	require.NoError(u.T(), err)
 
 	logrus.Info("Provisioning K3S cluster")
-	u.k3sCluster, err = resources.ProvisionRKE2K3SCluster(u.T(), standardUserClient, extClusters.K3SClusterType.String(), provider, *u.clusterConfig, machineConfigSpec, awsEC2Configs, false, true)
+	u.k3sCluster, err = resources.ProvisionRKE2K3SCluster(u.T(), standardUserClient, extClusters.K3SClusterType.String(), provider, *u.clusterConfig, machineConfigSpec, nil, false, false)
 	require.NoError(u.T(), err)
 }
 


### PR DESCRIPTION
### Description
The last PR did not fully fix dual-stack recurring runs. Looking deeper into it, the config is throwing a panic on select tests. Those tests are attempting to provision custom clusters when they should provision node driver clusters.

Originally, they were custom clusters as there was not support yet for node drivers. Now there are, so updating the tests.