### PR TITLE
Enhance error logging for `VerifyClusterPods()`

### DIFF
--- a/actions/workloads/pods/verify.go
+++ b/actions/workloads/pods/verify.go
@@ -9,7 +9,6 @@ import (
 
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
-	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
@@ -22,11 +21,14 @@ import (
 )
 
 const (
-	Webhook      = "rancher-webhook"
-	SUC          = "system-upgrade-controller"
-	Fleet        = "fleet-agent"
-	ClusterAgent = "cattle-cluster-agent"
-	helmPrefix   = "helm"
+	Webhook          = "rancher-webhook"
+	SUC              = "system-upgrade-controller"
+	Fleet            = "fleet-agent"
+	ClusterAgent     = "cattle-cluster-agent"
+	helmPrefix       = "helm"
+	errImagePull     = "ErrImagePull"
+	imagePullBackOff = "ImagePullBackOff"
+	crashLoopBackOff = "CrashLoopBackOff"
 )
 
 // VerifyReadyDaemonsetPods tries to poll the Steve API to verify the expected number of daemonset pods are in the Ready
@@ -67,54 +69,134 @@ func VerifyReadyDaemonsetPods(t *testing.T, client *rancher.Client, cluster *v1.
 	assert.Truef(t, daemonsetequals, "Ready Daemonset Pods didn't match expected")
 }
 
-// VerifyClusterPods validates that all pods (excluding the helm pods) are in a good state.
-func VerifyClusterPods(client *rancher.Client, cluster *steveV1.SteveAPIObject) error {
+// VerifyClusterPods validates that all pods (excluding Helm pods) are in a good state.
+func VerifyClusterPods(client *rancher.Client, cluster *v1.SteveAPIObject) error {
 	status := &provv1.ClusterStatus{}
-	err := steveV1.ConvertToK8sType(cluster.Status, status)
-	if err != nil {
+	if err := v1.ConvertToK8sType(cluster.Status, status); err != nil {
 		return err
 	}
 
-	var podErrors []error
-	err = kwait.PollUntilContextTimeout(context.TODO(), 10*time.Second, defaults.TenMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
-		downstreamClient, err := client.Steve.ProxyDownstream(status.ClusterName)
-		if err != nil {
-			return false, nil
-		}
+	badPodsMap := make(map[string]*v1.SteveAPIObject)
 
-		steveClient := downstreamClient.SteveType(stevetypes.Pod)
-
-		podErrors = []error{}
-
-		clusterPods, err := steveClient.List(nil)
-		if err != nil {
-			return false, nil
-		}
-
-		for _, pod := range clusterPods.Data {
-			isReady, err := pods.IsPodReady(&pod)
-			if !isReady {
+	err := kwait.PollUntilContextTimeout(
+		context.TODO(),
+		10*time.Second,
+		defaults.TenMinuteTimeout,
+		true,
+		func(ctx context.Context) (bool, error) {
+			downstreamClient, err := client.Steve.ProxyDownstream(status.ClusterName)
+			if err != nil {
 				return false, nil
 			}
 
+			steveClient := downstreamClient.SteveType(stevetypes.Pod)
+			clusterPods, err := steveClient.List(nil)
 			if err != nil {
-				if !strings.Contains(pod.Name, helmPrefix) {
-					podErrors = append(podErrors, err)
-				} else {
-					logrus.Warningf("Helm pod: %s is not ready", pod.Name)
+				return false, nil
+			}
+
+			badPodsMap = make(map[string]*v1.SteveAPIObject)
+
+			for _, pod := range clusterPods.Data {
+				isHelm := strings.Contains(pod.Name, helmPrefix)
+				if isHelm {
+					continue
+				}
+
+				statusMap, ok := pod.Status.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				statuses, ok := statusMap["containerStatuses"].([]interface{})
+				if !ok {
+					continue
+				}
+
+				for _, s := range statuses {
+					cs, ok := s.(map[string]interface{})
+					if !ok {
+						continue
+					}
+
+					containerName, _ := cs["name"].(string)
+					podState := "NotReady"
+
+					if stateMap, ok := cs["state"].(map[string]interface{}); ok {
+						if waiting, ok := stateMap["waiting"].(map[string]interface{}); ok {
+							if reason, ok := waiting["reason"].(string); ok && reason != "" {
+								podState = reason
+							}
+						} else if terminated, ok := stateMap["terminated"].(map[string]interface{}); ok {
+							if reason, ok := terminated["reason"].(string); ok && reason != "" {
+								podState = reason
+							}
+						}
+					}
+
+					isReady, _ := pods.IsPodReady(&pod)
+					if !isReady && !isHelm {
+						key := pod.Namespace + "/" + pod.Name + "/" + containerName
+
+						if pod.Annotations == nil {
+							pod.Annotations = make(map[string]string)
+						}
+						pod.Annotations["podState"] = podState
+
+						badPodsMap[key] = &pod
+						break
+					}
 				}
 			}
+
+			return len(badPodsMap) == 0, nil
+		},
+	)
+
+	for _, pod := range badPodsMap {
+		images := getPodImages(pod)
+		podState := "NotReady"
+		if state, ok := pod.Annotations["podState"]; ok {
+			podState = state
 		}
 
-		return true, nil
-	})
-
-	if len(podErrors) > 0 {
-		for _, err := range podErrors {
-			logrus.Error(err)
+		fields := logrus.Fields{
+			"pod":    pod.Name,
+			"state":  podState,
+			"images": images,
 		}
-		err = errors.New("Pod error list is not empty")
+		logrus.WithFields(fields).Error("Pod NotReady")
+	}
+
+	if len(badPodsMap) > 0 {
+		return errors.New("Detected pod(s) in a bad state. Check logs for details.")
 	}
 
 	return err
+}
+
+// getPodImages grabs all container images from a pod.
+func getPodImages(pod *v1.SteveAPIObject) []string {
+	var images []string
+
+	statusMap, ok := pod.Status.(map[string]interface{})
+	if !ok {
+		return images
+	}
+
+	statuses, ok := statusMap["containerStatuses"].([]interface{})
+	if !ok {
+		return images
+	}
+
+	for _, s := range statuses {
+		cs, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if image, ok := cs["image"].(string); ok && image != "" {
+			images = append(images, image)
+		}
+	}
+
+	return images
 }


### PR DESCRIPTION
If a pod is in a back state and encounters, `imagePullBackoff`, `ErrImagePull`, or `CrashloopBackoff`, the current behavior retries silently until the poll context deadline is met, then `context deadline exceeded` is seen in our error logs.

This PR aims to enhance this, by logging a pod if in a bad state, so we are able to see what went wrong, without having to re-run the job and "spy" on the problematic behavior observed.