### PR TITLE
Update GHA 2.14 jobs to use new environments

### DIFF
--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -46,7 +46,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     env:
       HOSTNAME_PREFIX: "gha-prov-214"
       REPORTING_ENABLED: >-

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -46,7 +46,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     env:
       HOSTNAME_PREFIX: "gha-ds-214"
       REPORTING_ENABLED: >-

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -46,7 +46,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     env:
       HOSTNAME_PREFIX: "gha6-ds-214"
       REPORTING_ENABLED: >-

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -46,7 +46,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     env:
       HOSTNAME_PREFIX: "gha6-prov-214"
       REPORTING_ENABLED: >-

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -46,7 +46,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: upgrade-community-head
     env:
       HOSTNAME_PREFIX: "gha-up-214"
       REPORTING_ENABLED: >-

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -46,7 +46,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -46,7 +46,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -46,7 +46,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/turtles-cluster-provisioning.yml
+++ b/.github/workflows/turtles-cluster-provisioning.yml
@@ -57,7 +57,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.turtles, 'false'))
     name: "[v214] turtles OFF"
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     env:
       HOSTNAME_PREFIX: "tp-off-214"
       REPORTING_ENABLED: >-
@@ -402,7 +402,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.turtles, 'true'))
     name: "[v214] turtles ON"
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     env:
       HOSTNAME_PREFIX: "tp-on-214"
       REPORTING_ENABLED: >-
@@ -747,7 +747,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.turtles, 'toggledOn'))
     name: "[v214] turtles toggled ON"
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     env:
       HOSTNAME_PREFIX: "tp-ton-214"
       REPORTING_ENABLED: >-
@@ -1092,7 +1092,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.turtles, 'toggledOff'))
     name: "[v214] turtles toggled OFF"
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     env:
       HOSTNAME_PREFIX: "tp-toff-214"
       REPORTING_ENABLED: >-

--- a/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/turtles-rancher-upgrade-cluster-provisioning.yml
@@ -57,7 +57,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.upgraded_turtles, 'false'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_13 }} -> v2-14 - turtles OFF
     runs-on: ubuntu-latest
-    environment: latest
+    environment: upgrade-community-head
     env:
       HOSTNAME_PREFIX: "tpu-off-214"
       REPORTING_ENABLED: >-
@@ -406,7 +406,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.upgraded_turtles, 'true'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_13 }} -> v2-14 - turtles ON
     runs-on: ubuntu-latest
-    environment: latest
+    environment: upgrade-community-head
     env:
       HOSTNAME_PREFIX: "tpu-on-214"
       REPORTING_ENABLED: >-
@@ -755,7 +755,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.upgraded_turtles, 'toggledOn'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_13 }} -> v2-14 - turtles toggled ON
     runs-on: ubuntu-latest
-    environment: latest
+    environment: upgrade-community-head
     env:
       HOSTNAME_PREFIX: "tpu-ton-214"
       REPORTING_ENABLED: >-
@@ -1104,7 +1104,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.upgraded_turtles, 'toggledOff'))
     name: ${{ vars.RELEASED_RANCHER_VERSION_2_13 }} -> v2-14 - turtles toggled OFF
     runs-on: ubuntu-latest
-    environment: latest
+    environment: upgrade-community-head
     env:
       HOSTNAME_PREFIX: "tpu-toff-214"
       REPORTING_ENABLED: >-

--- a/.github/workflows/turtles-recurring-tests.yml
+++ b/.github/workflows/turtles-recurring-tests.yml
@@ -57,7 +57,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.turtles, 'false'))
     name: "[v2-14] turtles OFF"
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     strategy:
       fail-fast: false
       matrix:
@@ -406,7 +406,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.turtles, 'true'))
     name: "[v2-14] turtles ON"
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     strategy:
       fail-fast: false
       matrix:
@@ -755,7 +755,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.turtles, 'toggledOn'))
     name: "[v2-14] turtles toggled ON"
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     strategy:
       fail-fast: false
       matrix:
@@ -1104,7 +1104,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.turtles, 'toggledOff'))
     name: "[v2-14] turtles toggled OFF"
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     strategy:
       fail-fast: false
       matrix:

--- a/actions/go.mod
+++ b/actions/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/qase-tms/qase-go/qase-api-client v1.2.0
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be
-	github.com/rancher/tfp-automation v0.0.0-20251219210947-f4a1a9882c29
+	github.com/rancher/tfp-automation v0.0.0-20260126225050-e17784ebc431
 )
 
 require (

--- a/actions/go.sum
+++ b/actions/go.sum
@@ -266,8 +266,8 @@ github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be h1:x7+nxYLCqygc5T
 github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be/go.mod h1:SJtW8Jqv0rphZzsGnvB965YdyR2FqFtB+TbbzVLt8F4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078 h1:1MJSgYkgXhr/Zc5idJkKa10SiBQd0HVtbxVOBoghlzY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078/go.mod h1:CV2Soy/Skw8/SA9dDJVgpeHxoEdtjYkNpNy6xvvC5kA=
-github.com/rancher/tfp-automation v0.0.0-20251219210947-f4a1a9882c29 h1:K7gKqQy8w4oPlm85x/t3WjMhHPi0nQTX49RMzJnkGK0=
-github.com/rancher/tfp-automation v0.0.0-20251219210947-f4a1a9882c29/go.mod h1:RjYzdxC3g1MOBrAR4/F210qnW+oqrD0HWNwAR1XYnCM=
+github.com/rancher/tfp-automation v0.0.0-20260126225050-e17784ebc431 h1:o7ct+rHgC2F8fedrkTTdK4L4IkrAerhdNTnA4rUQF10=
+github.com/rancher/tfp-automation v0.0.0-20260126225050-e17784ebc431/go.mod h1:VsLwhPUC2mmngFj34NVDEOmsllj7HuPnBYJLEjPAzUo=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=
 github.com/rancher/wrangler v1.1.2/go.mod h1:2k9MyhlBdjcutcBGoOJSUAz0HgDAXnMjv81d3n/AaQc=
 github.com/rancher/wrangler/v3 v3.3.1 h1:YFqRfhxjuLNudUrvWrn+64wUPZ8pnn2KWbTsha75JLg=

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be
 	github.com/rancher/tests/actions v0.0.0-20260105193042-a805683addc3
 	github.com/rancher/tests/interoperability v0.0.0-00010101000000-000000000000
-	github.com/rancher/tfp-automation v0.0.0-20251219210947-f4a1a9882c29
+	github.com/rancher/tfp-automation v0.0.0-20260126225050-e17784ebc431
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2192,8 +2192,8 @@ github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be h1:x7+nxYLCqygc5T
 github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be/go.mod h1:SJtW8Jqv0rphZzsGnvB965YdyR2FqFtB+TbbzVLt8F4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078 h1:1MJSgYkgXhr/Zc5idJkKa10SiBQd0HVtbxVOBoghlzY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078/go.mod h1:CV2Soy/Skw8/SA9dDJVgpeHxoEdtjYkNpNy6xvvC5kA=
-github.com/rancher/tfp-automation v0.0.0-20251219210947-f4a1a9882c29 h1:K7gKqQy8w4oPlm85x/t3WjMhHPi0nQTX49RMzJnkGK0=
-github.com/rancher/tfp-automation v0.0.0-20251219210947-f4a1a9882c29/go.mod h1:RjYzdxC3g1MOBrAR4/F210qnW+oqrD0HWNwAR1XYnCM=
+github.com/rancher/tfp-automation v0.0.0-20260126225050-e17784ebc431 h1:o7ct+rHgC2F8fedrkTTdK4L4IkrAerhdNTnA4rUQF10=
+github.com/rancher/tfp-automation v0.0.0-20260126225050-e17784ebc431/go.mod h1:VsLwhPUC2mmngFj34NVDEOmsllj7HuPnBYJLEjPAzUo=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/interoperability/go.mod
+++ b/interoperability/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be
 	github.com/rancher/tests/actions v0.0.0-20260105193042-a805683addc3
-	github.com/rancher/tfp-automation v0.0.0-20251219210947-f4a1a9882c29
+	github.com/rancher/tfp-automation v0.0.0-20260126225050-e17784ebc431
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/interoperability/go.sum
+++ b/interoperability/go.sum
@@ -2085,8 +2085,8 @@ github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be h1:x7+nxYLCqygc5T
 github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be/go.mod h1:SJtW8Jqv0rphZzsGnvB965YdyR2FqFtB+TbbzVLt8F4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078 h1:1MJSgYkgXhr/Zc5idJkKa10SiBQd0HVtbxVOBoghlzY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078/go.mod h1:CV2Soy/Skw8/SA9dDJVgpeHxoEdtjYkNpNy6xvvC5kA=
-github.com/rancher/tfp-automation v0.0.0-20251219210947-f4a1a9882c29 h1:K7gKqQy8w4oPlm85x/t3WjMhHPi0nQTX49RMzJnkGK0=
-github.com/rancher/tfp-automation v0.0.0-20251219210947-f4a1a9882c29/go.mod h1:RjYzdxC3g1MOBrAR4/F210qnW+oqrD0HWNwAR1XYnCM=
+github.com/rancher/tfp-automation v0.0.0-20260126225050-e17784ebc431 h1:o7ct+rHgC2F8fedrkTTdK4L4IkrAerhdNTnA4rUQF10=
+github.com/rancher/tfp-automation v0.0.0-20260126225050-e17784ebc431/go.mod h1:VsLwhPUC2mmngFj34NVDEOmsllj7HuPnBYJLEjPAzUo=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=


### PR DESCRIPTION
### Description
In debugging failing 2.14 runs today, it was noted through offline discussions that there are now two services in a Rancher install: `rancher` and `rancher-internal`. The backend code has already been merged in `rancher/tfp-automation`, so the `go.mod` updates are needed here, along with the environment updates in GHA workflows.