### PR TITLE
Fix flakiness for custom cluster tests

### DIFF
--- a/actions/provisioning/creates.go
+++ b/actions/provisioning/creates.go
@@ -304,19 +304,6 @@ func CreateProvisioningCustomCluster(client *rancher.Client, externalNodeProvide
 		return nil, err
 	}
 
-	kubeProvisioningClient, err := client.GetKubeAPIProvisioningClient()
-	if err != nil {
-		return nil, err
-	}
-
-	result, err := kubeProvisioningClient.Clusters(namespaces.FleetDefault).Watch(context.TODO(), metav1.ListOptions{
-		FieldSelector:  "metadata.name=" + clusterName,
-		TimeoutSeconds: &defaults.WatchTimeoutSeconds,
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	logrus.Debugf("Registering linux nodes (%s)", clusterName)
 
 	var command string
@@ -355,8 +342,7 @@ func CreateProvisioningCustomCluster(client *rancher.Client, externalNodeProvide
 		totalNodesObserved += int(quantityPerPool[poolIndex])
 	}
 
-	checkFunc := shepherdclusters.IsProvisioningClusterReady
-	err = wait.WatchWait(result, checkFunc)
+	err = VerifyClusterReady(client, customCluster)
 	if err != nil {
 		return nil, err
 	}

--- a/actions/provisioning/permutations/permutations.go
+++ b/actions/provisioning/permutations/permutations.go
@@ -87,7 +87,8 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						require.NoError(s.T(), err)
 
 						logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
-						provisioning.VerifyClusterReady(s.T(), client, clusterObject)
+						err = provisioning.VerifyClusterReady(client, clusterObject)
+						require.NoError(s.T(), err)
 
 						logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
 						err = pods.VerifyClusterPods(client, clusterObject)
@@ -123,7 +124,8 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						require.NoError(s.T(), err)
 
 						logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
-						provisioning.VerifyClusterReady(s.T(), client, clusterObject)
+						err = provisioning.VerifyClusterReady(client, clusterObject)
+						require.NoError(s.T(), err)
 
 						logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
 						err = pods.VerifyClusterPods(client, clusterObject)
@@ -160,7 +162,8 @@ func RunTestPermutations(s *suite.Suite, testNamePrefix string, client *rancher.
 						require.NoError(s.T(), err)
 
 						logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
-						provisioning.VerifyClusterReady(s.T(), client, clusterObject)
+						err = provisioning.VerifyClusterReady(client, clusterObject)
+						require.NoError(s.T(), err)
 
 						logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
 						err = pods.VerifyClusterPods(client, clusterObject)

--- a/validation/auth/kubeconfigs/kubeconfigs_test.go
+++ b/validation/auth/kubeconfigs/kubeconfigs_test.go
@@ -73,9 +73,12 @@ func (kc *ExtKubeconfigTestSuite) SetupSuite() {
 	cluster2ID, err := clusters.GetClusterIDByName(kc.client, clusterObject2.Name)
 	require.NoError(kc.T(), err)
 
-	provisioning.VerifyClusterReady(kc.T(), client, aceClusterObject1)
-	provisioning.VerifyClusterReady(kc.T(), client, aceClusterObject2)
-	provisioning.VerifyClusterReady(kc.T(), client, clusterObject2)
+	err = provisioning.VerifyClusterReady(client, aceClusterObject1)
+	require.NoError(kc.T(), err)
+	err = provisioning.VerifyClusterReady(client, aceClusterObject2)
+	require.NoError(kc.T(), err)
+	err = provisioning.VerifyClusterReady(client, clusterObject2)
+	require.NoError(kc.T(), err)
 
 	err = deployment.VerifyClusterDeployments(client, aceClusterObject1)
 	require.NoError(kc.T(), err)

--- a/validation/certificates/k3s/cert_rotation_test.go
+++ b/validation/certificates/k3s/cert_rotation_test.go
@@ -101,7 +101,8 @@ func (c *CertRotationTestSuite) TestCertRotation() {
 			require.NoError(c.T(), certificates.RotateCerts(c.client, tt.cluster.Name))
 
 			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
-			provisioning.VerifyClusterReady(c.T(), c.client, tt.cluster)
+			err = provisioning.VerifyClusterReady(c.client, tt.cluster)
+			require.NoError(c.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
 			err = deployment.VerifyClusterDeployments(c.client, tt.cluster)

--- a/validation/certificates/k3s/dualstack/cert_rotation_test.go
+++ b/validation/certificates/k3s/dualstack/cert_rotation_test.go
@@ -100,7 +100,8 @@ func (c *CertRotationDualstackTestSuite) TestCertRotationDualstack() {
 			require.NoError(c.T(), certificates.RotateCerts(c.client, tt.cluster.Name))
 
 			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
-			provisioning.VerifyClusterReady(c.T(), c.client, tt.cluster)
+			err = provisioning.VerifyClusterReady(c.client, tt.cluster)
+			require.NoError(c.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
 			err = deployment.VerifyClusterDeployments(c.client, tt.cluster)

--- a/validation/certificates/k3s/ipv6/cert_rotation_test.go
+++ b/validation/certificates/k3s/ipv6/cert_rotation_test.go
@@ -100,7 +100,8 @@ func (c *CertRotationIPv6TestSuite) TestCertRotationIPv6() {
 			require.NoError(c.T(), certificates.RotateCerts(c.client, tt.cluster.Name))
 
 			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
-			provisioning.VerifyClusterReady(c.T(), c.client, tt.cluster)
+			err = provisioning.VerifyClusterReady(c.client, tt.cluster)
+			require.NoError(c.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
 			err = deployment.VerifyClusterDeployments(c.client, tt.cluster)

--- a/validation/certificates/rke2/cert_rotation_test.go
+++ b/validation/certificates/rke2/cert_rotation_test.go
@@ -100,7 +100,8 @@ func (c *CertRotationTestSuite) TestCertRotation() {
 			require.NoError(c.T(), certificates.RotateCerts(c.client, tt.cluster.Name))
 
 			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
-			provisioning.VerifyClusterReady(c.T(), c.client, tt.cluster)
+			err = provisioning.VerifyClusterReady(c.client, tt.cluster)
+			require.NoError(c.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
 			err = deployment.VerifyClusterDeployments(c.client, tt.cluster)

--- a/validation/certificates/rke2/cert_rotation_wins_test.go
+++ b/validation/certificates/rke2/cert_rotation_wins_test.go
@@ -124,7 +124,8 @@ func (c *CertRotationWindowsTestSuite) TestCertRotationWindows() {
 			require.NoError(c.T(), certificates.RotateCerts(c.client, tt.cluster.Name))
 
 			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
-			provisioning.VerifyClusterReady(c.T(), c.client, tt.cluster)
+			err = provisioning.VerifyClusterReady(c.client, tt.cluster)
+			require.NoError(c.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
 			err = deployment.VerifyClusterDeployments(c.client, tt.cluster)

--- a/validation/certificates/rke2/dualstack/cert_rotation_test.go
+++ b/validation/certificates/rke2/dualstack/cert_rotation_test.go
@@ -100,7 +100,8 @@ func (c *CertRotationDualstackTestSuite) TestCertRotationDualstack() {
 			require.NoError(c.T(), certificates.RotateCerts(c.client, tt.cluster.Name))
 
 			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
-			provisioning.VerifyClusterReady(c.T(), c.client, tt.cluster)
+			err = provisioning.VerifyClusterReady(c.client, tt.cluster)
+			require.NoError(c.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
 			err = deployment.VerifyClusterDeployments(c.client, tt.cluster)

--- a/validation/certificates/rke2/ipv6/cert_rotation_test.go
+++ b/validation/certificates/rke2/ipv6/cert_rotation_test.go
@@ -100,7 +100,8 @@ func (c *CertRotationIPv6TestSuite) TestCertRotationIPv6() {
 			require.NoError(c.T(), certificates.RotateCerts(c.client, tt.cluster.Name))
 
 			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
-			provisioning.VerifyClusterReady(c.T(), c.client, tt.cluster)
+			err = provisioning.VerifyClusterReady(c.client, tt.cluster)
+			require.NoError(c.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
 			err = deployment.VerifyClusterDeployments(c.client, tt.cluster)

--- a/validation/charts/backup_restore/backup_restore.go
+++ b/validation/charts/backup_restore/backup_restore.go
@@ -318,7 +318,8 @@ func createRKE2dsCluster(t *testing.T, client *rancher.Client) (*v1.SteveAPIObje
 	}
 
 	logrus.Infof("Verifying the cluster is ready (%s)", steveObject.Name)
-	provisioning.VerifyClusterReady(t, client, steveObject)
+	err = provisioning.VerifyClusterReady(client, steveObject)
+	require.NoError(t, err)
 
 	logrus.Infof("Verifying cluster deployments (%s)", steveObject.Name)
 	err = deployment.VerifyClusterDeployments(client, steveObject)

--- a/validation/charts/backup_restore/backup_restore_test.go
+++ b/validation/charts/backup_restore/backup_restore_test.go
@@ -117,7 +117,8 @@ func (b *BackupTestSuite) TestS3InPlaceRestore() {
 	provisioning.VerifyRKE1Cluster(b.T(), b.client, rke1ClusterConfig, rke1ClusterObj)
 
 	logrus.Infof("Verifying the cluster is ready (%s)", rke2SteveObj.Name)
-	provisioning.VerifyClusterReady(b.T(), b.client, rke2SteveObj)
+	err = provisioning.VerifyClusterReady(b.client, rke2SteveObj)
+	require.NoError(b.T(), err)
 
 	logrus.Infof("Verifying cluster deployments (%s)", rke2SteveObj.Name)
 	err = deployment.VerifyClusterDeployments(b.client, rke2SteveObj)

--- a/validation/deleting/k3s/delete_init_machine_test.go
+++ b/validation/deleting/k3s/delete_init_machine_test.go
@@ -105,7 +105,8 @@ func (d *DeleteInitMachineTestSuite) TestDeleteInitMachine() {
 			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
-			provisioning.VerifyClusterReady(d.T(), d.client, tt.cluster)
+			err = provisioning.VerifyClusterReady(d.client, tt.cluster)
+			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
 			err = deployment.VerifyClusterDeployments(d.client, tt.cluster)

--- a/validation/deleting/k3s/dualstack/delete_init_machine_test.go
+++ b/validation/deleting/k3s/dualstack/delete_init_machine_test.go
@@ -105,7 +105,8 @@ func (d *DeleteInitMachineDualstackTestSuite) TestDeleteInitMachineDualstack() {
 			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
-			provisioning.VerifyClusterReady(d.T(), d.client, tt.cluster)
+			err = provisioning.VerifyClusterReady(d.client, tt.cluster)
+			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
 			err = deployment.VerifyClusterDeployments(d.client, tt.cluster)

--- a/validation/deleting/k3s/ipv6/delete_init_machine_test.go
+++ b/validation/deleting/k3s/ipv6/delete_init_machine_test.go
@@ -105,7 +105,8 @@ func (d *DeleteInitMachineIPv6TestSuite) TestDeleteInitMachineIPv6() {
 			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
-			provisioning.VerifyClusterReady(d.T(), d.client, tt.cluster)
+			err = provisioning.VerifyClusterReady(d.client, tt.cluster)
+			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
 			err = deployment.VerifyClusterDeployments(d.client, tt.cluster)

--- a/validation/deleting/rke2/delete_init_machine_test.go
+++ b/validation/deleting/rke2/delete_init_machine_test.go
@@ -105,7 +105,8 @@ func (d *DeleteInitMachineTestSuite) TestDeleteInitMachine() {
 			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
-			provisioning.VerifyClusterReady(d.T(), d.client, tt.cluster)
+			err = provisioning.VerifyClusterReady(d.client, tt.cluster)
+			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
 			err = deployment.VerifyClusterDeployments(d.client, tt.cluster)

--- a/validation/deleting/rke2/dualstack/delete_init_machine_test.go
+++ b/validation/deleting/rke2/dualstack/delete_init_machine_test.go
@@ -105,7 +105,8 @@ func (d *DeleteInitMachineDualstackTestSuite) TestDeleteInitMachineDualstack() {
 			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
-			provisioning.VerifyClusterReady(d.T(), d.client, tt.cluster)
+			err = provisioning.VerifyClusterReady(d.client, tt.cluster)
+			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
 			err = deployment.VerifyClusterDeployments(d.client, tt.cluster)

--- a/validation/deleting/rke2/ipv6/delete_init_machine_test.go
+++ b/validation/deleting/rke2/ipv6/delete_init_machine_test.go
@@ -105,7 +105,8 @@ func (d *DeleteInitMachineIPv6TestSuite) TestDeleteInitMachineIPv6() {
 			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
-			provisioning.VerifyClusterReady(d.T(), d.client, tt.cluster)
+			err = provisioning.VerifyClusterReady(d.client, tt.cluster)
+			require.NoError(d.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
 			err = deployment.VerifyClusterDeployments(d.client, tt.cluster)

--- a/validation/fleet/provisioning/airgap/fleet_in_airgap_test.go
+++ b/validation/fleet/provisioning/airgap/fleet_in_airgap_test.go
@@ -179,7 +179,8 @@ func (a *AirGapRKE2CustomClusterTestSuite) TestCustomClusterWithGitRepo() {
 		require.NoError(a.T(), err)
 
 		logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
-		provisioning.VerifyClusterReady(a.T(), a.standardClient, clusterObject)
+		err = provisioning.VerifyClusterReady(a.standardClient, clusterObject)
+		require.NoError(a.T(), err)
 
 		logrus.Infof("Verifying cluster deployments (%s)", clusterObject.Name)
 		err = deployment.VerifyClusterDeployments(a.standardClient, clusterObject)

--- a/validation/fleet/provisioning/new_cluster_existing_gitrepo_test.go
+++ b/validation/fleet/provisioning/new_cluster_existing_gitrepo_test.go
@@ -184,7 +184,8 @@ func (f *FleetWithProvisioningTestSuite) TestHardenedAfterAddedGitRepo() {
 			require.NoError(f.T(), err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
-			provisioning.VerifyClusterReady(f.T(), tt.client, clusterObject)
+			err = provisioning.VerifyClusterReady(tt.client, clusterObject)
+			require.NoError(f.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", clusterObject.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, clusterObject)
@@ -283,7 +284,8 @@ func (f *FleetWithProvisioningTestSuite) TestWindowsAfterAddedGitRepo() {
 			require.NoError(f.T(), err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
-			provisioning.VerifyClusterReady(f.T(), tt.client, clusterObject)
+			err = provisioning.VerifyClusterReady(tt.client, clusterObject)
+			require.NoError(f.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", clusterObject.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, clusterObject)

--- a/validation/harvester/provisioning/cloud_provider_test.go
+++ b/validation/harvester/provisioning/cloud_provider_test.go
@@ -72,7 +72,8 @@ func (p *HarvesterProvisioningTestSuite) TestCloudProvider() {
 	require.NoError(p.T(), err)
 
 	logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-	provisioning.VerifyClusterReady(p.T(), p.client, cluster)
+	err = provisioning.VerifyClusterReady(p.client, cluster)
+	require.NoError(p.T(), err)
 
 	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 	err = deployment.VerifyClusterDeployments(p.client, cluster)

--- a/validation/nodescaling/dualstack/scaling_test.go
+++ b/validation/nodescaling/dualstack/scaling_test.go
@@ -127,7 +127,8 @@ func (s *NodeScalingDualstackTestSuite) TestScalingDualstackNodePools() {
 			nodescaling.ScalingRKE2K3SCustomClusterPools(s.T(), s.client, tt.clusterID, s.scalingConfig.NodeProvider, tt.nodeRoles, awsEC2Configs, tt.clusterConfig)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+			err = provisioning.VerifyClusterReady(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(s.client, cluster)

--- a/validation/nodescaling/ipv6/scaling_test.go
+++ b/validation/nodescaling/ipv6/scaling_test.go
@@ -117,7 +117,8 @@ func (s *NodeScalingIPv6TestSuite) TestScalingIPv6NodePools() {
 			nodescaling.ScalingRKE2K3SNodePools(s.T(), s.client, tt.clusterID, tt.nodeRoles)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+			err = provisioning.VerifyClusterReady(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(s.client, cluster)

--- a/validation/nodescaling/rke2k3s/auto_replace_existing_cluster_test.go
+++ b/validation/nodescaling/rke2k3s/auto_replace_existing_cluster_test.go
@@ -83,7 +83,8 @@ func (s *AutoReplaceExistingClusterSuite) TestAutoReplaceExistingCluster() {
 			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+			err = provisioning.VerifyClusterReady(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(s.client, cluster)

--- a/validation/nodescaling/rke2k3s/auto_replace_test.go
+++ b/validation/nodescaling/rke2k3s/auto_replace_test.go
@@ -101,7 +101,8 @@ func (s *AutoReplaceSuite) TestAutoReplace() {
 			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+			err = provisioning.VerifyClusterReady(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(s.client, cluster)

--- a/validation/nodescaling/rke2k3s/scale_replace_test.go
+++ b/validation/nodescaling/rke2k3s/scale_replace_test.go
@@ -119,7 +119,8 @@ func (s *NodeReplacingTestSuite) TestReplacingNodes() {
 			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+			err = provisioning.VerifyClusterReady(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(s.client, cluster)

--- a/validation/nodescaling/rke2k3s/scaling_custom_cluster_test.go
+++ b/validation/nodescaling/rke2k3s/scaling_custom_cluster_test.go
@@ -144,7 +144,8 @@ func (s *CustomClusterNodeScalingTestSuite) TestScalingCustomClusterNodes() {
 			nodescaling.ScalingRKE2K3SCustomClusterPools(s.T(), s.client, tt.clusterID, s.scalingConfig.NodeProvider, tt.nodeRoles, awsEC2Configs, tt.clusterConfig)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+			err = provisioning.VerifyClusterReady(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(s.client, cluster)

--- a/validation/nodescaling/rke2k3s/scaling_node_driver_test.go
+++ b/validation/nodescaling/rke2k3s/scaling_node_driver_test.go
@@ -134,7 +134,8 @@ func (s *NodeScalingTestSuite) TestScalingNodePools() {
 			nodescaling.ScalingRKE2K3SNodePools(s.T(), s.client, tt.clusterID, tt.nodeRoles)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(s.T(), s.client, cluster)
+			err = provisioning.VerifyClusterReady(s.client, cluster)
+			require.NoError(s.T(), err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(s.client, cluster)

--- a/validation/prime/autoscaling/auto_scaling_test.go
+++ b/validation/prime/autoscaling/auto_scaling_test.go
@@ -122,7 +122,8 @@ func TestAutoScalingUp(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, s.client, cluster)
+			err = provisioning.VerifyClusterReady(s.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(s.client, cluster)
@@ -191,7 +192,8 @@ func TestAutoScalingDown(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(s.client, cluster)
@@ -224,7 +226,8 @@ func TestAutoScalingDown(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(s.client, cluster)
@@ -313,7 +316,8 @@ func TestAutoScalingPause(t *testing.T) {
 			require.Error(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, s.client, cluster)
+			err = provisioning.VerifyClusterReady(s.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Unpausing cluster autoscaler (%s)", cluster.Name)
 			err = scaling.UpdateAutoscalerState(s.client, cluster, false)
@@ -330,7 +334,8 @@ func TestAutoScalingPause(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, s.client, cluster)
+			err = provisioning.VerifyClusterReady(s.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(s.client, cluster)

--- a/validation/provisioning/dualstack/k3s_custom_test.go
+++ b/validation/provisioning/dualstack/k3s_custom_test.go
@@ -135,7 +135,8 @@ func TestCustomK3SDualstack(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/dualstack/k3s_node_driver_test.go
+++ b/validation/provisioning/dualstack/k3s_node_driver_test.go
@@ -119,7 +119,8 @@ func TestNodeDriverK3S(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/dualstack/rke2_custom_test.go
+++ b/validation/provisioning/dualstack/rke2_custom_test.go
@@ -134,7 +134,8 @@ func TestCustomRKE2Dualstack(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/dualstack/rke2_node_driver_test.go
+++ b/validation/provisioning/dualstack/rke2_node_driver_test.go
@@ -119,7 +119,8 @@ func TestNodeDriverRKE2(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/ipv6/k3s_custom_test.go
+++ b/validation/provisioning/ipv6/k3s_custom_test.go
@@ -134,7 +134,8 @@ func TestCustomK3SIPv6(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/ipv6/k3s_node_driver_test.go
+++ b/validation/provisioning/ipv6/k3s_node_driver_test.go
@@ -127,7 +127,8 @@ func TestNodeDriverK3SIPv6(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/ipv6/rke2_custom_test.go
+++ b/validation/provisioning/ipv6/rke2_custom_test.go
@@ -134,7 +134,8 @@ func TestCustomRKE2IPv6(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/ipv6/rke2_node_driver_test.go
+++ b/validation/provisioning/ipv6/rke2_node_driver_test.go
@@ -127,7 +127,8 @@ func TestNodeDriverRKE2IPv6(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/k3s/ace_test.go
+++ b/validation/provisioning/k3s/ace_test.go
@@ -111,7 +111,8 @@ func TestACE(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/k3s/custom_test.go
+++ b/validation/provisioning/k3s/custom_test.go
@@ -108,7 +108,8 @@ func TestCustom(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/k3s/data_directories_test.go
+++ b/validation/provisioning/k3s/data_directories_test.go
@@ -112,7 +112,8 @@ func TestDataDirectories(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/k3s/dynamic_custom_test.go
+++ b/validation/provisioning/k3s/dynamic_custom_test.go
@@ -106,7 +106,8 @@ func TestDynamicCustom(t *testing.T) {
 				require.NoError(t, err)
 
 				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-				provisioning.VerifyClusterReady(t, tt.client, cluster)
+				err = provisioning.VerifyClusterReady(tt.client, cluster)
+				require.NoError(t, err)
 
 				logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 				err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/k3s/dynamic_node_driver_test.go
+++ b/validation/provisioning/k3s/dynamic_node_driver_test.go
@@ -102,7 +102,8 @@ func TestDynamicNodeDriver(t *testing.T) {
 				require.NoError(t, err)
 
 				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-				provisioning.VerifyClusterReady(t, tt.client, cluster)
+				err = provisioning.VerifyClusterReady(tt.client, cluster)
+				require.NoError(t, err)
 
 				logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 				err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/k3s/hardened_test.go
+++ b/validation/provisioning/k3s/hardened_test.go
@@ -104,7 +104,8 @@ func TestHardened(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/k3s/hostname_truncation_test.go
+++ b/validation/provisioning/k3s/hostname_truncation_test.go
@@ -106,7 +106,8 @@ func TestHostnameTruncation(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/k3s/node_driver_test.go
+++ b/validation/provisioning/k3s/node_driver_test.go
@@ -108,7 +108,8 @@ func TestNodeDriver(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/k3s/psact_test.go
+++ b/validation/provisioning/k3s/psact_test.go
@@ -106,7 +106,8 @@ func TestPSACT(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, tt.client, cluster)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/k3s/template_test.go
+++ b/validation/provisioning/k3s/template_test.go
@@ -119,7 +119,8 @@ func TestTemplate(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, k.client, cluster)
+			err = provisioning.VerifyClusterReady(k.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(k.client, cluster)

--- a/validation/provisioning/registries/registry_test.go
+++ b/validation/provisioning/registries/registry_test.go
@@ -348,7 +348,8 @@ func (rt *RegistryTestSuite) TestRegistriesK3S() {
 				require.NoError(rt.T(), err)
 
 				logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
-				provisioning.VerifyClusterReady(rt.T(), subClient, clusterObject)
+				err = provisioning.VerifyClusterReady(subClient, clusterObject)
+				require.NoError(rt.T(), err)
 
 				logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
 				err = actionspods.VerifyClusterPods(subClient, clusterObject)
@@ -376,7 +377,8 @@ func (rt *RegistryTestSuite) TestRegistriesK3S() {
 				require.NoError(rt.T(), err)
 
 				logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
-				provisioning.VerifyClusterReady(rt.T(), subClient, clusterObject)
+				err = provisioning.VerifyClusterReady(subClient, clusterObject)
+				require.NoError(rt.T(), err)
 
 				logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
 				err = actionspods.VerifyClusterPods(subClient, clusterObject)
@@ -430,7 +432,8 @@ func (rt *RegistryTestSuite) TestRegistriesRKE2() {
 				require.NoError(rt.T(), err)
 
 				logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
-				provisioning.VerifyClusterReady(rt.T(), subClient, clusterObject)
+				err = provisioning.VerifyClusterReady(subClient, clusterObject)
+				require.NoError(rt.T(), err)
 
 				logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
 				err = actionspods.VerifyClusterPods(subClient, clusterObject)
@@ -456,7 +459,8 @@ func (rt *RegistryTestSuite) TestRegistriesRKE2() {
 				require.NoError(rt.T(), err)
 
 				logrus.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
-				provisioning.VerifyClusterReady(rt.T(), subClient, clusterObject)
+				err = provisioning.VerifyClusterReady(subClient, clusterObject)
+				require.NoError(rt.T(), err)
 
 				logrus.Infof("Verifying cluster pods (%s)", clusterObject.Name)
 				err = actionspods.VerifyClusterPods(subClient, clusterObject)

--- a/validation/provisioning/resources/provisioncluster/provision_cluster.go
+++ b/validation/provisioning/resources/provisioncluster/provision_cluster.go
@@ -48,7 +48,8 @@ func ProvisionRKE2K3SCluster(t *testing.T, client *rancher.Client, clusterType s
 		clusterObject, err = provisioning.CreateProvisioningCustomCluster(client, &externalNodeProvider, &clusterConfig, ec2Configs)
 		require.NoError(t, err)
 
-		provisioning.VerifyClusterReady(t, client, clusterObject)
+		err = provisioning.VerifyClusterReady(client, clusterObject)
+		require.NoError(t, err)
 
 		err = deployment.VerifyClusterDeployments(client, clusterObject)
 		require.NoError(t, err)
@@ -61,7 +62,8 @@ func ProvisionRKE2K3SCluster(t *testing.T, client *rancher.Client, clusterType s
 		clusterObject, err = provisioning.CreateProvisioningCluster(client, provider, credentialSpec, &clusterConfig, machineConfigs, nil)
 		require.NoError(t, err)
 
-		provisioning.VerifyClusterReady(t, client, clusterObject)
+		err = provisioning.VerifyClusterReady(client, clusterObject)
+		require.NoError(t, err)
 
 		err = deployment.VerifyClusterDeployments(client, clusterObject)
 		require.NoError(t, err)

--- a/validation/provisioning/rke2/ace_test.go
+++ b/validation/provisioning/rke2/ace_test.go
@@ -111,7 +111,8 @@ func TestACE(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/rke2/agent_customization_test.go
+++ b/validation/provisioning/rke2/agent_customization_test.go
@@ -142,7 +142,8 @@ func TestAgentCustomization(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/rke2/cloud_provider_test.go
+++ b/validation/provisioning/rke2/cloud_provider_test.go
@@ -107,7 +107,8 @@ func TestAWSCloudProvider(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)
@@ -173,7 +174,8 @@ func TestVSphereCloudProvider(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)
@@ -240,7 +242,8 @@ func TestHarvesterCloudProvider(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/rke2/cni_test.go
+++ b/validation/provisioning/rke2/cni_test.go
@@ -99,7 +99,8 @@ func TestCNI(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/rke2/custom_test.go
+++ b/validation/provisioning/rke2/custom_test.go
@@ -116,7 +116,8 @@ func TestCustom(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/rke2/data_directories_test.go
+++ b/validation/provisioning/rke2/data_directories_test.go
@@ -112,7 +112,8 @@ func TestDataDirectories(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/rke2/dynamic_custom_test.go
+++ b/validation/provisioning/rke2/dynamic_custom_test.go
@@ -110,7 +110,8 @@ func TestDynamicCustom(t *testing.T) {
 				require.NoError(t, err)
 
 				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-				provisioning.VerifyClusterReady(t, r.client, cluster)
+				err = provisioning.VerifyClusterReady(r.client, cluster)
+				require.NoError(t, err)
 
 				logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 				err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/rke2/dynamic_node_driver_test.go
+++ b/validation/provisioning/rke2/dynamic_node_driver_test.go
@@ -106,7 +106,8 @@ func TestDynamicNodeDriver(t *testing.T) {
 				require.NoError(t, err)
 
 				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-				provisioning.VerifyClusterReady(t, r.client, cluster)
+				err = provisioning.VerifyClusterReady(r.client, cluster)
+				require.NoError(t, err)
 
 				logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 				err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/rke2/hardened_test.go
+++ b/validation/provisioning/rke2/hardened_test.go
@@ -105,7 +105,8 @@ func TestHardened(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/rke2/hostname_truncation_test.go
+++ b/validation/provisioning/rke2/hostname_truncation_test.go
@@ -105,7 +105,8 @@ func TestHostnameTruncation(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/rke2/node_driver_test.go
+++ b/validation/provisioning/rke2/node_driver_test.go
@@ -115,7 +115,8 @@ func TestNodeDriver(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/rke2/psact_test.go
+++ b/validation/provisioning/rke2/psact_test.go
@@ -122,7 +122,8 @@ func TestPSACT(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/provisioning/rke2/template_test.go
+++ b/validation/provisioning/rke2/template_test.go
@@ -121,7 +121,8 @@ func TestTemplate(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			provisioning.VerifyClusterReady(t, r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
 			err = deployment.VerifyClusterDeployments(tt.client, cluster)

--- a/validation/rbac/clusterandprojectroles/membership_roles_test.go
+++ b/validation/rbac/clusterandprojectroles/membership_roles_test.go
@@ -58,7 +58,8 @@ func (mr *MembershipRolesTestSuite) TestClusterRolesOnClusterCreationAndDeletion
 	createdClusterID, err := clusters.GetClusterIDByName(mr.client, clusterObj.Name)
 	require.NoError(mr.T(), err)
 
-	provisioning.VerifyClusterReady(mr.T(), mr.client, clusterObj)
+	err = provisioning.VerifyClusterReady(mr.client, clusterObj)
+	require.NoError(mr.T(), err)
 	err = deployment.VerifyClusterDeployments(mr.client, clusterObj)
 	require.NoError(mr.T(), err)
 	err = pods.VerifyClusterPods(mr.client, clusterObj)

--- a/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
+++ b/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
@@ -99,7 +99,8 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementCre
 	require.NoError(ra.T(), err)
 
 	log.Infof("Verifying the cluster is ready (%s)", clusterObject.Name)
-	provisioning.VerifyClusterReady(ra.T(), ra.client, clusterObject)
+	err = provisioning.VerifyClusterReady(ra.client, clusterObject)
+	require.NoError(ra.T(), err)
 
 	logrus.Infof("Verifying cluster deployments (%s)", clusterObject.Name)
 	err = deployment.VerifyClusterDeployments(ra.client, clusterObject)

--- a/validation/rbac/globalrolesv2/globalroles_v2_test.go
+++ b/validation/rbac/globalrolesv2/globalroles_v2_test.go
@@ -175,7 +175,8 @@ func (gr *GlobalRolesV2TestSuite) TestClusterCreationAfterAddingGlobalRoleWithIn
 	_, firstClusterSteveObject, _, err := createDownstreamCluster(userClient, "K3S")
 	require.NoError(gr.T(), err)
 
-	provisioning.VerifyClusterReady(gr.T(), userClient, firstClusterSteveObject)
+	err = provisioning.VerifyClusterReady(userClient, firstClusterSteveObject)
+	require.NoError(gr.T(), err)
 
 	err = deployment.VerifyClusterDeployments(gr.client, firstClusterSteveObject)
 	require.NoError(gr.T(), err)
@@ -188,7 +189,8 @@ func (gr *GlobalRolesV2TestSuite) TestClusterCreationAfterAddingGlobalRoleWithIn
 	_, secondClusterSteveObject, _, err := createDownstreamCluster(userClient, "K3S")
 	require.NoError(gr.T(), err)
 
-	provisioning.VerifyClusterReady(gr.T(), userClient, secondClusterSteveObject)
+	err = provisioning.VerifyClusterReady(userClient, secondClusterSteveObject)
+	require.NoError(gr.T(), err)
 
 	logrus.Infof("Verifying cluster deployments (%s)", secondClusterSteveObject.Name)
 	err = deployment.VerifyClusterDeployments(gr.client, secondClusterSteveObject)
@@ -449,7 +451,8 @@ func (gr *GlobalRolesV2TestSuite) TestUserWithInheritedClusterRolesImpactFromClu
 	_, rke2SteveObject, _, err := createDownstreamCluster(gr.client, "RKE2")
 	require.NoError(gr.T(), err)
 
-	provisioning.VerifyClusterReady(gr.T(), gr.client, rke2SteveObject)
+	err = provisioning.VerifyClusterReady(gr.client, rke2SteveObject)
+	require.NoError(gr.T(), err)
 
 	logrus.Infof("Verifying cluster deployments (%s)", rke2SteveObject.Name)
 	err = deployment.VerifyClusterDeployments(gr.client, rke2SteveObject)

--- a/validation/snapshot/k3s/snapshot_restore_test.go
+++ b/validation/snapshot/k3s/snapshot_restore_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 const (
-	containerImage        = "nginx"
-	windowsContainerImage = "mcr.microsoft.com/windows/servercore/iis"
+	containerImage = "nginx"
 )
 
 type SnapshotRestoreTestSuite struct {

--- a/validation/snapshot/rke2/snapshot_restore_test.go
+++ b/validation/snapshot/rke2/snapshot_restore_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 const (
-	containerImage        = "nginx"
-	windowsContainerImage = "mcr.microsoft.com/windows/servercore/iis"
+	containerImage = "nginx"
 )
 
 type SnapshotRestoreTestSuite struct {

--- a/validation/snapshot/rke2/snapshot_restore_wins_test.go
+++ b/validation/snapshot/rke2/snapshot_restore_wins_test.go
@@ -28,6 +28,10 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const (
+	windowsContainerImage = "mcr.microsoft.com/windows/servercore/iis"
+)
+
 type SnapshotRestoreWindowsTestSuite struct {
 	suite.Suite
 	session      *session.Session

--- a/validation/upgrade/kubernetes.go
+++ b/validation/upgrade/kubernetes.go
@@ -78,7 +78,8 @@ func DownstreamCluster(u *suite.Suite, testName string, client *rancher.Client, 
 		require.NoError(u.T(), err)
 
 		logrus.Infof("Verifying the cluster is ready (%s)", upgradedCluster.Name)
-		provisioning.VerifyClusterReady(u.T(), client, upgradedCluster)
+		err = provisioning.VerifyClusterReady(client, upgradedCluster)
+		require.NoError(u.T(), err)
 
 		logrus.Infof("Verifying cluster deployments (%s)", upgradedCluster.Name)
 		err = deployment.VerifyClusterDeployments(client, upgradedCluster)

--- a/validation/upgrade/workload.go
+++ b/validation/upgrade/workload.go
@@ -68,7 +68,6 @@ const (
 	servicePortName                            = "port"
 	servicePortNumber                          = 80
 	volumeMountPath                            = "/root/usr/"
-	windowsContainerImage                      = "mcr.microsoft.com/windows/servercore/iis"
 )
 
 // createPreUpgradeWorkloads creates workloads in the downstream cluster before the upgrade.

--- a/validation/upgrade/workload_test.go
+++ b/validation/upgrade/workload_test.go
@@ -16,6 +16,10 @@ import (
 
 var verifyIngress = true
 
+const (
+	windowsContainerImage = "mcr.microsoft.com/windows/servercore/iis"
+)
+
 type UpgradeWorkloadTestSuite struct {
 	suite.Suite
 	session  *session.Session


### PR DESCRIPTION
Currently the custom cluster tests occasionally fail with a context deadline exceeded error. This can also occur in all custom cluster tests across the framework

Changes:
* Updated the VerifyClusterReady func to return an error to the user 
Note: this brings it inline with our other verifications and allows it to be reused in funcs without requiring testing T. In this case I added it to the custom cluster provisioning since its not flakey in comparison to the watch func.
* Updated the Timeout for VerifyDeployment to handle windows deployments.
* Updated the logging around VerifyDeployment to report the last known status when a context deadline is exceeded.


While this PR does help fix custom cluster flakiness and make flakiness in windows tests less frequent it will not solve all snapshot restore flakiness as there are other deep rooted issues that are still present in the snapshot package.