### PR TITLE
Add post-provisioning check for ETCD S3 configuration

### DIFF
--- a/actions/etcdsnapshot/creates.go
+++ b/actions/etcdsnapshot/creates.go
@@ -703,3 +703,12 @@ func createDeployment(steveclient *steveV1.Client, wlName string, deployment *v1
 
 	return deploymentResp, err
 }
+
+// This function validates that spec.rkeConfig.etcd.s3 is not null for S3-specific snapshot tests.
+func VerifyS3Config(cluster *apisV1.Cluster) error {
+	if cluster.Spec.RKEConfig == nil ||
+		cluster.Spec.RKEConfig.ETCD.S3 == nil {
+		return fmt.Errorf("expected S3 config to be set, but spec.rkeConfig.etcd.s3 is empty")
+	}
+	return nil
+}

--- a/validation/snapshot/k3s/snapshot_s3_restore_test.go
+++ b/validation/snapshot/k3s/snapshot_s3_restore_test.go
@@ -105,6 +105,9 @@ func (s *S3SnapshotRestoreTestSuite) TestS3SnapshotRestore() {
 
 			err = etcdsnapshot.CreateAndValidateSnapshotRestore(s.client, cluster.Name, tt.etcdSnapshot, containerImage)
 			require.NoError(s.T(), err)
+
+			err = etcdsnapshot.VerifyS3Config(s.cluster)
+			require.NoError(s.T(), err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(s.client, s.cattleConfig)

--- a/validation/snapshot/rke2/snapshot_s3_restore_test.go
+++ b/validation/snapshot/rke2/snapshot_s3_restore_test.go
@@ -105,6 +105,9 @@ func (s *S3SnapshotRestoreTestSuite) TestS3SnapshotRestore() {
 
 			err = etcdsnapshot.CreateAndValidateSnapshotRestore(s.client, cluster.Name, tt.etcdSnapshot, containerImage)
 			require.NoError(s.T(), err)
+
+			err = etcdsnapshot.VerifyS3Config(s.cluster)
+			require.NoError(s.T(), err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(s.client, s.cattleConfig)


### PR DESCRIPTION
This PR adds a post-provisioning validation to S3 snapshot restore tests to ensure the cluster was created with ETCD S3 configuration enabled.