### PR TITLE
Add check to skip a release line if it is not available

### DIFF
--- a/.github/actions/get-latest-rancher-tag/action.yaml
+++ b/.github/actions/get-latest-rancher-tag/action.yaml
@@ -30,7 +30,16 @@ runs:
         TAGS=$(curl -s https://api.github.com/repos/rancher/rancher/releases | jq -r '.[].tag_name')
 
         for RELEASE_LINE in $RELEASE_LINES; do
-          LATEST_VERSION=$(curl -s https://api.github.com/repos/rancher/rancher/releases | jq -r '.[].tag_name' | grep -E "^$RELEASE_LINE" | head -n 1)
+          LATEST_VERSION=$(curl -s https://api.github.com/repos/rancher/rancher/releases | jq -r '.[].tag_name' | grep -E "^$RELEASE_LINE" | head -n 1 || true)
+
+          SUFFIX=$(echo "$RELEASE_LINE" | tr -d '.')
+
+          if [[ -z "$LATEST_VERSION" ]]; then
+            echo "No tag found for $RELEASE_LINE, skipping..."
+            eval "LATEST_TAG_${SUFFIX}=''"
+            echo "LATEST_TAG_${SUFFIX}=" >> $GITHUB_ENV
+            continue
+          fi
 
           echo "Latest tag for $RELEASE_LINE: $LATEST_VERSION"
 
@@ -53,15 +62,14 @@ runs:
             fi
           fi
 
-          SUFFIX=$(echo "$RELEASE_LINE" | tr -d '.')
           eval "LATEST_TAG_${SUFFIX}=$LATEST_VERSION"
           echo "LATEST_TAG_${SUFFIX}=$LATEST_VERSION" >> $GITHUB_ENV
         done
       shell: bash
     - id: set-outputs
       run: |
-        echo "latest_tag_v214=$LATEST_TAG_v214" >> $GITHUB_OUTPUT
-        echo "latest_tag_v213=$LATEST_TAG_v213" >> $GITHUB_OUTPUT
-        echo "latest_tag_v212=$LATEST_TAG_v212" >> $GITHUB_OUTPUT
-        echo "latest_tag_v211=$LATEST_TAG_v211" >> $GITHUB_OUTPUT
+        echo "latest_tag_v214=${LATEST_TAG_v214}" >> $GITHUB_OUTPUT
+        echo "latest_tag_v213=${LATEST_TAG_v213}" >> $GITHUB_OUTPUT
+        echo "latest_tag_v212=${LATEST_TAG_v212}" >> $GITHUB_OUTPUT
+        echo "latest_tag_v211=${LATEST_TAG_v211}" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
### Description
Last PR did not fix the issue. The suspicion now is that since 2.14 is not available, that is why it is failing. If so, we should add a check for any community release where if it is not ready in the API, skip to the next release line.

This helps future-proof for upcoming releases.