### PR TITLE
Configure DockerHub registry auth to avoid image pull rate limits

### DIFF
--- a/.github/scripts/platform-qa-create-cattle-config.sh
+++ b/.github/scripts/platform-qa-create-cattle-config.sh
@@ -46,6 +46,16 @@ provisioningInput:
     - "ec2"
 
 clusterConfig:
+  registries:
+    rke2Registries:
+      mirrors:
+        "docker.io":
+          endpoint: ["https://${QA_PRIVATE_REGISTRY_NAME}"]
+      configs:
+        "${QA_PRIVATE_REGISTRY_NAME}":
+          "auth":
+            username: "${DOCKERHUB_USERNAME}"
+            password: "${DOCKERHUB_PASSWORD}"
   machinePools:
   - machinePoolConfig:
       etcd: true

--- a/.github/scripts/platform-qa-provision-downstream-k3s.sh
+++ b/.github/scripts/platform-qa-provision-downstream-k3s.sh
@@ -16,6 +16,9 @@ set -e
 : "${AWS_SECRET_KEY:?AWS secret key not set}"
 : "${CLUSTER_NAME:?Cluster name not set}"
 : "${NETWORK_STACK_PREFERENCE:?Network stack preference not set}"
+: "${QA_PRIVATE_REGISTRY_NAME:?QA private registry name not set}"
+: "${DOCKERHUB_USERNAME:?DockerHub username not set}"
+: "${DOCKERHUB_PASSWORD:?DockerHub password not set}"
 
 API="https://$RANCHER_HOST/v3"
 MACHINECONFIG_NAME="mc-${CLUSTER_NAME}-pool1"
@@ -104,6 +107,15 @@ spec:
   cloudCredentialSecretName: "${CLOUD_CREDENTIAL_ID}"
   kubernetesVersion: ${K3S_VERSION}
   rkeConfig:
+    registries:
+      mirrors:
+        "docker.io":
+          endpoint: ["https://${QA_PRIVATE_REGISTRY_NAME}"]
+      configs:
+        "${QA_PRIVATE_REGISTRY_NAME}":
+          "auth":
+            username: "${DOCKERHUB_USERNAME}"
+            password: "${DOCKERHUB_PASSWORD}"
     machinePools:
       - name: pool1
         quantity: 1

--- a/.github/workflows/platform-qa-test-runner.yml
+++ b/.github/workflows/platform-qa-test-runner.yml
@@ -33,6 +33,7 @@ on:
         required: false
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -89,6 +90,18 @@ jobs:
           chmod 600 ~/.ssh/$SSH_PRIVATE_KEY_NAME.pem
           echo "SSH_PRIVATE_KEY_PATH=$HOME/.ssh" >> $GITHUB_ENV
 
+      - name: Fetch and Set DockerHub Credentials
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Mask Dockerhub Credentials
+        run: |
+          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
+          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
+
       - name: Create Rancher admin token
         id: create-token
         env:
@@ -115,6 +128,9 @@ jobs:
           AWS_VPC_ID: ${{ secrets.PQA_AWS_VPC_ID }}
           AWS_SUBNET_ID: ${{ secrets.PQA_AWS_SUBNET_ID }}
           AWS_SECURITY_GROUP_NAMES: ${{ secrets.PQA_AWS_SECURITY_GROUP_NAMES }}
+          QA_PRIVATE_REGISTRY_NAME: ${{ secrets.QA_PRIVATE_REGISTRY_NAME }}
+          DOCKERHUB_USERNAME: ${{ env.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ env.DOCKERHUB_PASSWORD }}
         run: bash .github/scripts/platform-qa-provision-downstream-k3s.sh
 
       - name: Create cattle config
@@ -124,6 +140,9 @@ jobs:
           QUAY_REGISTRY_NAME: ${{ secrets.QUAY_REGISTRY_NAME }}
           QUAY_REGISTRY_USERNAME: ${{ secrets.QUAY_REGISTRY_USERNAME }}
           QUAY_REGISTRY_PASSWORD: ${{ secrets.QUAY_REGISTRY_PASSWORD }}
+          QA_PRIVATE_REGISTRY_NAME: ${{ secrets.QA_PRIVATE_REGISTRY_NAME }}
+          DOCKERHUB_USERNAME: ${{ env.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ env.DOCKERHUB_PASSWORD }}
           AWS_ACCESS_KEY: ${{ secrets.PQA_AWS_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.PQA_AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}


### PR DESCRIPTION
This PR adds DockerHub registry authentication to avoid image pull rate limits.
- Fetch DockerHub credentials from Vault in the Platform QA test runner workflow
- Configure `rkeConfig.registries` in the cattle config for downstream clusters
