### PR TITLE
Update validation logic

### DIFF
--- a/actions/provisioning/verify.go
+++ b/actions/provisioning/verify.go
@@ -141,7 +141,7 @@ func VerifyClusterReady(t *testing.T, client *rancher.Client, cluster *steveV1.S
 		checkFunc := shepherdclusters.IsProvisioningClusterReady
 		err = wait.WatchWait(watchInterface, checkFunc)
 		if err != nil {
-			logrus.Warningf("Unable to get cluster status (%s): %v. Retrying", cluster.Name, err)
+			logrus.Warningf("Unable to get cluster status (%s) Retrying", cluster.Name)
 			return false, nil
 		}
 

--- a/actions/workloads/pods/verify.go
+++ b/actions/workloads/pods/verify.go
@@ -3,7 +3,6 @@ package pods
 import (
 	"context"
 	"errors"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -84,23 +83,6 @@ func VerifyClusterPods(client *rancher.Client, cluster *steveV1.SteveAPIObject) 
 		}
 
 		steveClient := downstreamClient.SteveType(stevetypes.Pod)
-		deploymentClient := downstreamClient.SteveType(stevetypes.Deployment)
-		clusterDeployments, err := deploymentClient.List(nil)
-		if err != nil {
-			return false, nil
-		}
-
-		requiredDeployments := []string{ClusterAgent, Webhook, Fleet, SUC}
-		requiredDeploymentCount := 0
-		for _, deployment := range clusterDeployments.Data {
-			if slices.Contains(requiredDeployments, deployment.Name) {
-				logrus.Tracef("Deployment: %s exists", deployment.Name)
-				requiredDeploymentCount += 1
-			}
-		}
-		if requiredDeploymentCount != len(requiredDeployments) {
-			return false, nil
-		}
 
 		podErrors = []error{}
 

--- a/actions/workloads/verify.go
+++ b/actions/workloads/verify.go
@@ -97,7 +97,15 @@ func VerifyWorkloads(client *rancher.Client, clusterName string, workloads Workl
 	}
 
 	err = pods.VerifyClusterPods(client, cluster)
+	if err != nil {
+		return nil, err
+	}
 
-	return &workloads, err
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	return &workloads, nil
 
 }

