### PR TITLE
Update template test to have unique template names

### DIFF
--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -3,7 +3,7 @@ name: Cluster Provisioning
 
 on:
   schedule:
-    - cron: "0 10 * * 1,3,4,5"
+    - cron: "0 10 * * 3,4,5"
   workflow_dispatch:
     inputs:
       rancher_version:
@@ -291,8 +291,6 @@ jobs:
 
           templateTest:
             repo:
-              metadata:
-                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main
@@ -641,8 +639,6 @@ jobs:
 
           templateTest:
             repo:
-              metadata:
-                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main
@@ -991,8 +987,6 @@ jobs:
 
           templateTest:
             repo:
-              metadata:
-                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -3,7 +3,7 @@ name: Upgraded Rancher Cluster Provisioning
 
 on:
   schedule:
-    - cron: "0 10 * * 1,2,4,5"
+    - cron: "0 10 * * 1,5"
   workflow_dispatch:
     inputs:
       rancher_version:
@@ -297,8 +297,6 @@ jobs:
 
           templateTest:
             repo:
-              metadata:
-                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main
@@ -654,8 +652,6 @@ jobs:
 
           templateTest:
             repo:
-              metadata:
-                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main
@@ -1011,8 +1007,6 @@ jobs:
 
           templateTest:
             repo:
-              metadata:
-                name: "${{ env.HOSTNAME_PREFIX }}-template-test"
               spec:
                 gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
                 gitBranch: main

