### PR TITLE
Add tests for WatchList to ext tokens and kubeconfigs

### DIFF
--- a/actions/watchlist/watchlist.go
+++ b/actions/watchlist/watchlist.go
@@ -1,0 +1,54 @@
+package watchlist
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// WaitForWatchListEnd monitors a watch channel for the Bookmark event containing the initial-events-end annotation.
+func WaitForWatchListEnd(ctx context.Context, watcher watch.Interface) error {
+	defer watcher.Stop()
+
+	// Use a 0 interval because the channel itself provides the 'waiting' mechanism
+	return kwait.PollUntilContextCancel(ctx, 0, true, func(ctx context.Context) (bool, error) {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return false, fmt.Errorf("watch channel closed")
+			}
+
+			metaAccessor, err := meta.Accessor(event.Object)
+			if err != nil {
+				return false, fmt.Errorf("failed to access event metadata: %v", err)
+			}
+
+			log.Printf("Event: %-8s | Resource: %s/%s\n",
+				event.Type,
+				metaAccessor.GetNamespace(),
+				metaAccessor.GetName(),
+			)
+
+			if event.Type == watch.Bookmark {
+				metaAccessor, err := meta.Accessor(event.Object)
+				if err != nil {
+					return false, err
+				}
+
+				annotations := metaAccessor.GetAnnotations()
+				if annotations["k8s.io/initial-events-end"] == "true" {
+					log.Printf("Received WatchList completion signal successfully")
+					return true, nil
+				}
+				return false, fmt.Errorf("bookmark received but annotation was stripped")
+			}
+			return false, nil
+		}
+	})
+}

--- a/validation/auth/kubeconfigs/README.md
+++ b/validation/auth/kubeconfigs/README.md
@@ -8,9 +8,12 @@ This repository contains Golang automation tests for Ext Kubeconfigs (Public API
 
 ## Test Setup
 
-Your GO suite should be set to `-run ^TestKubeconfigTestSuite$`. You can find specific tests by checking the test file you plan to run.
+Your GO suite should be set to `-run ^Test<TestSuite>$`
 
-In your config file, set the following:
+- To run the kubeconfigs_test.go, set the GO suite to `-run ^TestExtKubeconfigTestSuite$`
+- To run the kubeconfigs_watchlist_test.go set the GO suite to `-run ^TestKubeconfigWatchListTestSuite$`
+
+In your config file for ***TestExtKubeconfigTestSuite***, set the following:
 
 ```yaml
 rancher:
@@ -61,3 +64,13 @@ awsMachineConfigs:
 sshPath:
  sshPath: "<Your ssh path>"
 ```
+
+In your config file for ***TestKubeconfigWatchListTestSuite***, set the following:
+```yaml
+rancher:
+  host: "rancher_server_address"
+  adminToken: "rancher_admin_token"
+  insecure: True #optional
+  cleanup: True #optional
+  clusterName: "downstream_cluster_name"
+  ```

--- a/validation/auth/kubeconfigs/kubeconfigs_watchlist_test.go
+++ b/validation/auth/kubeconfigs/kubeconfigs_watchlist_test.go
@@ -1,0 +1,78 @@
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !2.8 && !2.9 && !2.10 && !2.11 && !2.12 && !2.13
+
+package kubeconfigs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	extensionscluster "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/pkg/session"
+	kubeconfigapi "github.com/rancher/tests/actions/kubeconfigs"
+	watchlistapi "github.com/rancher/tests/actions/watchlist"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ExtKubeconfigWatchListTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	session            *session.Session
+	cluster            *management.Cluster
+}
+
+func (w *ExtKubeconfigWatchListTestSuite) TearDownSuite() {
+	w.session.Cleanup()
+}
+
+func (w *ExtKubeconfigWatchListTestSuite) SetupSuite() {
+	w.session = session.NewSession()
+
+	client, err := rancher.NewClient("", w.session)
+	require.NoError(w.T(), err)
+	w.client = client
+
+	log.Info("Getting cluster name from the config file and append cluster details in the struct.")
+	clusterName := client.RancherConfig.ClusterName
+	require.NotEmptyf(w.T(), clusterName, "Cluster name to install should be set")
+	clusterID, err := extensionscluster.GetClusterIDByName(w.client, clusterName)
+	require.NoError(w.T(), err, "Error getting cluster ID")
+	w.cluster, err = w.client.Management.Cluster.ByID(clusterID)
+	require.NoError(w.T(), err)
+}
+
+func (w *ExtKubeconfigWatchListTestSuite) TestWatchListForKubeconfigs() {
+	subSession := w.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Infof("As user %s, creating a kubeconfig for cluster: %s", w.client.UserID, w.cluster.ID)
+	createdKubeconfig, err := kubeconfigapi.CreateKubeconfig(w.client, []string{w.cluster.ID}, "", nil)
+	require.NoError(w.T(), err)
+	require.NotEmpty(w.T(), createdKubeconfig.Status.Value)
+
+	log.Info("Starting watch on kubeconfigs")
+	sendInitial := true
+	watcher, err := w.client.WranglerContext.Ext.Kubeconfig().Watch(metav1.ListOptions{
+		SendInitialEvents:    &sendInitial,
+		AllowWatchBookmarks:  true,
+		ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
+	})
+	require.NoError(w.T(), err, "failed to start watch")
+
+	log.Info("Verifying WatchList completion signal")
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.OneMinuteTimeout)
+	defer cancel()
+	
+	err = watchlistapi.WaitForWatchListEnd(ctx, watcher)
+	require.NoError(w.T(), err, "WatchList validation failed")
+}
+
+func TestKubeconfigWatchListTestSuite(w *testing.T) {
+	suite.Run(w, new(ExtKubeconfigWatchListTestSuite))
+}
+

