### PR TITLE
Temporarily remove workloads checks in various tests

### DIFF
--- a/validation/provisioning/dualstack/k3s_custom_test.go
+++ b/validation/provisioning/dualstack/k3s_custom_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -157,17 +156,6 @@ func TestCustomK3SDualstack(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)
-			require.NoError(t, err)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, k.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(k.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(k.client, cluster.Name, *workloadConfigs)
 			require.NoError(t, err)
 		})
 

--- a/validation/provisioning/dualstack/k3s_node_driver_test.go
+++ b/validation/provisioning/dualstack/k3s_node_driver_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -141,17 +140,6 @@ func TestNodeDriverK3S(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)
-			require.NoError(t, err)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, k.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(k.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(k.client, cluster.Name, *workloadConfigs)
 			require.NoError(t, err)
 		})
 

--- a/validation/provisioning/dualstack/rke2_custom_test.go
+++ b/validation/provisioning/dualstack/rke2_custom_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -143,17 +142,6 @@ func TestCustomRKE2Dualstack(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)
-			require.NoError(t, err)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, r.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(r.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(r.client, cluster.Name, *workloadConfigs)
 			require.NoError(t, err)
 		})
 

--- a/validation/provisioning/dualstack/rke2_node_driver_test.go
+++ b/validation/provisioning/dualstack/rke2_node_driver_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -128,17 +127,6 @@ func TestNodeDriverRKE2(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)
-			require.NoError(t, err)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, r.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(r.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(r.client, cluster.Name, *workloadConfigs)
 			require.NoError(t, err)
 		})
 

--- a/validation/provisioning/ipv6/k3s_custom_test.go
+++ b/validation/provisioning/ipv6/k3s_custom_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -156,17 +155,6 @@ func TestCustomK3SIPv6(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)
-			require.NoError(t, err)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, r.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(r.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(r.client, cluster.Name, *workloadConfigs)
 			require.NoError(t, err)
 		})
 

--- a/validation/provisioning/ipv6/k3s_node_driver_test.go
+++ b/validation/provisioning/ipv6/k3s_node_driver_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -151,16 +150,6 @@ func TestNodeDriverK3SIPv6(t *testing.T) {
 			err = pods.VerifyClusterPods(tt.client, cluster)
 			require.NoError(t, err)
 
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, r.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(r.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(r.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/ipv6/rke2_custom_test.go
+++ b/validation/provisioning/ipv6/rke2_custom_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -143,17 +142,6 @@ func TestCustomRKE2IPv6(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)
-			require.NoError(t, err)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, r.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(r.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(r.client, cluster.Name, *workloadConfigs)
 			require.NoError(t, err)
 		})
 

--- a/validation/provisioning/ipv6/rke2_node_driver_test.go
+++ b/validation/provisioning/ipv6/rke2_node_driver_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -136,17 +135,6 @@ func TestNodeDriverRKE2IPv6(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)
-			require.NoError(t, err)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, r.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(r.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(r.client, cluster.Name, *workloadConfigs)
 			require.NoError(t, err)
 		})
 

--- a/validation/provisioning/k3s/custom_test.go
+++ b/validation/provisioning/k3s/custom_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -117,17 +116,6 @@ func TestCustom(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)
-			require.NoError(t, err)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, k.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(k.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(k.client, cluster.Name, *workloadConfigs)
 			require.NoError(t, err)
 		})
 

--- a/validation/provisioning/k3s/hardened_test.go
+++ b/validation/provisioning/k3s/hardened_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/reports"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	cis "github.com/rancher/tests/validation/provisioning/resources/cisbenchmark"
@@ -147,17 +146,6 @@ func TestHardened(t *testing.T) {
 
 			logrus.Infof("Running CIS scan on cluster (%s)", cluster.Name)
 			cis.RunCISScan(tt.client, k.project.ClusterID, tt.scanProfileName)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, k.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(k.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(k.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
 		})
 
 		params := provisioning.GetCustomSchemaParams(tt.client, k.cattleConfig)

--- a/validation/provisioning/k3s/node_driver_test.go
+++ b/validation/provisioning/k3s/node_driver_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -117,17 +116,6 @@ func TestNodeDriver(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)
-			require.NoError(t, err)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, k.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(k.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(k.client, cluster.Name, *workloadConfigs)
 			require.NoError(t, err)
 		})
 

--- a/validation/provisioning/rke2/cni_test.go
+++ b/validation/provisioning/rke2/cni_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -108,17 +107,6 @@ func TestCNI(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)
-			require.NoError(t, err)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, r.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(r.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(r.client, cluster.Name, *workloadConfigs)
 			require.NoError(t, err)
 		})
 

--- a/validation/provisioning/rke2/custom_test.go
+++ b/validation/provisioning/rke2/custom_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -125,17 +124,6 @@ func TestCustom(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)
-			require.NoError(t, err)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, r.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(r.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(r.client, cluster.Name, *workloadConfigs)
 			require.NoError(t, err)
 		})
 

--- a/validation/provisioning/rke2/hardened_test.go
+++ b/validation/provisioning/rke2/hardened_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/reports"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	cis "github.com/rancher/tests/validation/provisioning/resources/cisbenchmark"
@@ -148,17 +147,6 @@ func TestHardened(t *testing.T) {
 
 			logrus.Infof("Running CIS scan on cluster (%s)", cluster.Name)
 			cis.RunCISScan(tt.client, r.project.ClusterID, tt.scanProfileName)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, r.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(r.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(r.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
 		})
 
 		params := provisioning.GetCustomSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/rke2/node_driver_test.go
+++ b/validation/provisioning/rke2/node_driver_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/workloads"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -124,17 +123,6 @@ func TestNodeDriver(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)
-			require.NoError(t, err)
-
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, r.cattleConfig, workloadConfigs)
-
-			logrus.Infof("Creating workloads (%s)", cluster.Name)
-			workloadConfigs, err = workloads.CreateWorkloads(r.client, cluster.Name, *workloadConfigs)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying workloads (%s)", cluster.Name)
-			_, err = workloads.VerifyWorkloads(r.client, cluster.Name, *workloadConfigs)
 			require.NoError(t, err)
 		})
 


### PR DESCRIPTION
### Description
This PR is temporarily removing the workload checks in various provisioning/provisioning checks. While not ideal, there are a number of issues in the GHA workflows from them.

We should take a step back, ensure these are consistently fine and them bring them back. Some of these, however, are due to Docker abuse limits, which isn't directly in our control.