--- a/validation/auth/kubeconfigs/kubeconfigs_test.go
+++ b/validation/auth/kubeconfigs/kubeconfigs_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/rbac"
 	"github.com/rancher/tests/actions/settings"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -73,6 +74,10 @@ func (kc *ExtKubeconfigTestSuite) SetupSuite() {
 	require.NoError(kc.T(), err)
 
 	provisioning.VerifyClusterReady(kc.T(), client, aceClusterObject1)
+
+	err = deployment.VerifyClusterDeployments(client, aceClusterObject1)
+	require.NoError(kc.T(), err)
+
 	err = pods.VerifyClusterPods(client, aceClusterObject1)
 	require.NoError(kc.T(), err)
 	provisioning.VerifyDynamicCluster(kc.T(), client, aceClusterObject1)
@@ -81,6 +86,10 @@ func (kc *ExtKubeconfigTestSuite) SetupSuite() {
 	log.Infof("ACE-enabled cluster created: %s (%s)", kc.aceCluster1.Name, aceCluster1ID)
 
 	provisioning.VerifyClusterReady(kc.T(), client, aceClusterObject2)
+
+	err = deployment.VerifyClusterDeployments(client, aceClusterObject2)
+	require.NoError(kc.T(), err)
+
 	err = pods.VerifyClusterPods(client, aceClusterObject2)
 	require.NoError(kc.T(), err)
 	provisioning.VerifyDynamicCluster(kc.T(), client, aceClusterObject2)
@@ -89,6 +98,10 @@ func (kc *ExtKubeconfigTestSuite) SetupSuite() {
 	log.Infof("ACE-enabled cluster created: %s (%s)", kc.aceCluster2.Name, aceCluster2ID)
 
 	provisioning.VerifyClusterReady(kc.T(), client, clusterObject2)
+
+	err = deployment.VerifyClusterDeployments(client, clusterObject2)
+	require.NoError(kc.T(), err)
+
 	err = pods.VerifyClusterPods(client, clusterObject2)
 	require.NoError(kc.T(), err)
 	provisioning.VerifyDynamicCluster(kc.T(), client, clusterObject2)

--- a/validation/certificates/dualstack/cert_rotation_test.go
+++ b/validation/certificates/dualstack/cert_rotation_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/certificates"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
@@ -111,6 +112,10 @@ func (c *CertRotationDualstackTestSuite) TestCertRotationDualstack() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(c.T(), c.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(c.client, cluster)
+			require.NoError(c.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(c.client, cluster)

--- a/validation/certificates/ipv6/cert_rotation_test.go
+++ b/validation/certificates/ipv6/cert_rotation_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/certificates"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
@@ -111,6 +112,10 @@ func (c *CertRotationIPv6TestSuite) TestCertRotationIPv6() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(c.T(), c.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(c.client, cluster)
+			require.NoError(c.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(c.client, cluster)

--- a/validation/certificates/rke2k3s/cert_rotation_existing_cluster_test.go
+++ b/validation/certificates/rke2k3s/cert_rotation_existing_cluster_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/certificates"
 	"github.com/sirupsen/logrus"
@@ -77,6 +78,10 @@ func (c *CertRotationExistingClusterTestSuite) TestCertRotationExistingCluster()
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(c.T(), c.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(c.client, cluster)
+			require.NoError(c.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(c.client, cluster)

--- a/validation/certificates/rke2k3s/cert_rotation_test.go
+++ b/validation/certificates/rke2k3s/cert_rotation_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/certificates"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
@@ -98,6 +99,10 @@ func (c *CertRotationTestSuite) TestCertRotation() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(c.T(), c.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(c.client, cluster)
+			require.NoError(c.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(c.client, cluster)

--- a/validation/certificates/rke2k3s/cert_rotation_wins_test.go
+++ b/validation/certificates/rke2k3s/cert_rotation_wins_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/certificates"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
@@ -115,6 +116,10 @@ func (c *CertRotationWindowsTestSuite) TestCertRotationWindows() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(c.T(), c.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(c.client, cluster)
+			require.NoError(c.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(c.client, cluster)

--- a/validation/charts/backup_restore/backup_restore.go
+++ b/validation/charts/backup_restore/backup_restore.go
@@ -14,6 +14,7 @@ import (
 	actionscharts "github.com/rancher/tests/actions/charts"
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/secrets"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/interoperability/charts"
 	"github.com/stretchr/testify/require"
@@ -318,6 +319,10 @@ func createRKE2dsCluster(t *testing.T, client *rancher.Client) (*v1.SteveAPIObje
 
 	logrus.Infof("Verifying the cluster is ready (%s)", steveObject.Name)
 	provisioning.VerifyClusterReady(t, client, steveObject)
+
+	logrus.Infof("Verifying cluster deployments (%s)", steveObject.Name)
+	err = deployment.VerifyClusterDeployments(client, steveObject)
+	require.NoError(t, err)
 
 	logrus.Infof("Verifying cluster pods (%s)", steveObject.Name)
 	err = pods.VerifyClusterPods(client, steveObject)

--- a/validation/charts/backup_restore/backup_restore_test.go
+++ b/validation/charts/backup_restore/backup_restore_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/interoperability/charts"
 	"github.com/stretchr/testify/assert"
@@ -117,6 +118,10 @@ func (b *BackupTestSuite) TestS3InPlaceRestore() {
 
 	logrus.Infof("Verifying the cluster is ready (%s)", rke2SteveObj.Name)
 	provisioning.VerifyClusterReady(b.T(), b.client, rke2SteveObj)
+
+	logrus.Infof("Verifying cluster deployments (%s)", rke2SteveObj.Name)
+	err = deployment.VerifyClusterDeployments(b.client, rke2SteveObj)
+	require.NoError(b.T(), err)
 
 	logrus.Infof("Verifying cluster pods (%s)", rke2SteveObj.Name)
 	err = pods.VerifyClusterPods(b.client, rke2SteveObj)

--- a/validation/deleting/dualstack/delete_init_machine_test.go
+++ b/validation/deleting/dualstack/delete_init_machine_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/deleting/rke2k3s"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
@@ -106,6 +107,10 @@ func (d *DeleteInitMachineDualstackTestSuite) TestDeleteInitMachineDualstack() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(d.T(), d.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(d.client, cluster)
+			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			pods.VerifyClusterPods(d.client, cluster)

--- a/validation/deleting/ipv6/delete_init_machine_test.go
+++ b/validation/deleting/ipv6/delete_init_machine_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/deleting/rke2k3s"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
@@ -119,6 +120,10 @@ func (d *DeleteInitMachineIPv6TestSuite) TestDeleteInitMachineIPv6() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(d.T(), d.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(d.client, cluster)
+			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(d.client, cluster)

--- a/validation/deleting/rke2k3s/delete_init_machine_test.go
+++ b/validation/deleting/rke2k3s/delete_init_machine_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -105,6 +106,10 @@ func (d *DeleteInitMachineTestSuite) TestDeleteInitMachine() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(d.T(), d.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(d.client, cluster)
+			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(d.client, cluster)

--- a/validation/fleet/provisioning/airgap/fleet_in_airgap_test.go
+++ b/validation/fleet/provisioning/airgap/fleet_in_airgap_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning/permutations"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/reports"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/interoperability/fleet"
 	"github.com/sirupsen/logrus"
@@ -179,6 +180,10 @@ func (a *AirGapRKE2CustomClusterTestSuite) TestCustomClusterWithGitRepo() {
 
 		logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
 		provisioning.VerifyClusterReady(a.T(), a.standardClient, clusterObject)
+
+		logrus.Infof("Verifying cluster deployments (%s)", clusterObject.Name)
+		err = deployment.VerifyClusterDeployments(a.standardClient, clusterObject)
+		require.NoError(a.T(), err)
 
 		logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
 		err = pods.VerifyClusterPods(a.standardClient, clusterObject)

--- a/validation/fleet/provisioning/new_cluster_existing_gitrepo_test.go
+++ b/validation/fleet/provisioning/new_cluster_existing_gitrepo_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning/permutations"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/reports"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/interoperability/fleet"
 	"github.com/sirupsen/logrus"
@@ -185,6 +186,10 @@ func (f *FleetWithProvisioningTestSuite) TestHardenedAfterAddedGitRepo() {
 			logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
 			provisioning.VerifyClusterReady(f.T(), tt.client, clusterObject)
 
+			logrus.Infof("Verifying cluster deployments (%s)", clusterObject.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, clusterObject)
+			require.NoError(f.T(), err)
+
 			logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
 			err = pods.VerifyClusterPods(tt.client, clusterObject)
 			require.NoError(f.T(), err)
@@ -279,6 +284,10 @@ func (f *FleetWithProvisioningTestSuite) TestWindowsAfterAddedGitRepo() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
 			provisioning.VerifyClusterReady(f.T(), tt.client, clusterObject)
+
+			logrus.Infof("Verifying cluster deployments (%s)", clusterObject.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, clusterObject)
+			require.NoError(f.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
 			err = pods.VerifyClusterPods(tt.client, clusterObject)

--- a/validation/nodescaling/dualstack/scaling_test.go
+++ b/validation/nodescaling/dualstack/scaling_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/scalinginput"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/nodescaling"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
@@ -127,6 +128,10 @@ func (s *NodeScalingDualstackTestSuite) TestScalingDualstackNodePools() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(s.client, cluster)

--- a/validation/nodescaling/ipv6/scaling_test.go
+++ b/validation/nodescaling/ipv6/scaling_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/nodescaling"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
@@ -131,6 +132,10 @@ func (s *NodeScalingIPv6TestSuite) TestScalingIPv6NodePools() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(s.client, cluster)

--- a/validation/nodescaling/rke2k3s/auto_replace_existing_cluster_test.go
+++ b/validation/nodescaling/rke2k3s/auto_replace_existing_cluster_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/scalinginput"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -83,6 +84,10 @@ func (s *AutoReplaceExistingClusterSuite) TestAutoReplaceExistingCluster() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(s.client, cluster)

--- a/validation/nodescaling/rke2k3s/auto_replace_test.go
+++ b/validation/nodescaling/rke2k3s/auto_replace_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/scalinginput"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -101,6 +102,10 @@ func (s *AutoReplaceSuite) TestAutoReplace() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(s.client, cluster)

--- a/validation/nodescaling/rke2k3s/scale_replace_test.go
+++ b/validation/nodescaling/rke2k3s/scale_replace_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/scalinginput"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -119,6 +120,10 @@ func (s *NodeReplacingTestSuite) TestReplacingNodes() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(s.client, cluster)

--- a/validation/nodescaling/rke2k3s/scaling_custom_cluster_test.go
+++ b/validation/nodescaling/rke2k3s/scaling_custom_cluster_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/scalinginput"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/nodescaling"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
@@ -144,6 +145,10 @@ func (s *CustomClusterNodeScalingTestSuite) TestScalingCustomClusterNodes() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(s.client, cluster)

--- a/validation/nodescaling/rke2k3s/scaling_node_driver_test.go
+++ b/validation/nodescaling/rke2k3s/scaling_node_driver_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/scalinginput"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/validation/nodescaling"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
@@ -134,6 +135,10 @@ func (s *NodeScalingTestSuite) TestScalingNodePools() {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(s.client, cluster)

--- a/validation/prime/autoscaling/auto_scaling_test.go
+++ b/validation/prime/autoscaling/auto_scaling_test.go
@@ -123,6 +123,14 @@ func TestAutoScalingUp(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, s.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			err = pods.VerifyClusterPods(s.client, cluster)
+			require.NoError(t, err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, s.cattleConfig)
@@ -185,6 +193,14 @@ func TestAutoScalingDown(t *testing.T) {
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
 
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			err = pods.VerifyClusterPods(s.client, cluster)
+			require.NoError(t, err)
+
 			logrus.Infof("Verifying cluster autoscaler (%s)", cluster.Name)
 			scaling.VerifyAutoscaler(t, s.client, cluster)
 
@@ -210,8 +226,12 @@ func TestAutoScalingDown(t *testing.T) {
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
 
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.client, cluster)
+			require.NoError(t, err)
+
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
-			err = pods.VerifyClusterPods(tt.client, cluster)
+			err = pods.VerifyClusterPods(s.client, cluster)
 			require.NoError(t, err)
 		})
 
@@ -311,6 +331,14 @@ func TestAutoScalingPause(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, s.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			err = pods.VerifyClusterPods(s.client, cluster)
+			require.NoError(t, err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, s.cattleConfig)

--- a/validation/provisioning/dualstack/k3s_custom_test.go
+++ b/validation/provisioning/dualstack/k3s_custom_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -149,6 +150,10 @@ func TestCustomK3SDualstack(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/dualstack/k3s_node_driver_test.go
+++ b/validation/provisioning/dualstack/k3s_node_driver_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -133,6 +134,10 @@ func TestNodeDriverK3S(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/dualstack/rke2_custom_test.go
+++ b/validation/provisioning/dualstack/rke2_custom_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -135,6 +136,10 @@ func TestCustomRKE2Dualstack(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/dualstack/rke2_node_driver_test.go
+++ b/validation/provisioning/dualstack/rke2_node_driver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -120,6 +121,10 @@ func TestNodeDriverRKE2(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/ipv6/k3s_custom_test.go
+++ b/validation/provisioning/ipv6/k3s_custom_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -148,6 +149,10 @@ func TestCustomK3SIPv6(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/ipv6/k3s_node_driver_test.go
+++ b/validation/provisioning/ipv6/k3s_node_driver_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -141,6 +142,10 @@ func TestNodeDriverK3SIPv6(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/ipv6/rke2_custom_test.go
+++ b/validation/provisioning/ipv6/rke2_custom_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -135,6 +136,10 @@ func TestCustomRKE2IPv6(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/ipv6/rke2_node_driver_test.go
+++ b/validation/provisioning/ipv6/rke2_node_driver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -128,6 +129,10 @@ func TestNodeDriverRKE2IPv6(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/k3s/ace_test.go
+++ b/validation/provisioning/k3s/ace_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -111,6 +112,10 @@ func TestACE(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/k3s/custom_test.go
+++ b/validation/provisioning/k3s/custom_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -109,6 +110,10 @@ func TestCustom(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/k3s/data_directories_test.go
+++ b/validation/provisioning/k3s/data_directories_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -112,6 +113,10 @@ func TestDataDirectories(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/k3s/dynamic_custom_test.go
+++ b/validation/provisioning/k3s/dynamic_custom_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/reports"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -106,6 +107,10 @@ func TestDynamicCustom(t *testing.T) {
 
 				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 				provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+				logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+				err = deployment.VerifyClusterDeployments(tt.client, cluster)
+				require.NoError(t, err)
 
 				logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 				err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/k3s/dynamic_node_driver_test.go
+++ b/validation/provisioning/k3s/dynamic_node_driver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/config/permutationdata"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -102,6 +103,10 @@ func TestDynamicNodeDriver(t *testing.T) {
 
 				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 				provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+				logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+				err = deployment.VerifyClusterDeployments(tt.client, cluster)
+				require.NoError(t, err)
 
 				logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 				err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/k3s/hardened_test.go
+++ b/validation/provisioning/k3s/hardened_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/reports"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	cis "github.com/rancher/tests/validation/provisioning/resources/cisbenchmark"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -105,6 +106,10 @@ func TestHardened(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/k3s/hostname_truncation_test.go
+++ b/validation/provisioning/k3s/hostname_truncation_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -106,6 +107,10 @@ func TestHostnameTruncation(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/k3s/node_driver_test.go
+++ b/validation/provisioning/k3s/node_driver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -109,6 +110,10 @@ func TestNodeDriver(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/k3s/psact_test.go
+++ b/validation/provisioning/k3s/psact_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -106,6 +107,10 @@ func TestPSACT(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, tt.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)

--- a/validation/provisioning/k3s/template_test.go
+++ b/validation/provisioning/k3s/template_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -119,6 +120,12 @@ func TestTemplate(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, k.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(k.client, cluster)
+			if err != nil {
+				logrus.Warningf("Deployment verification received an error: %v", err)
+			}
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(k.client, cluster)

--- a/validation/provisioning/resources/provisioncluster/provision_cluster.go
+++ b/validation/provisioning/resources/provisioncluster/provision_cluster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/stretchr/testify/require"
 )
@@ -48,6 +49,10 @@ func ProvisionRKE2K3SCluster(t *testing.T, client *rancher.Client, clusterType s
 		require.NoError(t, err)
 
 		provisioning.VerifyClusterReady(t, client, clusterObject)
+
+		err = deployment.VerifyClusterDeployments(client, clusterObject)
+		require.NoError(t, err)
+
 		err = pods.VerifyClusterPods(client, clusterObject)
 		require.NoError(t, err)
 	} else {
@@ -57,6 +62,10 @@ func ProvisionRKE2K3SCluster(t *testing.T, client *rancher.Client, clusterType s
 		require.NoError(t, err)
 
 		provisioning.VerifyClusterReady(t, client, clusterObject)
+
+		err = deployment.VerifyClusterDeployments(client, clusterObject)
+		require.NoError(t, err)
+
 		err = pods.VerifyClusterPods(client, clusterObject)
 		require.NoError(t, err)
 	}

--- a/validation/provisioning/rke2/ace_test.go
+++ b/validation/provisioning/rke2/ace_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -111,6 +112,10 @@ func TestACE(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)

--- a/validation/provisioning/rke2/agent_customization_test.go
+++ b/validation/provisioning/rke2/agent_customization_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -142,6 +143,10 @@ func TestAgentCustomization(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)

--- a/validation/provisioning/rke2/cloud_provider_test.go
+++ b/validation/provisioning/rke2/cloud_provider_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -108,6 +109,10 @@ func TestAWSCloudProvider(t *testing.T) {
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
 
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
+
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(t, err)
@@ -169,6 +174,10 @@ func TestVSphereCloudProvider(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)
@@ -232,6 +241,10 @@ func TestHarvesterCloudProvider(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)

--- a/validation/provisioning/rke2/cni_test.go
+++ b/validation/provisioning/rke2/cni_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -100,6 +101,10 @@ func TestCNI(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)

--- a/validation/provisioning/rke2/custom_test.go
+++ b/validation/provisioning/rke2/custom_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -117,6 +118,10 @@ func TestCustom(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)

--- a/validation/provisioning/rke2/data_directories_test.go
+++ b/validation/provisioning/rke2/data_directories_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -112,6 +113,10 @@ func TestDataDirectories(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)

--- a/validation/provisioning/rke2/dynamic_custom_test.go
+++ b/validation/provisioning/rke2/dynamic_custom_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/reports"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -110,6 +111,10 @@ func TestDynamicCustom(t *testing.T) {
 
 				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 				provisioning.VerifyClusterReady(t, r.client, cluster)
+
+				logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+				err = deployment.VerifyClusterDeployments(tt.client, cluster)
+				require.NoError(t, err)
 
 				logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 				err = pods.VerifyClusterPods(r.client, cluster)

--- a/validation/provisioning/rke2/dynamic_node_driver_test.go
+++ b/validation/provisioning/rke2/dynamic_node_driver_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -106,6 +107,10 @@ func TestDynamicNodeDriver(t *testing.T) {
 
 				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 				provisioning.VerifyClusterReady(t, r.client, cluster)
+
+				logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+				err = deployment.VerifyClusterDeployments(tt.client, cluster)
+				require.NoError(t, err)
 
 				logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 				err = pods.VerifyClusterPods(r.client, cluster)

--- a/validation/provisioning/rke2/hardened_test.go
+++ b/validation/provisioning/rke2/hardened_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/reports"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	cis "github.com/rancher/tests/validation/provisioning/resources/cisbenchmark"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -106,6 +107,10 @@ func TestHardened(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)

--- a/validation/provisioning/rke2/hostname_truncation_test.go
+++ b/validation/provisioning/rke2/hostname_truncation_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -105,6 +106,10 @@ func TestHostnameTruncation(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)

--- a/validation/provisioning/rke2/node_driver_test.go
+++ b/validation/provisioning/rke2/node_driver_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -116,6 +117,10 @@ func TestNodeDriver(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)

--- a/validation/provisioning/rke2/psact_test.go
+++ b/validation/provisioning/rke2/psact_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -122,6 +123,10 @@ func TestPSACT(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)

--- a/validation/provisioning/rke2/template_test.go
+++ b/validation/provisioning/rke2/template_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/reports"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -121,6 +122,12 @@ func TestTemplate(t *testing.T) {
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			provisioning.VerifyClusterReady(t, r.client, cluster)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			if err != nil {
+				logrus.Warningf("Deployment verification received an error: %v", err)
+			}
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)

--- a/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
+++ b/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
@@ -23,7 +23,9 @@ import (
 	rbac "github.com/rancher/tests/actions/rbac"
 	"github.com/rancher/tests/actions/settings"
 	"github.com/rancher/tests/actions/users"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -98,6 +100,10 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCre
 
 	log.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
 	provisioning.VerifyClusterReady(ra.T(), ra.client, clusterObject)
+
+	logrus.Infof("Verifying cluster deployments (%s)", clusterObject.Name)
+	err = deployment.VerifyClusterDeployments(ra.client, clusterObject)
+	require.NoError(ra.T(), err)
 
 	log.Infof("Verifying cluster pods (%s)", clusterObject.Name)
 	err = pods.VerifyClusterPods(ra.client, clusterObject)

--- a/validation/rbac/globalrolesv2/globalroles_v2_test.go
+++ b/validation/rbac/globalrolesv2/globalroles_v2_test.go
@@ -5,6 +5,7 @@ package globalrolesv2
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -21,6 +22,7 @@ import (
 	"github.com/rancher/shepherd/extensions/users"
 	rbacapi "github.com/rancher/tests/actions/kubeapi/rbac"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 
 	"github.com/rancher/tests/actions/rbac"
@@ -174,6 +176,10 @@ func (gr *GlobalRolesV2TestSuite) TestClusterCreationAfterAddingGlobalRoleWithIn
 	require.NoError(gr.T(), err)
 
 	provisioning.VerifyClusterReady(gr.T(), userClient, firstClusterSteveObject)
+
+	err = deployment.VerifyClusterDeployments(gr.client, firstClusterSteveObject)
+	require.NoError(gr.T(), err)
+
 	err = pods.VerifyClusterPods(userClient, firstClusterSteveObject)
 	require.NoError(gr.T(), err)
 
@@ -183,6 +189,11 @@ func (gr *GlobalRolesV2TestSuite) TestClusterCreationAfterAddingGlobalRoleWithIn
 	require.NoError(gr.T(), err)
 
 	provisioning.VerifyClusterReady(gr.T(), userClient, secondClusterSteveObject)
+
+	logrus.Infof("Verifying cluster deployments (%s)", secondClusterSteveObject.Name)
+	err = deployment.VerifyClusterDeployments(gr.client, secondClusterSteveObject)
+	require.NoError(gr.T(), err)
+
 	err = pods.VerifyClusterPods(userClient, secondClusterSteveObject)
 	require.NoError(gr.T(), err)
 
@@ -439,6 +450,11 @@ func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromClu
 	require.NoError(gr.T(), err)
 
 	provisioning.VerifyClusterReady(gr.T(), gr.client, rke2SteveObject)
+
+	logrus.Infof("Verifying cluster deployments (%s)", rke2SteveObject.Name)
+	err = deployment.VerifyClusterDeployments(gr.client, rke2SteveObject)
+	require.NoError(gr.T(), err)
+
 	err = pods.VerifyClusterPods(gr.client, rke2SteveObject)
 	require.NoError(gr.T(), err)
 

--- a/validation/upgrade/kubernetes.go
+++ b/validation/upgrade/kubernetes.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/upgradeinput"
+	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 
 	kcluster "github.com/rancher/shepherd/extensions/kubeapi/cluster"
@@ -86,6 +87,10 @@ func DownstreamCluster(u *suite.Suite, testName string, client *rancher.Client, 
 
 		logrus.Infof("Verifying the cluster is ready (%s)", upgradedCluster.Name)
 		provisioning.VerifyClusterReady(u.T(), client, upgradedCluster)
+
+		logrus.Infof("Verifying cluster deployments (%s)", upgradedCluster.Name)
+		err = deployment.VerifyClusterDeployments(client, upgradedCluster)
+		require.NoError(u.T(), err)
 
 		logrus.Infof("Verifying cluster pods (%s)", upgradedCluster.Name)
 		err = pods.VerifyClusterPods(client, upgradedCluster)


### PR DESCRIPTION
Modularize verify logic

Previously we added a check to the VerifyClusterPods that verifies certain required deployments spin up (SUC, fleet, rancher-webhook, cluster-agent). 

Changes:
* Updated pod/deployment logic to be modular.
* Update deployment logic to have clear error messages instead of "context deadline exxceeded"
* Updated tests to match the new structure.