### PR TITLE
Set reporting to true if the actor is github-actions[bot]

### DIFF
--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -53,6 +53,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -386,6 +387,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -719,6 +721,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1061,6 +1064,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -53,6 +53,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -366,6 +367,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -53,6 +53,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -365,6 +366,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -53,6 +53,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -367,6 +368,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/post-release-prime.yml
+++ b/.github/workflows/post-release-prime.yml
@@ -54,6 +54,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -300,6 +301,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -547,6 +549,7 @@ jobs:
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -53,6 +53,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -392,6 +393,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -731,6 +733,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1080,6 +1083,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -59,6 +59,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -383,6 +384,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -59,6 +59,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -384,6 +385,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -59,6 +59,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -397,6 +398,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -735,6 +737,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1082,6 +1085,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/turtles-cluster-provisioning.yml
+++ b/.github/workflows/turtles-cluster-provisioning.yml
@@ -64,6 +64,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -404,6 +405,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -744,6 +746,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1084,6 +1087,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1424,6 +1428,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1764,6 +1769,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -2104,6 +2110,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -2444,6 +2451,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
@@ -64,6 +64,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -408,6 +409,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -752,6 +754,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1096,6 +1099,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1440,6 +1444,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1784,6 +1789,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -2128,6 +2134,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -2472,6 +2479,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 

--- a/.github/workflows/turtles-recurring-tests.yml
+++ b/.github/workflows/turtles-recurring-tests.yml
@@ -70,6 +70,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -414,6 +415,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -758,6 +760,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1102,6 +1105,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1446,6 +1450,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -1790,6 +1795,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -2134,6 +2140,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 
@@ -2478,6 +2485,7 @@ jobs:
         ${{
           github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
         }}
 


### PR DESCRIPTION
### Description
This change has already been merged in `rancher/tfp-automation` and is confirmed to be working. For the alphas, the results are not being reported to Qase or slack. Digging into it, it is because the `github-actions[bot]` is not explicitly called out in the reporting block.

Simple change to add that.