### PR TITLE
Update tfp go.mod to get latest VerifyRancherVersion changes

### DIFF
--- a/actions/go.mod
+++ b/actions/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/qase-tms/qase-go/qase-api-client v1.2.1
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be
-	github.com/rancher/tfp-automation v0.0.0-20260218000731-aad585fd2634
+	github.com/rancher/tfp-automation v0.0.0-20260223200320-56541017be04
 )
 
 require (

--- a/actions/go.sum
+++ b/actions/go.sum
@@ -266,8 +266,8 @@ github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be h1:x7+nxYLCqygc5T
 github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be/go.mod h1:SJtW8Jqv0rphZzsGnvB965YdyR2FqFtB+TbbzVLt8F4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078 h1:1MJSgYkgXhr/Zc5idJkKa10SiBQd0HVtbxVOBoghlzY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078/go.mod h1:CV2Soy/Skw8/SA9dDJVgpeHxoEdtjYkNpNy6xvvC5kA=
-github.com/rancher/tfp-automation v0.0.0-20260218000731-aad585fd2634 h1:qAfSUEpHyc1NbjRHEuEvXKCF8tKz73B6fADsZJGkliU=
-github.com/rancher/tfp-automation v0.0.0-20260218000731-aad585fd2634/go.mod h1:SHAVDTRqO8etqSRBtGj1jot25Bkbum1z/Z8NpE9dPyE=
+github.com/rancher/tfp-automation v0.0.0-20260223200320-56541017be04 h1:pvs3UWfAtSK+7Wf+/unqV/sALE8Tr3kuOeu9QVDq+G4=
+github.com/rancher/tfp-automation v0.0.0-20260223200320-56541017be04/go.mod h1:SHAVDTRqO8etqSRBtGj1jot25Bkbum1z/Z8NpE9dPyE=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=
 github.com/rancher/wrangler v1.1.2/go.mod h1:2k9MyhlBdjcutcBGoOJSUAz0HgDAXnMjv81d3n/AaQc=
 github.com/rancher/wrangler/v3 v3.3.1 h1:YFqRfhxjuLNudUrvWrn+64wUPZ8pnn2KWbTsha75JLg=

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/rancher/shepherd v0.0.0-20260206205036-22f6b44492e1
 	github.com/rancher/tests/actions v0.0.0-20260206233613-bf28ed655999
 	github.com/rancher/tests/interoperability v0.0.0-00010101000000-000000000000
-	github.com/rancher/tfp-automation v0.0.0-20260218000731-aad585fd2634
+	github.com/rancher/tfp-automation v0.0.0-20260223200320-56541017be04
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2192,8 +2192,8 @@ github.com/rancher/shepherd v0.0.0-20260206205036-22f6b44492e1 h1:Ig+5QXWZkOsDjM
 github.com/rancher/shepherd v0.0.0-20260206205036-22f6b44492e1/go.mod h1:SJtW8Jqv0rphZzsGnvB965YdyR2FqFtB+TbbzVLt8F4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078 h1:1MJSgYkgXhr/Zc5idJkKa10SiBQd0HVtbxVOBoghlzY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078/go.mod h1:CV2Soy/Skw8/SA9dDJVgpeHxoEdtjYkNpNy6xvvC5kA=
-github.com/rancher/tfp-automation v0.0.0-20260218000731-aad585fd2634 h1:qAfSUEpHyc1NbjRHEuEvXKCF8tKz73B6fADsZJGkliU=
-github.com/rancher/tfp-automation v0.0.0-20260218000731-aad585fd2634/go.mod h1:SHAVDTRqO8etqSRBtGj1jot25Bkbum1z/Z8NpE9dPyE=
+github.com/rancher/tfp-automation v0.0.0-20260223200320-56541017be04 h1:pvs3UWfAtSK+7Wf+/unqV/sALE8Tr3kuOeu9QVDq+G4=
+github.com/rancher/tfp-automation v0.0.0-20260223200320-56541017be04/go.mod h1:SHAVDTRqO8etqSRBtGj1jot25Bkbum1z/Z8NpE9dPyE=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/interoperability/go.mod
+++ b/interoperability/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be
 	github.com/rancher/tests/actions v0.0.0-20260206233613-bf28ed655999
-	github.com/rancher/tfp-automation v0.0.0-20260218000731-aad585fd2634
+	github.com/rancher/tfp-automation v0.0.0-20260223200320-56541017be04
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/interoperability/go.sum
+++ b/interoperability/go.sum
@@ -2085,8 +2085,8 @@ github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be h1:x7+nxYLCqygc5T
 github.com/rancher/shepherd v0.0.0-20260122211220-e4fc12acd2be/go.mod h1:SJtW8Jqv0rphZzsGnvB965YdyR2FqFtB+TbbzVLt8F4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078 h1:1MJSgYkgXhr/Zc5idJkKa10SiBQd0HVtbxVOBoghlzY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078/go.mod h1:CV2Soy/Skw8/SA9dDJVgpeHxoEdtjYkNpNy6xvvC5kA=
-github.com/rancher/tfp-automation v0.0.0-20260218000731-aad585fd2634 h1:qAfSUEpHyc1NbjRHEuEvXKCF8tKz73B6fADsZJGkliU=
-github.com/rancher/tfp-automation v0.0.0-20260218000731-aad585fd2634/go.mod h1:SHAVDTRqO8etqSRBtGj1jot25Bkbum1z/Z8NpE9dPyE=
+github.com/rancher/tfp-automation v0.0.0-20260223200320-56541017be04 h1:pvs3UWfAtSK+7Wf+/unqV/sALE8Tr3kuOeu9QVDq+G4=
+github.com/rancher/tfp-automation v0.0.0-20260223200320-56541017be04/go.mod h1:SHAVDTRqO8etqSRBtGj1jot25Bkbum1z/Z8NpE9dPyE=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=


### PR DESCRIPTION
### Description
Recently, a QOL enhancement went into to tfp-automation to display the Rancher version and commit version. This is purely for troubleshooting purposes in our recurring runs. This PR is porting that change over.

Additionally, cleaning up the `createRancherServer.go` file a little bit as it is over-engineered.