### PR TITLE
Enhance Error Logging for VerifyClusterReady()

### DIFF
--- a/actions/provisioning/verify.go
+++ b/actions/provisioning/verify.go
@@ -47,6 +47,8 @@ const (
 	etcdSnapshotAnnotation      = "etcdsnapshot.rke.io/storage"
 	machineNameAnnotation       = "cluster.x-k8s.io/machine"
 	deploymentNameLabel         = "cluster.x-k8s.io/deployment-name"
+	capiRoleLabel               = "cluster.x-k8s.io/role"
+	rancherRoleLabel            = "rke.cattle.io/role"
 	onDemandPrefix              = "on-demand-"
 	s3                          = "s3"
 	DefaultRancherDataDir       = "/var/lib/rancher"
@@ -117,43 +119,69 @@ func VerifyRKE1Cluster(t *testing.T, client *rancher.Client, clustersConfig *clu
 
 // VerifyClusterReady validates that a non-rke1 cluster and its resources are in a good state, matching a given config.
 func VerifyClusterReady(client *rancher.Client, cluster *steveV1.SteveAPIObject) error {
-	err := kwait.PollUntilContextTimeout(context.TODO(), 10*time.Second, defaults.FifteenMinuteTimeout, false, func(context.Context) (done bool, err error) {
-		adminClient, err := client.ReLogin()
-		if err != nil {
-			logrus.Warningf("Unable to get cluster client (%s) retrying", cluster.Name)
-			return false, nil
-		}
+	var lastErr error
 
-		kubeProvisioningClient, err := adminClient.GetKubeAPIProvisioningClient()
-		if err != nil {
-			logrus.Warningf("Unable to get cluster kube client (%s) retrying", cluster.Name)
-			return false, nil
-		}
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FifteenMinuteTimeout)
+	defer cancel()
 
-		watchInterface, err := kubeProvisioningClient.Clusters(namespaces.FleetDefault).Watch(context.TODO(), metav1.ListOptions{
-			FieldSelector:  "metadata.name=" + cluster.Name,
-			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
-		})
-		if err != nil {
-			return false, nil
-		}
+	err := kwait.PollUntilContextTimeout(
+		ctx,
+		10*time.Second,
+		defaults.FifteenMinuteTimeout,
+		false,
+		func(ctx context.Context) (bool, error) {
 
-		checkFunc := shepherdclusters.IsProvisioningClusterReady
-		err = wait.WatchWait(watchInterface, checkFunc)
-		if err != nil {
-			logrus.Warningf("Unable to get cluster status (%s) Retrying", cluster.Name)
-			return false, nil
-		}
+			adminClient, err := client.ReLogin()
+			if err != nil {
+				logrus.Debugf("Unable to fetch cluster client (%s), retrying", cluster.Name)
+				return false, nil
+			}
 
-		return true, nil
-	})
+			kubeProvisioningClient, err := adminClient.GetKubeAPIProvisioningClient()
+			if err != nil {
+				logrus.Debugf("Unable to fetch cluster kube client (%s), retrying", cluster.Name)
+				return false, nil
+			}
+
+			watchInterface, err := kubeProvisioningClient.
+				Clusters(namespaces.FleetDefault).
+				Watch(
+					ctx,
+					metav1.ListOptions{
+						FieldSelector:  "metadata.name=" + cluster.Name,
+						TimeoutSeconds: &defaults.WatchTimeoutSeconds,
+					},
+				)
+			if err != nil {
+				logrus.Debugf("Unable to watch cluster (%s), retrying", cluster.Name)
+				return false, nil
+			}
+			defer watchInterface.Stop()
+
+			checkFunc := shepherdclusters.IsProvisioningClusterReady
+
+			err = wait.WatchWait(watchInterface, checkFunc)
+			if err != nil {
+				lastErr = err
+				logrus.Debugf("Cluster (%s) not ready yet, retrying: %v", cluster.Name, err)
+				return false, nil
+			}
+
+			return true, nil
+		},
+	)
+
 	if err != nil {
+		logrus.Errorf("Cluster (%s) failed to become ready: %v", cluster.Name, err)
+		dumpProvisioningClusterState(ctx, client, cluster.Name, lastErr)
 		return err
 	}
 
 	logrus.Debugf("Waiting for all machines to be ready on cluster (%s)", cluster.Name)
 	err = nodestat.AllMachineReady(client, cluster.ID, defaults.FiveMinuteTimeout)
 	if err != nil {
+		logrus.Errorf("Machine readiness check failed for cluster (%s)", cluster.Name)
+		dumpProvisioningClusterState(ctx, client, cluster.Name, nil)
 		return err
 	}
 
@@ -163,11 +191,163 @@ func VerifyClusterReady(client *rancher.Client, cluster *steveV1.SteveAPIObject)
 		return err
 	}
 
-	if clusterToken != true {
+	if !clusterToken {
 		return fmt.Errorf("cluster token is not valid")
 	}
 
 	return nil
+}
+
+func dumpProvisioningClusterState(ctx context.Context, client *rancher.Client, clusterName string, lastPollingErr error) {
+	adminClient, err := client.ReLogin()
+	if err != nil {
+		logrus.Errorf("Log dump: unable to relogin: %v", err)
+		return
+	}
+
+	kubeProvisioningClient, err := adminClient.GetKubeAPIProvisioningClient()
+	if err != nil {
+		logrus.Errorf("Log dump: unable to get provisioning client: %v", err)
+		return
+	}
+
+	clusterObj, err := kubeProvisioningClient.
+		Clusters(namespaces.FleetDefault).
+		Get(ctx, clusterName, metav1.GetOptions{})
+	if err != nil {
+		logrus.Errorf("Log dump: unable to fetch provisioning cluster: %v", err)
+		return
+	}
+
+	logrus.Errorf("\n")
+	logrus.Errorf("==================================================")
+	logrus.Errorf("CLUSTER FAILED: %s", clusterObj.Name)
+	logrus.Errorf("==================================================\n")
+	logrus.Errorf("\n")
+	if lastPollingErr != nil {
+		logrus.Errorf("Final Error: %v\n", lastPollingErr)
+		logrus.Errorf("\n")
+	}
+
+	logrus.Errorf("Provisioning State")
+	logrus.Errorf("  Ready:        %v\n", clusterObj.Status.Ready)
+	logrus.Errorf("\n")
+
+	logrus.Errorf("Cluster Conditions:")
+	for _, cond := range clusterObj.Status.Conditions {
+		logrus.Errorf("  - Type:       %s", cond.Type)
+		logrus.Errorf("    Status:     %s", cond.Status)
+		logrus.Errorf("    Reason:     %v", populateValue(cond.Reason))
+		logrus.Errorf("    Message:    %v\n", populateValue(cond.Message))
+		logrus.Errorf("\n")
+	}
+
+	machineSteve := adminClient.Steve.SteveType(stevetypes.Machine)
+	machineList, err := machineSteve.List(nil)
+	if err != nil {
+		logrus.Errorf("Log dump: unable to list machines via Steve: %v", err)
+		return
+	}
+
+	type machineInfo struct {
+		Name           string
+		Role           string
+		Phase          any
+		NodeRef        any
+		FailureReason  any
+		FailureMessage any
+	}
+
+	var machines []machineInfo
+
+	for _, m := range machineList.Data {
+		if m.Labels == nil || m.Labels[capi.ClusterNameLabel] != clusterName {
+			continue
+		}
+
+		statusMap, ok := m.Status.(map[string]any)
+		if !ok {
+			logrus.Errorf(
+				"Machine %s has unexpected status format; expected map[string]any, got %T",
+				m.Name,
+				m.Status,
+			)
+			continue
+		}
+
+		role := "unknown"
+		if r, ok := m.Labels[capiRoleLabel]; ok {
+			role = r
+		} else if r, ok := m.Labels[rancherRoleLabel]; ok {
+			role = r
+		}
+
+		machines = append(machines, machineInfo{
+			Name:           m.Name,
+			Role:           role,
+			Phase:          statusMap["phase"],
+			NodeRef:        statusMap["nodeRef"],
+			FailureReason:  statusMap["failureReason"],
+			FailureMessage: statusMap["failureMessage"],
+		})
+	}
+
+	total := len(machines)
+	running, provisioning, failed := 0, 0, 0
+
+	for _, m := range machines {
+		switch m.Phase {
+		case "Running":
+			running++
+		case "Failed":
+			failed++
+		default:
+			provisioning++
+		}
+	}
+
+	logrus.Errorf("Machine Summary:")
+	logrus.Errorf("  Total:        %d", total)
+	logrus.Errorf("  Running:      %d", running)
+	logrus.Errorf("  Provisioning: %d", provisioning)
+	logrus.Errorf("  Failed:       %d\n", failed)
+	logrus.Errorf("\n")
+
+	logrus.Errorf("Machine Details:")
+
+	skippedHealthy := 0
+	for _, m := range machines {
+		if m.Phase == "Running" && m.FailureReason == nil {
+			skippedHealthy++
+			continue
+		}
+
+		logrus.Errorf("  • %s", m.Name)
+		logrus.Errorf("      Role:          %s", m.Role)
+		logrus.Errorf("      Phase:         %v", m.Phase)
+		logrus.Errorf("      NodeRef:       %v", m.NodeRef)
+		logrus.Errorf("      FailureReason: %v", populateValue(m.FailureReason))
+		logrus.Errorf("      FailureMsg:    %v\n", populateValue(m.FailureMessage))
+		logrus.Errorf("\n")
+	}
+
+	if skippedHealthy > 0 {
+		logrus.Infof("  • %d healthy machines detected", skippedHealthy)
+	}
+}
+
+func populateValue(v any) any {
+	switch val := v.(type) {
+	case nil:
+		return "<nil>"
+	case string:
+		if val == "" {
+			return `""`
+		}
+		return val
+	default:
+		return val
+	}
 }
 
 func VerifyPSACT(t *testing.T, client *rancher.Client, cluster *steveV1.SteveAPIObject) {


### PR DESCRIPTION
Recently a number of our automation runs end in errors with not a whole lot of context, including "context deadline exceeded".  When this occurs, QA often has to re-run the automation to investigate the root cause.

This PR aims to enhance the logging, so in the event of a timeout, the last observed state and key data points are log dumped, to help assist in troubleshooting.

Example output w/ enhancement + Trace level logging set:
```logs
gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestNodeDriver -timeout=1h -v
=== RUN   TestNodeDriver
=== PAUSE TestNodeDriver
=== CONT  TestNodeDriver
INFO   [2026-03-03 08:56:22] Setting logging level to: trace              
INFO   [2026-03-03 08:56:22] no version found in kubernetesVersions; default rke2 kubernetes version v1.35.1+rke2r1 will be used: [v1.35.1+rke2r1] 
=== RUN   TestNodeDriver/RKE2_Node_Driver|3_etcd|2_cp|3_worker
=== PAUSE TestNodeDriver/RKE2_Node_Driver|3_etcd|2_cp|3_worker
=== CONT  TestNodeDriver/RKE2_Node_Driver|3_etcd|2_cp|3_worker
INFO   [2026-03-03 08:56:28] Provisioning cluster                         
DEBUG  [2026-03-03 08:56:28] Creating Cloud credential (auto-aws-<REDACTED>)   
TRACE  [2026-03-03 08:56:34] Creating Secret(cc-<REDACTED>)                    
TRACE  [2026-03-03 08:56:34] Waiting for Secret(cc-<REDACTED>) to reach a active state 
TRACE  [2026-03-03 08:56:34] Secret(cc-<REDACTED>) is active                   
DEBUG  [2026-03-03 08:56:34] Creating Machine Pools (auto-aws-<REDACTED>)      
DEBUG  [2026-03-03 08:56:35] Creating cluster steve object (auto-aws-<REDACTED>) 
DEBUG  [2026-03-03 08:56:46] Get cluster object (auto-aws-<REDACTED>)          
INFO   [2026-03-03 08:57:01] Verifying the cluster is ready (auto-aws-<REDACTED>) 
DEBUG  [2026-03-03 08:58:58] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: error with watch connection 
DEBUG  [2026-03-03 09:00:03] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: error with watch connection 
DEBUG  [2026-03-03 09:01:08] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: error with watch connection 
DEBUG  [2026-03-03 09:02:12] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: error with watch connection 
DEBUG  [2026-03-03 09:03:17] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: error with watch connection 
DEBUG  [2026-03-03 09:04:21] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: error with watch connection 
DEBUG  [2026-03-03 09:05:26] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: error with watch connection 
DEBUG  [2026-03-03 09:06:30] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: error with watch connection 
DEBUG  [2026-03-03 09:07:35] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: error with watch connection 
DEBUG  [2026-03-03 09:08:40] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: error with watch connection 
DEBUG  [2026-03-03 09:09:44] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: error with watch connection 
DEBUG  [2026-03-03 09:10:48] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: error with watch connection 
DEBUG  [2026-03-03 09:11:53] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: error with watch connection 
DEBUG  [2026-03-03 09:12:01] Cluster (auto-aws-<REDACTED>) not ready yet, retrying: timeout waiting on condition 
ERROR  [2026-03-03 09:12:01] Cluster (auto-aws-<REDACTED>) failed to become ready: context deadline exceeded 
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06] ================================================== 
ERROR  [2026-03-03 09:12:06] CLUSTER FAILED: auto-aws-<REDACTED>               
ERROR  [2026-03-03 09:12:06] ================================================== 
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06] Final Error: timeout waiting on condition    
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06] Provisioning State                           
ERROR  [2026-03-03 09:12:06]   Ready:        false                        
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06] Cluster Conditions:                          
ERROR  [2026-03-03 09:12:06]   - Type:       RKECluster                   
ERROR  [2026-03-03 09:12:06]     Status:     True                         
ERROR  [2026-03-03 09:12:06]     Reason:     ""                           
ERROR  [2026-03-03 09:12:06]     Message:    ""                           
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       Reconciling                  
ERROR  [2026-03-03 09:12:06]     Status:     True                         
ERROR  [2026-03-03 09:12:06]     Reason:     Reconciling                  
ERROR  [2026-03-03 09:12:06]     Message:    ""                           
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       Stalled                      
ERROR  [2026-03-03 09:12:06]     Status:     False                        
ERROR  [2026-03-03 09:12:06]     Reason:     ""                           
ERROR  [2026-03-03 09:12:06]     Message:    ""                           
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       Created                      
ERROR  [2026-03-03 09:12:06]     Status:     True                         
ERROR  [2026-03-03 09:12:06]     Reason:     ""                           
ERROR  [2026-03-03 09:12:06]     Message:    ""                           
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       BackingNamespaceCreated      
ERROR  [2026-03-03 09:12:06]     Status:     True                         
ERROR  [2026-03-03 09:12:06]     Reason:     ""                           
ERROR  [2026-03-03 09:12:06]     Message:    ""                           
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       DefaultProjectCreated        
ERROR  [2026-03-03 09:12:06]     Status:     True                         
ERROR  [2026-03-03 09:12:06]     Reason:     ""                           
ERROR  [2026-03-03 09:12:06]     Message:    ""                           
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       SystemProjectCreated         
ERROR  [2026-03-03 09:12:06]     Status:     True                         
ERROR  [2026-03-03 09:12:06]     Reason:     ""                           
ERROR  [2026-03-03 09:12:06]     Message:    ""                           
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       InitialRolesPopulated        
ERROR  [2026-03-03 09:12:06]     Status:     True                         
ERROR  [2026-03-03 09:12:06]     Reason:     ""                           
ERROR  [2026-03-03 09:12:06]     Message:    ""                           
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       CreatorMadeOwner             
ERROR  [2026-03-03 09:12:06]     Status:     True                         
ERROR  [2026-03-03 09:12:06]     Reason:     ""                           
ERROR  [2026-03-03 09:12:06]     Message:    ""                           
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       Updated                      
ERROR  [2026-03-03 09:12:06]     Status:     Unknown                      
ERROR  [2026-03-03 09:12:06]     Reason:     Waiting                      
ERROR  [2026-03-03 09:12:06]     Message:    configuring bootstrap node(s) auto-aws-<REDACTED>-pool0-<REDACTED>-zj575: error applying plan -- check rancher-system-agent.service and rke2-server.service logs on node for more information, waiting for agent to check in and apply initial plan 
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       Provisioned                  
ERROR  [2026-03-03 09:12:06]     Status:     Unknown                      
ERROR  [2026-03-03 09:12:06]     Reason:     Waiting                      
ERROR  [2026-03-03 09:12:06]     Message:    configuring bootstrap node(s) auto-aws-<REDACTED>-pool0-<REDACTED>-zj575: error applying plan -- check rancher-system-agent.service and rke2-server.service logs on node for more information, waiting for agent to check in and apply initial plan 
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       Ready                        
ERROR  [2026-03-03 09:12:06]     Status:     Unknown                      
ERROR  [2026-03-03 09:12:06]     Reason:     Waiting                      
ERROR  [2026-03-03 09:12:06]     Message:    configuring bootstrap node(s) auto-aws-<REDACTED>-pool0-<REDACTED>-zj575: error applying plan -- check rancher-system-agent.service and rke2-server.service logs on node for more information, waiting for agent to check in and apply initial plan 
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       NoDiskPressure               
ERROR  [2026-03-03 09:12:06]     Status:     True                         
ERROR  [2026-03-03 09:12:06]     Reason:     ""                           
ERROR  [2026-03-03 09:12:06]     Message:    ""                           
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       NoMemoryPressure             
ERROR  [2026-03-03 09:12:06]     Status:     True                         
ERROR  [2026-03-03 09:12:06]     Reason:     ""                           
ERROR  [2026-03-03 09:12:06]     Message:    ""                           
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       ServiceAccountSecretsMigrated 
ERROR  [2026-03-03 09:12:06]     Status:     True                         
ERROR  [2026-03-03 09:12:06]     Reason:     ""                           
ERROR  [2026-03-03 09:12:06]     Message:    ""                           
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   - Type:       Connected                    
ERROR  [2026-03-03 09:12:06]     Status:     False                        
ERROR  [2026-03-03 09:12:06]     Reason:     ""                           
ERROR  [2026-03-03 09:12:06]     Message:    ""                           
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06] Machine Summary:                             
ERROR  [2026-03-03 09:12:06]   Total:        8                            
ERROR  [2026-03-03 09:12:06]   Running:      0                            
ERROR  [2026-03-03 09:12:06]   Provisioning: 8                            
ERROR  [2026-03-03 09:12:06]   Failed:       0                            
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06] Machine Details:                             
ERROR  [2026-03-03 09:12:06]   • auto-aws-<REDACTED>-pool0-<REDACTED>-mnlhx         
ERROR  [2026-03-03 09:12:06]       Role:          unknown                 
ERROR  [2026-03-03 09:12:06]       Phase:         Provisioning            
ERROR  [2026-03-03 09:12:06]       NodeRef:       <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureReason: <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureMsg:    <nil>                   
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   • auto-aws-<REDACTED>-pool0-<REDACTED>-s2t5q         
ERROR  [2026-03-03 09:12:06]       Role:          unknown                 
ERROR  [2026-03-03 09:12:06]       Phase:         Provisioning            
ERROR  [2026-03-03 09:12:06]       NodeRef:       <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureReason: <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureMsg:    <nil>                   
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   • auto-aws-<REDACTED>-pool0-<REDACTED>-zj575         
ERROR  [2026-03-03 09:12:06]       Role:          unknown                 
ERROR  [2026-03-03 09:12:06]       Phase:         Provisioning            
ERROR  [2026-03-03 09:12:06]       NodeRef:       <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureReason: <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureMsg:    <nil>                   
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   • auto-aws-<REDACTED>-pool1-<REDACTED>-hsh95         
ERROR  [2026-03-03 09:12:06]       Role:          unknown                 
ERROR  [2026-03-03 09:12:06]       Phase:         Provisioning            
ERROR  [2026-03-03 09:12:06]       NodeRef:       <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureReason: <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureMsg:    <nil>                   
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   • auto-aws-<REDACTED>-pool1-<REDACTED>-r98n9         
ERROR  [2026-03-03 09:12:06]       Role:          unknown                 
ERROR  [2026-03-03 09:12:06]       Phase:         Provisioning            
ERROR  [2026-03-03 09:12:06]       NodeRef:       <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureReason: <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureMsg:    <nil>                   
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   • auto-aws-<REDACTED>-pool2-<REDACTED>-5886d         
ERROR  [2026-03-03 09:12:06]       Role:          unknown                 
ERROR  [2026-03-03 09:12:06]       Phase:         Provisioning            
ERROR  [2026-03-03 09:12:06]       NodeRef:       <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureReason: <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureMsg:    <nil>                   
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   • auto-aws-<REDACTED>-pool2-<REDACTED>-9gw9n         
ERROR  [2026-03-03 09:12:06]       Role:          unknown                 
ERROR  [2026-03-03 09:12:06]       Phase:         Provisioning            
ERROR  [2026-03-03 09:12:06]       NodeRef:       <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureReason: <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureMsg:    <nil>                   
ERROR  [2026-03-03 09:12:06]                                              
ERROR  [2026-03-03 09:12:06]   • auto-aws-<REDACTED>-pool2-<REDACTED>-b2kpl         
ERROR  [2026-03-03 09:12:06]       Role:          unknown                 
ERROR  [2026-03-03 09:12:06]       Phase:         Provisioning            
ERROR  [2026-03-03 09:12:06]       NodeRef:       <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureReason: <nil>                   
ERROR  [2026-03-03 09:12:06]       FailureMsg:    <nil>                   
ERROR  [2026-03-03 09:12:06]                                              
    node_driver_test.go:119: 
        	Error Trace:	/Users/<REDACTED>/go/src/github.com/rancher/tests/validation/provisioning/rke2/node_driver_test.go:119
        	Error:      	Received unexpected error:
        	            	context deadline exceeded
        	Test:       	TestNodeDriver/RKE2_Node_Driver|3_etcd|2_cp|3_worker
INFO   [2026-03-03 09:12:06] Running cleanup (RKE2_Node_Driver|3_etcd|2_cp|3_worker) 
--- FAIL: TestNodeDriver (10.96s)
    --- FAIL: TestNodeDriver/RKE2_Node_Driver|3_etcd|2_cp|3_worker (938.38s)
FAIL
FAIL	github.com/rancher/tests/validation/provisioning/rke2	950.676s
```
