### PR TITLE
fix reporting issues when failures are seen

### DIFF
--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -364,7 +364,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -696,7 +696,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1037,7 +1037,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1379,7 +1379,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -344,7 +344,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -656,7 +656,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -343,7 +343,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -654,7 +654,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -345,7 +345,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -658,7 +658,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}

--- a/.github/workflows/post-release-prime.yml
+++ b/.github/workflows/post-release-prime.yml
@@ -273,7 +273,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -515,7 +515,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -771,7 +771,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -369,7 +369,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -707,7 +707,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1055,7 +1055,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1403,7 +1403,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -355,7 +355,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -678,7 +678,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -356,7 +356,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -680,7 +680,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -368,7 +368,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -705,7 +705,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1051,7 +1051,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1397,7 +1397,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}

--- a/.github/workflows/turtles-cluster-provisioning.yml
+++ b/.github/workflows/turtles-cluster-provisioning.yml
@@ -380,7 +380,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -719,7 +719,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1058,7 +1058,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1397,7 +1397,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1736,7 +1736,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -2075,7 +2075,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -2414,7 +2414,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -2753,7 +2753,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}

--- a/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
@@ -384,7 +384,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -727,7 +727,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1070,7 +1070,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1413,7 +1413,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1756,7 +1756,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -2099,7 +2099,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -2442,7 +2442,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -2785,7 +2785,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}

--- a/.github/workflows/turtles-recurring-tests.yml
+++ b/.github/workflows/turtles-recurring-tests.yml
@@ -384,7 +384,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -727,7 +727,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1070,7 +1070,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1413,7 +1413,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -1756,7 +1756,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -2099,7 +2099,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -2442,7 +2442,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
@@ -2785,7 +2785,7 @@ jobs:
         id: set-job-status
 
       - name: Reporting Results to Slack
-        if: env.REPORTING_ENABLED == 'true'
+        if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
           job-status: ${{ steps.set-job-status.outputs.job_status }}


### PR DESCRIPTION
Currently, if a test fails, reporting is skipped.  This is not the desired behavior and this PR aims to resolve this by allowing reporting, regardless of errors which may arise during testing.