### PR TITLE
Update GlobalRolesV2 to handle ACR binding differences

### DIFF
--- a/actions/kubeapi/rbac/create.go
+++ b/actions/kubeapi/rbac/create.go
@@ -296,8 +296,8 @@ func CreateGroupProjectRoleTemplateBinding(client *rancher.Client, projectID str
 	return prtb, nil
 }
 
-// CreateGlobalRoleWithInheritedClusterRolesWrangler creates a global role with inherited cluster roles using wrangler context
-func CreateGlobalRoleWithInheritedClusterRolesWrangler(client *rancher.Client, inheritedRoles []string) (*v3.GlobalRole, error) {
+// CreateGlobalRoleWithInheritedClusterRoles creates a global role with inherited cluster roles using wrangler context
+func CreateGlobalRoleWithInheritedClusterRoles(client *rancher.Client, inheritedRoles []string) (*v3.GlobalRole, error) {
 	globalRole := v3.GlobalRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namegen.AppendRandomString("testgr"),

--- a/validation/hostedtenant/rbac/hosted_tenant_rbac_test.go
+++ b/validation/hostedtenant/rbac/hosted_tenant_rbac_test.go
@@ -60,7 +60,7 @@ func (h *HostedRancherTestSuite) TestGlobalRoleInheritedClusterRoles() {
 
 	log.Info("Create global role with inheritedClusterRoles")
 	inheritedClusterRoles := []string{rbac.ClusterOwner.String()}
-	createdGlobalRole, err := rbacapi.CreateGlobalRoleWithInheritedClusterRolesWrangler(h.hostClient, inheritedClusterRoles)
+	createdGlobalRole, err := rbacapi.CreateGlobalRoleWithInheritedClusterRoles(h.hostClient, inheritedClusterRoles)
 	require.NoError(h.T(), err)
 
 	log.Info("Verify the global role is created on the hosted Rancher")

--- a/validation/rbac/globalrolesv2/globalroles_v2.go
+++ b/validation/rbac/globalrolesv2/globalroles_v2.go
@@ -121,7 +121,7 @@ func createDownstreamCluster(client *rancher.Client, clusterType string) (*manag
 }
 
 func createGlobalRoleAndUser(client *rancher.Client, inheritedClusterrole []string) (*management.User, *v3.GlobalRole, error) {
-	gr, err := rbacapi.CreateGlobalRoleWithInheritedClusterRolesWrangler(client, inheritedClusterrole)
+	gr, err := rbacapi.CreateGlobalRoleWithInheritedClusterRoles(client, inheritedClusterrole)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/validation/rbac/globalrolesv2/globalroles_v2_webhook_test.go
+++ b/validation/rbac/globalrolesv2/globalroles_v2_webhook_test.go
@@ -116,7 +116,7 @@ func (grw *GlobalRolesV2WebhookTestSuite) TestLockedRoleTemplateInInheritedClust
 	lockedRoleTemplate, err := grw.client.WranglerContext.Mgmt.RoleTemplate().Create(roleTemplate)
 	require.NoError(grw.T(), err)
 
-	_, err = rbacapi.CreateGlobalRoleWithInheritedClusterRolesWrangler(grw.client, []string{lockedRoleTemplate.Name})
+	_, err = rbacapi.CreateGlobalRoleWithInheritedClusterRoles(grw.client, []string{lockedRoleTemplate.Name})
 	require.Error(grw.T(), err)
 
 	pattern := "^failed to create global role with inherited cluster roles: admission webhook.*" + regexp.QuoteMeta(lockedRoleTemplate.Name+"\": unable to use locked roleTemplate") + "$"
@@ -133,7 +133,7 @@ func (grw *GlobalRolesV2WebhookTestSuite) TestAddGlobalRoleWithCustomTemplateAnd
 	customRoleTemplate, err := grw.client.WranglerContext.Mgmt.RoleTemplate().Create(roleTemplate)
 	require.NoError(grw.T(), err)
 
-	_, err = rbacapi.CreateGlobalRoleWithInheritedClusterRolesWrangler(grw.client, []string{customRoleTemplate.Name})
+	_, err = rbacapi.CreateGlobalRoleWithInheritedClusterRoles(grw.client, []string{customRoleTemplate.Name})
 	require.NoError(grw.T(), err)
 
 	customRoleTemplate, err = rbacapi.GetRoleTemplateByName(grw.client, customRoleTemplate.Name)
@@ -155,7 +155,7 @@ func (grw *GlobalRolesV2WebhookTestSuite) TestDeleteCustomRoleTemplateInInherite
 	})
 	require.NoError(grw.T(), err)
 
-	gr, err := rbacapi.CreateGlobalRoleWithInheritedClusterRolesWrangler(grw.client, []string{inheritedRoleTemplate.ID})
+	gr, err := rbacapi.CreateGlobalRoleWithInheritedClusterRoles(grw.client, []string{inheritedRoleTemplate.ID})
 	require.NoError(grw.T(), err)
 
 	err = rbacapi.DeleteRoleTemplate(grw.client, inheritedRoleTemplate.ID)
@@ -175,7 +175,7 @@ func (grw *GlobalRolesV2WebhookTestSuite) TestAddProjectRoleTemplateInInheritedC
 	})
 	require.NoError(grw.T(), err)
 
-	_, err = rbacapi.CreateGlobalRoleWithInheritedClusterRolesWrangler(grw.client, []string{inheritedRoleTemplate.ID})
+	_, err = rbacapi.CreateGlobalRoleWithInheritedClusterRoles(grw.client, []string{inheritedRoleTemplate.ID})
 	require.Error(grw.T(), err)
 
 	pattern := "admission webhook.*" + regexp.QuoteMeta("unable to bind a roleTemplate with non-cluster context: project")


### PR DESCRIPTION
Update tests in GlobalRolesV2 to handle role/clusterrole binding differences when aggregated roletemplates feature is enabled