--- a/validation/provisioning/k3s/template_test.go
+++ b/validation/provisioning/k3s/template_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
-	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
@@ -29,7 +28,6 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
-	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -40,12 +38,11 @@ const (
 )
 
 type templateTest struct {
-	client             *rancher.Client
-	standardUserClient *rancher.Client
-	session            *session.Session
-	templateConfig     *provisioninginput.TemplateConfig
-	cloudCredentials   *v1.SteveAPIObject
-	cattleConfig       map[string]any
+	client           *rancher.Client
+	session          *session.Session
+	templateConfig   *provisioninginput.TemplateConfig
+	cloudCredentials *v1.SteveAPIObject
+	cattleConfig     map[string]any
 }
 
 func templateSetup(t *testing.T) templateTest {
@@ -77,9 +74,6 @@ func templateSetup(t *testing.T) templateTest {
 	k.cloudCredentials, err = provider.CloudCredFunc(client, cloudCredentialConfig)
 	require.NoError(t, err)
 
-	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
-	require.NoError(t, err)
-
 	return k
 }
 
@@ -88,10 +82,9 @@ func TestTemplate(t *testing.T) {
 	k := templateSetup(t)
 
 	tests := []struct {
-		name   string
-		client *rancher.Client
+		name string
 	}{
-		{"K3S_Template|etcd|cp|worker", k.standardUserClient},
+		{"K3S_Template|etcd|cp|worker"},
 	}
 
 	for _, tt := range tests {
@@ -103,19 +96,22 @@ func TestTemplate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			templateName := namegenerator.AppendRandomString(actionsDefaults.K3S + "-template")
+			k.templateConfig.Repo.ObjectMeta.Name = templateName
+
 			_, err := steve.CreateAndWaitForResource(k.client, namespaces.FleetLocal+"/"+localCluster, stevetypes.ClusterRepo, k.templateConfig.Repo, stevestates.Active, 5*time.Second, defaults.FiveMinuteTimeout)
 			require.NoError(t, err)
 
 			k8sversions, err := kubernetesversions.Default(k.client, actionsDefaults.K3S, nil)
 			require.NoError(t, err)
 
-			clusterName := namegenerator.AppendRandomString(actionsDefaults.K3S + "-template")
+			templateClusterName := namegenerator.AppendRandomString(actionsDefaults.K3S + "-template")
 
-			logrus.Infof("Provisioning template cluster (%s)", clusterName)
-			err = charts.InstallTemplateChart(k.client, k.templateConfig.Repo.ObjectMeta.Name, k.templateConfig.TemplateName, clusterName, k8sversions[0], k.cloudCredentials)
+			logrus.Infof("Provisioning template cluster (%s)", templateClusterName)
+			err = charts.InstallTemplateChart(k.client, k.templateConfig.Repo.ObjectMeta.Name, k.templateConfig.TemplateName, templateClusterName, k8sversions[0], k.cloudCredentials)
 			require.NoError(t, err)
 
-			_, cluster, err := clusters.GetProvisioningClusterByName(k.client, clusterName, namespaces.FleetDefault)
+			cluster, err := k.client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + templateClusterName)
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)

--- a/validation/provisioning/rke2/template_test.go
+++ b/validation/provisioning/rke2/template_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
-	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
@@ -29,7 +28,6 @@ import (
 	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
-	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -40,12 +38,11 @@ const (
 )
 
 type templateTest struct {
-	client             *rancher.Client
-	standardUserClient *rancher.Client
-	session            *session.Session
-	templateConfig     *provisioninginput.TemplateConfig
-	cloudCredentials   *v1.SteveAPIObject
-	cattleConfig       map[string]any
+	client           *rancher.Client
+	session          *session.Session
+	templateConfig   *provisioninginput.TemplateConfig
+	cloudCredentials *v1.SteveAPIObject
+	cattleConfig     map[string]any
 }
 
 func templateSetup(t *testing.T) templateTest {
@@ -77,9 +74,6 @@ func templateSetup(t *testing.T) templateTest {
 	r.cloudCredentials, err = provider.CloudCredFunc(client, cloudCredentialConfig)
 	require.NoError(t, err)
 
-	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
-	require.NoError(t, err)
-
 	return r
 }
 
@@ -88,10 +82,9 @@ func TestTemplate(t *testing.T) {
 	r := templateSetup(t)
 
 	tests := []struct {
-		name   string
-		client *rancher.Client
+		name string
 	}{
-		{"RKE2_Template|etcd|cp|worker", r.standardUserClient},
+		{"RKE2_Template|etcd|cp|worker"},
 	}
 
 	for _, tt := range tests {
@@ -103,19 +96,22 @@ func TestTemplate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			templateName := namegenerator.AppendRandomString(actionsDefaults.RKE2 + "-template")
+			r.templateConfig.Repo.ObjectMeta.Name = templateName
+
 			_, err := steve.CreateAndWaitForResource(r.client, namespaces.FleetLocal+"/"+localCluster, stevetypes.ClusterRepo, r.templateConfig.Repo, stevestates.Active, 5*time.Second, defaults.FiveMinuteTimeout)
 			require.NoError(t, err)
 
 			k8sversions, err := kubernetesversions.Default(r.client, actionsDefaults.RKE2, nil)
 			require.NoError(t, err)
 
-			clusterName := namegenerator.AppendRandomString(actionsDefaults.RKE2 + "-template")
+			templateClusterName := namegenerator.AppendRandomString(actionsDefaults.RKE2 + "-template")
 
-			logrus.Infof("Provisioning template cluster (%s)", clusterName)
-			err = charts.InstallTemplateChart(r.client, r.templateConfig.Repo.ObjectMeta.Name, r.templateConfig.TemplateName, clusterName, k8sversions[0], r.cloudCredentials)
+			logrus.Infof("Provisioning template cluster (%s)", templateClusterName)
+			err = charts.InstallTemplateChart(r.client, r.templateConfig.Repo.ObjectMeta.Name, r.templateConfig.TemplateName, templateClusterName, k8sversions[0], r.cloudCredentials)
 			require.NoError(t, err)
 
-			_, cluster, err := clusters.GetProvisioningClusterByName(r.client, clusterName, namespaces.FleetDefault)
+			cluster, err := r.client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + templateClusterName)
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
@@ -123,7 +119,7 @@ func TestTemplate(t *testing.T) {
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
-			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			err = deployment.VerifyClusterDeployments(r.client, cluster)
 			if err != nil {
 				logrus.Warningf("Deployment verification received an error: %v", err)
 			}


### PR DESCRIPTION
### Description
For the template test, there still is duplication occurring in the recurring runs. To rectify this, this PR makes the template name unique to get around that issue.

Additionally, looking deeper into the feature and our test case, we aren't even using a standard user to set this up. So removing the unnecessary code.