### PR TITLE
Support triggered workflow reporting

### DIFF
--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -52,6 +52,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -384,6 +385,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -716,6 +718,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1057,6 +1060,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -52,6 +52,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -364,6 +365,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -52,6 +52,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -363,6 +364,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -52,6 +52,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -365,6 +366,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/post-release-prime.yml
+++ b/.github/workflows/post-release-prime.yml
@@ -51,7 +51,11 @@ jobs:
     environment: prime
     env:
       HOSTNAME_PREFIX: "gha-prime-213"
-      REPORTING_ENABLED: ${{ github.event.inputs.reporting == 'true' }}
+      REPORTING_ENABLED: >-
+        ${{
+          github.event_name == 'workflow_call' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
+        }}
 
     steps:
       - name: Checkout repository
@@ -293,7 +297,11 @@ jobs:
     environment: prime
     env:
       HOSTNAME_PREFIX: "gha-prime-212"
-      REPORTING_ENABLED: ${{ github.event.inputs.reporting == 'true' }}
+      REPORTING_ENABLED: >-
+        ${{
+          github.event_name == 'workflow_call' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
+        }}
 
     steps:
       - name: Checkout repository
@@ -536,7 +544,11 @@ jobs:
     environment: prime
     env:
       HOSTNAME_PREFIX: "gha-prime-211"
-      REPORTING_ENABLED: ${{ github.event.inputs.reporting == 'true' }}
+      REPORTING_ENABLED: >-
+        ${{
+          github.event_name == 'workflow_call' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
+        }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -52,6 +52,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -390,6 +391,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -728,6 +730,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1076,6 +1079,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -58,6 +58,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -381,6 +382,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -58,6 +58,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -382,6 +383,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -58,6 +58,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -395,6 +396,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -732,6 +734,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1078,6 +1081,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/turtles-cluster-provisioning.yml
+++ b/.github/workflows/turtles-cluster-provisioning.yml
@@ -63,6 +63,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -402,6 +403,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -741,6 +743,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1080,6 +1083,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1419,6 +1423,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1758,6 +1763,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -2097,6 +2103,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -2436,6 +2443,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
@@ -63,6 +63,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -406,6 +407,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -749,6 +751,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1092,6 +1095,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1435,6 +1439,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1778,6 +1783,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -2121,6 +2127,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -2464,6 +2471,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/turtles-recurring-tests.yml
+++ b/.github/workflows/turtles-recurring-tests.yml
@@ -69,6 +69,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -412,6 +413,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -755,6 +757,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1098,6 +1101,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1441,6 +1445,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1784,6 +1789,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -2127,6 +2133,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -2470,6 +2477,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 


### PR DESCRIPTION
Previous Qase enhancement PRs allow reporting to be toggled for scheduled and manually dispatched workflows only.  This PR aims to spread coverage to also include this enhancement for triggered jobs.