### PR TITLE
Enhance GHA workflows to properly use private registry

### DIFF
--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -218,6 +218,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -227,6 +229,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -552,6 +555,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -561,6 +566,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -895,6 +901,8 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -904,6 +912,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -218,6 +218,8 @@ jobs:
               serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -227,6 +229,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -532,6 +535,8 @@ jobs:
               serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -541,6 +546,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -218,6 +218,8 @@ jobs:
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -227,6 +229,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -531,6 +534,8 @@ jobs:
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -540,6 +545,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -220,6 +220,8 @@ jobs:
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -229,6 +231,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -535,6 +538,8 @@ jobs:
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -544,6 +549,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -225,6 +225,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -234,6 +236,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -565,6 +568,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -574,6 +579,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -915,6 +921,8 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -924,6 +932,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -228,6 +228,8 @@ jobs:
               serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -237,6 +239,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -553,6 +556,8 @@ jobs:
               serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -562,6 +567,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -230,6 +230,8 @@ jobs:
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -239,6 +241,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -556,6 +559,8 @@ jobs:
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -565,6 +570,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/turtles-cluster-provisioning.yml
+++ b/.github/workflows/turtles-cluster-provisioning.yml
@@ -232,6 +232,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -241,6 +243,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -573,6 +576,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -582,6 +587,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -914,6 +920,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -923,6 +931,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -1255,6 +1264,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -1264,6 +1275,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -1596,6 +1608,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -1605,6 +1619,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -1937,6 +1952,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -1946,6 +1963,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -2278,6 +2296,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -2287,6 +2307,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -2619,6 +2640,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -2628,6 +2651,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
@@ -238,6 +238,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -247,6 +249,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -583,6 +586,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -592,6 +597,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -928,6 +934,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -937,6 +945,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -1273,6 +1282,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -1282,6 +1293,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -1618,6 +1630,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -1627,6 +1641,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -1963,6 +1978,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -1972,6 +1989,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -2308,6 +2326,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -2317,6 +2337,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -2653,6 +2674,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -2662,6 +2685,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/turtles-recurring-tests.yml
+++ b/.github/workflows/turtles-recurring-tests.yml
@@ -235,6 +235,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -244,6 +246,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -580,6 +583,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -589,6 +594,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -925,6 +931,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -934,6 +942,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -1270,6 +1279,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -1279,6 +1290,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -1615,6 +1627,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -1624,6 +1638,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -1960,6 +1975,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -1969,6 +1986,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -2305,6 +2323,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -2314,6 +2334,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
@@ -2650,6 +2671,8 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             compliance: true
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -2659,6 +2682,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"


### PR DESCRIPTION
### Description
When provisioning clusters, it was noted that the private registry was not being used. This is because the config was incorrect and did not have the registry username/password specified where needed. As a result, none of the GHA workflows are using it either. 

When dealing with the 429 requests we have been seeing, we need to ensure that we have this enhancement to limit the amount where possible.