### PR TITLE
Remove start anchor in regex expression for globalrolesv2 webhook test

### DIFF
--- a/validation/rbac/globalrolesv2/globalroles_v2_webhook_test.go
+++ b/validation/rbac/globalrolesv2/globalroles_v2_webhook_test.go
@@ -161,7 +161,7 @@ func (grw *GlobalRolesV2WebhookTestSuite) TestDeleteCustomRoleTemplateInInherite
 	err = rbacapi.DeleteRoleTemplate(grw.client, inheritedRoleTemplate.ID)
 	require.Error(grw.T(), err)
 
-	pattern := "^admission webhook .*" + regexp.QuoteMeta("cannot be deleted because it is inherited by globalRole(s) \"") + regexp.QuoteMeta(gr.Name) + "\"$"
+	pattern := "admission webhook .*" + regexp.QuoteMeta("cannot be deleted because it is inherited by globalRole(s) \"") + regexp.QuoteMeta(gr.Name) + "\"$"
 	require.Regexp(grw.T(), regexp.MustCompile(pattern), err.Error())
 }
 


### PR DESCRIPTION
This PR removes the start anchor in the regex expression for error pattern check in the `TestDeleteCustomRoleTemplateInInheritedClusterRole` test case.