### PR TITLE
Fix typo in get-latest-rancher-tag action

### DIFF
--- a/.github/actions/get-latest-rancher-tag/action.yaml
+++ b/.github/actions/get-latest-rancher-tag/action.yaml
@@ -9,7 +9,7 @@ inputs:
     description: "Path to prime artifacts"
     required: true
 outputs:
-  lateset_tag_v214:
+  latest_tag_v214:
     description: "Latest tag for v2.14"
     value: ${{ steps.set-outputs.outputs.latest_tag_v214 }}
   latest_tag_v213:


### PR DESCRIPTION
### Description
There was a small typo in the `get-latest-rancher-tag` causing an error when running.