### PR TITLE
Add RKE2 provisioning test for ingress-nginx and traefik

### DIFF
--- a/validation/provisioning/rke2/README.md
+++ b/validation/provisioning/rke2/README.md
@@ -177,6 +177,24 @@ Hardened test verifies that a cluster can deploy the cis-benchmark(2.11<=)/compl
 1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestHardened -timeout=1h -v`
 
 
+### Ingress Test
+
+#### Description: 
+Hardened test verifies that a cluster can deploy the cis-benchmark(2.11<=)/compliance(2.12+) chart on a custom cluster
+
+#### Required Configurations: 
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Machine Config](#machine-config)
+
+#### Table Tests
+1. `RKE2_Ingress_Nginx`
+2. `RKE2_Traefik`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/rke2 --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestIngress -timeout=1h -v`
+
+
 ### Node Driver Test
 
 #### Description: 

--- a/validation/provisioning/rke2/ingress_test.go
+++ b/validation/provisioning/rke2/ingress_test.go
@@ -1,0 +1,136 @@
+//go:build validation || recurring
+
+package rke2
+
+import (
+	"os"
+	"testing"
+
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/cloudcredentials"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+type ingressTest struct {
+	client             *rancher.Client
+	session            *session.Session
+	standardUserClient *rancher.Client
+	cattleConfig       map[string]any
+}
+
+func ingressSetup(t *testing.T) ingressTest {
+	var r ingressTest
+	testSession := session.NewSession()
+	r.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	r.client = client
+
+	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
+
+	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
+	require.NoError(t, err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(t, err)
+
+	r.cattleConfig, err = defaults.SetK8sDefault(client, defaults.RKE2, r.cattleConfig)
+	require.NoError(t, err)
+
+	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
+	require.NoError(t, err)
+
+	return r
+}
+
+func TestIngress(t *testing.T) {
+	t.Parallel()
+	r := ingressSetup(t)
+
+	ingressNginx := rkev1.GenericMap{
+		Data: map[string]any{
+			"ingress-controller": "ingress-nginx",
+		},
+	}
+
+	traefik := rkev1.GenericMap{
+		Data: map[string]any{
+			"ingress-controller": "traefik",
+		},
+	}
+
+	tests := []struct {
+		name                string
+		client              *rancher.Client
+		machineGlobalConfig rkev1.GenericMap
+	}{
+		{"RKE2_Ingress_Nginx", r.standardUserClient, ingressNginx},
+		{"RKE2_Traefik", r.standardUserClient, traefik},
+	}
+
+	for _, tt := range tests {
+		var err error
+		t.Cleanup(func() {
+			logrus.Infof("Running cleanup (%s)", tt.name)
+			r.session.Cleanup()
+		})
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clusterConfig := new(clusters.ClusterConfig)
+			operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
+
+			if clusterConfig.Advanced == nil {
+				clusterConfig.Advanced = new(provisioninginput.Advanced)
+			}
+
+			clusterConfig.Advanced.MachineGlobalConfig = &tt.machineGlobalConfig
+
+			provider := provisioning.CreateProvider(clusterConfig.Provider)
+			credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
+			machineConfigSpec := provider.LoadMachineConfigFunc(r.cattleConfig)
+
+			logrus.Info("Provisioning cluster")
+			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			err = pods.VerifyClusterPods(r.client, cluster)
+			require.NoError(t, err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}


### PR DESCRIPTION
### Description
As part of the migration efforts from `ingress-nginx` to `traefik`, it still is important that we are intentionally testing both networking, if at least in the short term. This PR creates the `ingress_test.go` file that accomplishes just that for RKE2 downstream clusters.