### PR TITLE
Allow reporting when reporting is set to true

### DIFF
--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -52,7 +52,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -316,7 +316,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -384,7 +384,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -648,7 +648,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -716,7 +716,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -989,7 +989,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1057,7 +1057,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1331,7 +1331,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -52,7 +52,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -296,7 +296,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-dualstack-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -364,7 +364,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -608,7 +608,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-dualstack-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -52,7 +52,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -295,7 +295,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-ipv6-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -363,7 +363,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -606,7 +606,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-ipv6-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -52,7 +52,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -297,7 +297,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-ipv6-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -365,7 +365,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -610,7 +610,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-ipv6-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/post-release-prime.yml
+++ b/.github/workflows/post-release-prime.yml
@@ -51,7 +51,7 @@ jobs:
     environment: prime
     env:
       HOSTNAME_PREFIX: "gha-prime-213"
-      REPORTING_ENABLED: ${{ github.event.inputs.reporting }}
+      REPORTING_ENABLED: ${{ github.event.inputs.reporting == 'true' }}
 
     steps:
       - name: Checkout repository
@@ -239,7 +239,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-prime-ui-checks
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -293,7 +293,7 @@ jobs:
     environment: prime
     env:
       HOSTNAME_PREFIX: "gha-prime-212"
-      REPORTING_ENABLED: ${{ github.event.inputs.reporting }}
+      REPORTING_ENABLED: ${{ github.event.inputs.reporting == 'true' }}
 
     steps:
       - name: Checkout repository
@@ -481,7 +481,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-prime-ui-checks
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -536,7 +536,7 @@ jobs:
     environment: prime
     env:
       HOSTNAME_PREFIX: "gha-prime-211"
-      REPORTING_ENABLED: ${{ github.event.inputs.reporting }}
+      REPORTING_ENABLED: ${{ github.event.inputs.reporting == 'true' }}
 
     steps:
       - name: Checkout repository
@@ -737,7 +737,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-prime-ui-checks
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -52,7 +52,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -321,7 +321,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -390,7 +390,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -659,7 +659,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -728,7 +728,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1007,7 +1007,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1076,7 +1076,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1355,7 +1355,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -58,7 +58,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -306,7 +306,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-dualstack-test-suites
 
       - name: Cleanup Infrastructure
@@ -381,7 +381,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -629,7 +629,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-dualstack-test-suites
 
       - name: Cleanup Infrastructure

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -58,7 +58,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -307,7 +307,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-ipv6-test-suites
 
       - name: Cleanup Infrastructure
@@ -382,7 +382,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -631,7 +631,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-ipv6-test-suites
 
       - name: Cleanup Infrastructure

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -58,7 +58,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -319,7 +319,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
@@ -395,7 +395,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -656,7 +656,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
@@ -732,7 +732,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1002,7 +1002,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
@@ -1078,7 +1078,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1348,7 +1348,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure

--- a/.github/workflows/turtles-cluster-provisioning.yml
+++ b/.github/workflows/turtles-cluster-provisioning.yml
@@ -63,7 +63,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -332,7 +332,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -402,7 +402,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -671,7 +671,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -741,7 +741,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1010,7 +1010,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1080,7 +1080,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1349,7 +1349,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1419,7 +1419,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1688,7 +1688,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1758,7 +1758,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -2027,7 +2027,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -2097,7 +2097,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -2366,7 +2366,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -2436,7 +2436,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -2705,7 +2705,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
@@ -63,7 +63,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -336,7 +336,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -406,7 +406,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -679,7 +679,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -749,7 +749,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1022,7 +1022,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1092,7 +1092,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1365,7 +1365,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1435,7 +1435,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1708,7 +1708,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1778,7 +1778,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -2051,7 +2051,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -2121,7 +2121,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -2394,7 +2394,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()
@@ -2464,7 +2464,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -2737,7 +2737,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/turtles-recurring-tests.yml
+++ b/.github/workflows/turtles-recurring-tests.yml
@@ -69,7 +69,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -335,7 +335,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
@@ -412,7 +412,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -678,7 +678,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
@@ -755,7 +755,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1021,7 +1021,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
@@ -1098,7 +1098,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1364,7 +1364,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
@@ -1441,7 +1441,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -1707,7 +1707,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
@@ -1784,7 +1784,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -2050,7 +2050,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
@@ -2127,7 +2127,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -2393,7 +2393,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure
@@ -2470,7 +2470,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting)
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
     steps:
@@ -2736,7 +2736,7 @@ jobs:
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
         with:
           suite: ${{ matrix.suite }}
-          reporting: env.REPORTING_ENABLED
+          reporting: ${{ env.REPORTING_ENABLED }}
         uses: ./.github/actions/run-hostbusters-test-suites
 
       - name: Cleanup Infrastructure


### PR DESCRIPTION
This resolves an issue where reporting to slack and qase will never be successful, due to a syntax error on inputs, which was introduced in my earlier PR to allow reporting to be toggled on/off.