--- a/validation/auth/tokens/README.md
+++ b/validation/auth/tokens/README.md
@@ -12,6 +12,7 @@ Your GO suite should be set to `-run ^Test<TestSuite>$`
 
 - To run the token_test.go, set the GO suite to `-run ^TestTokenTestSuite$`
 - To run the ext_token_test.go, set the GO suite to `-run ^TestExtTokenTestSuite$`
+- To run the ext_token_watchlist_test.go set the GO suite to `-run ^TestExtTokenWatchListTestSuite$`
 
 In your config file, set the following:
 

--- a/validation/auth/tokens/ext_token_watchlist_test.go
+++ b/validation/auth/tokens/ext_token_watchlist_test.go
@@ -1,0 +1,78 @@
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !2.8 && !2.9 && !2.10 && !2.11 && !2.12 && !2.13
+
+package tokens
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/settings"
+	exttokenapi "github.com/rancher/tests/actions/tokens/exttokens"
+	watchlistapi "github.com/rancher/tests/actions/watchlist"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type ExtTokenWatchListTestSuite struct {
+	suite.Suite
+	client             *rancher.Client
+	session            *session.Session
+	cluster            *management.Cluster
+	defaultExtTokenTTL int64
+}
+
+func (w *ExtTokenWatchListTestSuite) TearDownSuite() {
+	w.session.Cleanup()
+}
+
+func (w *ExtTokenWatchListTestSuite) SetupSuite() {
+	w.session = session.NewSession()
+
+	client, err := rancher.NewClient("", w.session)
+	require.NoError(w.T(), err)
+	w.client = client
+
+	log.Info("Getting default TTL value to be used in tests")
+	defaultTTLString, err := settings.GetGlobalSettingDefaultValue(w.client, settings.AuthTokenMaxTTLMinutes)
+	require.NoError(w.T(), err)
+	defaultTTLInt, err := strconv.Atoi(defaultTTLString)
+	require.NoError(w.T(), err)
+	defaultTTL := int64(defaultTTLInt * 60000)
+	w.defaultExtTokenTTL = defaultTTL
+}
+
+func (w *ExtTokenWatchListTestSuite) TestWatchListForExtTokens() {
+	subSession := w.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Infof("As user %s, creating ext token", w.client.UserID)
+	_, err := exttokenapi.CreateExtToken(w.client, w.defaultExtTokenTTL)
+	require.NoError(w.T(), err)
+
+	log.Info("Starting watch on ext tokens")
+	sendInitial := true
+	watcher, err := w.client.WranglerContext.Ext.Token().Watch(metav1.ListOptions{
+		SendInitialEvents:    &sendInitial,
+		AllowWatchBookmarks:  true,
+		ResourceVersionMatch: metav1.ResourceVersionMatchNotOlderThan,
+	})
+	require.NoError(w.T(), err, "failed to start watch")
+
+	log.Info("Verifying WatchList completion signal")
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.OneMinuteTimeout)
+	defer cancel()
+
+	err = watchlistapi.WaitForWatchListEnd(ctx, watcher)
+	require.NoError(w.T(), err, "WatchList validation failed")
+}
+
+func TestExtTokenWatchListTestSuite(w *testing.T) {
+	suite.Run(w, new(ExtTokenWatchListTestSuite))
+}


### PR DESCRIPTION
This PR adds tests for the WatchList feature to the ext token and kubeconfig test suites.

These tests verify the WatchList feature for both ext token and kubeconfig stores is working and no longer stripping bookmark annotations(https://github.com/rancher/rancher/issues/53663).