### PR TITLE
Fix misc failures noted in recurring runs

### DIFF
--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -281,7 +281,7 @@ jobs:
           templateTest:
             repo:
               metadata:
-                name: "test"
+                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main
@@ -620,7 +620,7 @@ jobs:
           templateTest:
             repo:
               metadata:
-                name: "test"
+                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main
@@ -968,7 +968,7 @@ jobs:
           templateTest:
             repo:
               metadata:
-                name: "test"
+                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -286,7 +286,7 @@ jobs:
           templateTest:
             repo:
               metadata:
-                name: "test"
+                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main
@@ -631,7 +631,7 @@ jobs:
           templateTest:
             repo:
               metadata:
-                name: "test"
+                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main
@@ -986,7 +986,7 @@ jobs:
           templateTest:
             repo:
               metadata:
-                name: "test"
+                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -281,7 +281,7 @@ jobs:
           templateTest:
             repo:
               metadata:
-                name: "test"
+                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main
@@ -622,7 +622,7 @@ jobs:
           templateTest:
             repo:
               metadata:
-                name: "test"
+                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main
@@ -972,7 +972,7 @@ jobs:
           templateTest:
             repo:
               metadata:
-                name: "test"
+                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main

--- a/actions/workloads/deployment/verify.go
+++ b/actions/workloads/deployment/verify.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 	"time"
 
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/charts"
-	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/workloads"
@@ -508,14 +508,14 @@ func VerifyDeploymentOrchestration(client *rancher.Client, clusterID, namespace,
 
 // VerifyClusterDeployments verifies that all required deployments are present and available in the cluster
 func VerifyClusterDeployments(client *rancher.Client, cluster *v1.SteveAPIObject) error {
-	clusterID, err := clusters.GetClusterIDByName(client, cluster.Name)
-	if err != nil {
+	status := &provv1.ClusterStatus{}
+	if err := v1.ConvertToK8sType(cluster.Status, status); err != nil {
 		return err
 	}
 
 	var downstreamClient *v1.Client
-	err = kwait.PollUntilContextTimeout(context.TODO(), 5*time.Second, defaults.FiveMinuteTimeout, false, func(ctx context.Context) (done bool, err error) {
-		downstreamClient, err = client.Steve.ProxyDownstream(clusterID)
+	err := kwait.PollUntilContextTimeout(context.TODO(), 5*time.Second, defaults.FiveMinuteTimeout, false, func(ctx context.Context) (done bool, err error) {
+		downstreamClient, err = client.Steve.ProxyDownstream(status.ClusterName)
 		if err != nil {
 			return false, nil
 		}

--- a/validation/provisioning/k3s/dynamic_custom_test.go
+++ b/validation/provisioning/k3s/dynamic_custom_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/rancher/tests/actions/config/permutationdata"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
-	"github.com/rancher/tests/actions/reports"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -102,7 +101,6 @@ func TestDynamicCustom(t *testing.T) {
 
 				logrus.Info("Provisioning cluster")
 				cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
-				reports.TimeoutClusterReport(cluster, err)
 				require.NoError(t, err)
 
 				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)

--- a/validation/provisioning/k3s/hardened_test.go
+++ b/validation/provisioning/k3s/hardened_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/reports"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	cis "github.com/rancher/tests/validation/provisioning/resources/cisbenchmark"
@@ -100,7 +99,6 @@ func TestHardened(t *testing.T) {
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
-			reports.TimeoutClusterReport(cluster, err)
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
@@ -123,14 +121,12 @@ func TestHardened(t *testing.T) {
 			}
 
 			clusterMeta, err := extensionscluster.NewClusterMeta(tt.client, cluster.Name)
-			reports.TimeoutClusterReport(cluster, err)
 			require.NoError(t, err)
 
 			latestCISBenchmarkVersion, err := tt.client.Catalog.GetLatestChartVersion(chartName, catalog.RancherChartRepo)
 			require.NoError(t, err)
 
 			project, err := projects.GetProjectByName(tt.client, clusterMeta.ID, cis.System)
-			reports.TimeoutClusterReport(cluster, err)
 			require.NoError(t, err)
 
 			k.project = project

--- a/validation/provisioning/rke2/dynamic_custom_test.go
+++ b/validation/provisioning/rke2/dynamic_custom_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
-	"github.com/rancher/tests/actions/reports"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -106,7 +105,6 @@ func TestDynamicCustom(t *testing.T) {
 
 				logrus.Info("Provisioning cluster")
 				cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
-				reports.TimeoutClusterReport(cluster, err)
 				require.NoError(t, err)
 
 				logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)

--- a/validation/provisioning/rke2/hardened_test.go
+++ b/validation/provisioning/rke2/hardened_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
-	"github.com/rancher/tests/actions/reports"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	cis "github.com/rancher/tests/validation/provisioning/resources/cisbenchmark"
@@ -101,7 +100,6 @@ func TestHardened(t *testing.T) {
 
 			logrus.Infof("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
-			reports.TimeoutClusterReport(cluster, err)
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
@@ -124,14 +122,12 @@ func TestHardened(t *testing.T) {
 			}
 
 			clusterMeta, err := extensionscluster.NewClusterMeta(tt.client, cluster.Name)
-			reports.TimeoutClusterReport(cluster, err)
 			require.NoError(t, err)
 
 			latestHardenedChartVersion, err := tt.client.Catalog.GetLatestChartVersion(chartName, catalog.RancherChartRepo)
 			require.NoError(t, err)
 
 			project, err := projects.GetProjectByName(tt.client, clusterMeta.ID, cis.System)
-			reports.TimeoutClusterReport(cluster, err)
 			require.NoError(t, err)
 
 			r.project = project

--- a/validation/provisioning/rke2/template_test.go
+++ b/validation/provisioning/rke2/template_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
-	"github.com/rancher/tests/actions/reports"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
@@ -117,7 +116,6 @@ func TestTemplate(t *testing.T) {
 			require.NoError(t, err)
 
 			_, cluster, err := clusters.GetProvisioningClusterByName(r.client, clusterName, namespaces.FleetDefault)
-			reports.TimeoutClusterReport(cluster, err)
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)


### PR DESCRIPTION
### Description
Looking at the recurring runs today, there were several things noted that this PR is addressing. See below:
- Some test files are referencing `TimeoutClusterReport`. We have long removed those and those are just calling failures for no reason, so good bye.
- The template test will run into an issue where if you already have created `test`, it will error out. To get around this, we should use a uniquely-named template test.
- `VerifyClusterDeployments` was using an outdated v3 API call. This has been changed to match what `VerifyClusterPods` is doing.