### PR TITLE
Remove hardcoded k8s version suffixes

### DIFF
--- a/.github/scripts/platform-qa-get-k8s-version.sh
+++ b/.github/scripts/platform-qa-get-k8s-version.sh
@@ -5,6 +5,7 @@ set -e
 : "${RANCHER_ADMIN_TOKEN:?RANCHER_ADMIN_TOKEN not set}"
 : "${RANCHER_SHORT_VERSION:?RANCHER_SHORT_VERSION not set}"
 
+# Fetch supported K8s range from Rancher
 RANGE=$(curl -sfk -H "Authorization: Bearer $RANCHER_ADMIN_TOKEN" -H "Accept: application/json"  \
   "https://$RANCHER_HOST/v1/management.cattle.io.settings/ui-k8s-supported-versions-range" \
   | jq -r .value)
@@ -15,29 +16,30 @@ MIN_K8S_RAW=$(echo "$RANGE" | awk '{print substr($1,3)}')
 MAX_K8S_RAW=$(echo "$RANGE" | awk '{print substr($2,3)}') 
 
 DATA_URL="https://releases.rancher.com/kontainer-driver-metadata/dev-v$RANCHER_SHORT_VERSION/data.json"
-K8S_VERSIONS=$(curl -sf "$DATA_URL" \
-  | jq -r '.. | .version? // empty' \
-  | grep '+k3s' \
-  | sed 's/+k3s.*//' \
-  | sort -V)
+ALL_VERSIONS=$(curl -sf "$DATA_URL" | jq -r '.. | .version? // empty')
+
+# Get latest RKE2 and K3S versions
+RKE2_VERSION=$(echo "$ALL_VERSIONS" | egrep 'rke2' | sort -V | tail -n1)
+K3S_VERSION=$(echo "$ALL_VERSIONS" | egrep 'k3s'  | sort -V | tail -n1)
+
+K8S_VERSIONS=$(echo "$ALL_VERSIONS" | egrep 'k3s' | sed 's/+k3s.*//' | sort -V)
 MIN_K8S=$(echo "$K8S_VERSIONS" | grep -E "^${MIN_K8S_RAW%.*}" | head -n1)
 MAX_K8S=$(echo "$K8S_VERSIONS" | grep -E "^${MAX_K8S_RAW%.*}" | tail -n1)
 if [ -z "$MAX_K8S" ]; then
   MAX_K8S=$(echo "$K8S_VERSIONS" | tail -n1)
 fi
 
-K8S_VERSION=$(echo "$K8S_VERSIONS" | sort -V | awk -v min="$MIN_K8S" -v max="$MAX_K8S" '$0 >= min && $0 <= max' | tail -n1)
+K8S_VERSION=$(echo "$K8S_VERSIONS" | awk -v min="$MIN_K8S" -v max="$MAX_K8S" '$0 >= min && $0 <= max' | tail -n1)
 if [ -z "$K8S_VERSION" ]; then
   echo "❌ No valid K8s version found within supported range. Exiting."
   exit 1
 fi
 
 echo "Supported range from Rancher: $RANGE"
-echo "Minimum supported K8s version: $MIN_K8S"
-echo "Maximum supported K8s version: $MAX_K8S"
 echo "K8s version picked for testing: $K8S_VERSION"
-echo "K8S_VERSION=${K8S_VERSION// /}" >> $GITHUB_ENV
-CLEAN_VERSION="${K8S_VERSION#v}"
-echo "RKE2_VERSION=v${CLEAN_VERSION}+rke2r1" >> $GITHUB_ENV
-echo "K3S_VERSION=v${CLEAN_VERSION}+k3s1" >> $GITHUB_ENV
-echo "KUBERNETES_VERSION=v${CLEAN_VERSION}+k3s1" >> $GITHUB_ENV
+echo "RKE2 version: $RKE2_VERSION"
+echo "K3S version: $K3S_VERSION"
+
+echo "RKE2_VERSION=${RKE2_VERSION}" >> $GITHUB_ENV
+echo "K3S_VERSION=${K3S_VERSION}" >> $GITHUB_ENV
+echo "KUBERNETES_VERSION=${K3S_VERSION}" >> $GITHUB_ENV

--- a/.github/scripts/platform-qa-report-to-qase.sh
+++ b/.github/scripts/platform-qa-report-to-qase.sh
@@ -6,11 +6,13 @@ PACKAGE_NAME="${2:-}"
 QASE_TEST_RUN_ID="${3:-}"
 QASE_AUTOMATION_TOKEN="${4:-}"
 
+# Check required arguments
 if [ -z "$RESULTS_JSON" ] || [ -z "$PACKAGE_NAME" ] || [ -z "$QASE_TEST_RUN_ID" ] || [ -z "$QASE_AUTOMATION_TOKEN" ]; then
   echo "Usage: $0 <results_json> <package_name> <qase_test_run_id> <qase_automation_token>"
   exit 1
 fi
 
+# Check that results file exists
 if [ ! -f "$RESULTS_JSON" ]; then
   echo "⚠️ No results file found at $RESULTS_JSON. Skipping Qase reporting."
   exit 0
@@ -26,6 +28,17 @@ PACKAGE_SAFE=$(echo "$PACKAGE_NAME" | tr '/' '_')
 PACKAGE_RESULTS_JSON="$RESULTS_DIR/results_${PACKAGE_SAFE}.json"
 cp "$RESULTS_JSON" "$PACKAGE_RESULTS_JSON"
 
+# Remove skipped tests
+if command -v jq >/dev/null 2>&1; then
+  jq 'map(select(.Status != "skip" and .Status != "skipped"))' "$PACKAGE_RESULTS_JSON" > "$RESULTS_DIR/results.json"
+else
+  echo "❌ jq is required to filter skipped tests"
+  exit 1
+fi
+TEST_COUNT=$(jq length "$RESULTS_DIR/results.json")
+echo "📝 Reporting $TEST_COUNT tests to Qase"
+
+# Build Qase reporter
 REPORTER_SCRIPT="${GITHUB_WORKSPACE}/validation/pipeline/scripts/build_qase_reporter.sh"
 REPORTER_BINARY="${GITHUB_WORKSPACE}/validation/reporter"
 
@@ -37,11 +50,13 @@ if [ ! -f "$REPORTER_BINARY" ]; then
   exit 1
 fi
 
-cp "$PACKAGE_RESULTS_JSON" "$RESULTS_DIR/results.json"
+# Run reporter
 cd "$RESULTS_DIR"
 chmod +x "$REPORTER_BINARY"
 export QASE_TEST_RUN_ID QASE_AUTOMATION_TOKEN
 "$REPORTER_BINARY" --results results.json
+
+# Clean up
 rm -f "${GITHUB_WORKSPACE}/results.xml" "${GITHUB_WORKSPACE}/results.json"
 
 echo "✅ Test Results have been published to Qase (Run ID: $QASE_TEST_RUN_ID) for package: $PACKAGE_NAME"


### PR DESCRIPTION
Currently the Kubernetes version suffixes (k3s1 and rke2r1) are hardcoded.
This PR removes the hardcoded suffixes and derives versions dynamically.