### PR TITLE
Add Prime recurring tests to dispatch-workflows.yml

### DIFF
--- a/.github/workflows/dispatch-workflows.yml
+++ b/.github/workflows/dispatch-workflows.yml
@@ -19,6 +19,7 @@ jobs:
         workflow:
           - rancher-upgrade-cluster-provisioning.yml
           - post-release-prime.yml
+          - prime-recurring-tests.yml
           - recurring-tests.yml
 
     steps:


### PR DESCRIPTION
### Description
The last PR that added `prime-recurring-tests.yml` was meant to add it to `dispatch-workflows.yml` to ensure it runs when alphas get cut. This PR simply adds that.