### PR TITLE
Update validation logic to support imported clusters

### DIFF
--- a/actions/clusters/verify.go
+++ b/actions/clusters/verify.go
@@ -2,9 +2,12 @@ package clusters
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 
+	"github.com/rancher/shepherd/clients/rancher"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/sirupsen/logrus"
 )
 
@@ -30,6 +33,25 @@ func VerifyNodePoolSize(steveClient *steveV1.Client, labelSelector string, poolS
 
 	if len(nodeList.Data) < poolSize {
 		return errors.New(SmallerPoolMessageError)
+	}
+
+	return nil
+}
+
+// VerifyServiceAccountTokenSecret verifies if a serviceAccountTokenSecret exists or not in the cluster.
+func VerifyServiceAccountTokenSecret(client *rancher.Client, clusterName string) error {
+	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	if err != nil {
+		return err
+	}
+
+	cluster, err := client.Management.Cluster.ByID(clusterID)
+	if err != nil {
+		return err
+	}
+
+	if cluster.ServiceAccountTokenSecret == "" {
+		return fmt.Errorf("ServiceAccountTokenSecret does not exist on cluster (%s)", clusterName)
 	}
 
 	return nil

--- a/actions/provisioning/verify.go
+++ b/actions/provisioning/verify.go
@@ -76,10 +76,9 @@ func VerifyRKE1Cluster(t *testing.T, client *rancher.Client, clustersConfig *clu
 
 	require.Equal(t, clustersConfig.KubernetesVersion, cluster.RancherKubernetesEngineConfig.Version)
 
-	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, cluster.Name)
+	err = clusters.VerifyServiceAccountTokenSecret(client, cluster.Name)
 	reports.TimeoutRKEReport(cluster, err)
 	require.NoError(t, err)
-	require.NotEmpty(t, clusterToken)
 
 	err = nodestat.AllManagementNodeReady(client, cluster.ID, defaults.ThirtyMinuteTimeout)
 	reports.TimeoutRKEReport(cluster, err)
@@ -124,67 +123,38 @@ func VerifyClusterReady(client *rancher.Client, cluster *steveV1.SteveAPIObject)
 	ctx, cancel := context.WithTimeout(context.Background(), defaults.FifteenMinuteTimeout)
 	defer cancel()
 
-	err := kwait.PollUntilContextTimeout(ctx, 10*time.Second, defaults.FifteenMinuteTimeout, false, func(ctx context.Context) (bool, error) {
-		adminClient, err := client.ReLogin()
+	err := kwait.PollUntilContextTimeout(ctx, 10*time.Second, defaults.FifteenMinuteTimeout, false, func(context.Context) (done bool, err error) {
+		client, err = client.ReLogin()
 		if err != nil {
 			logrus.Debugf("Unable to fetch cluster client (%s), retrying", cluster.Name)
 			return false, nil
 		}
 
-		kubeProvisioningClient, err := adminClient.GetKubeAPIProvisioningClient()
+		cluster, err = client.Steve.SteveType(stevetypes.Provisioning).ByID(cluster.ID)
+		clusterStatus := &provv1.ClusterStatus{}
+		err = steveV1.ConvertToK8sType(cluster.Status, clusterStatus)
 		if err != nil {
 			logrus.Debugf("Unable to fetch cluster kube client (%s), retrying", cluster.Name)
 			return false, nil
 		}
 
-		watchInterface, err := kubeProvisioningClient.
-			Clusters(namespaces.FleetDefault).
-			Watch(ctx, metav1.ListOptions{
-				FieldSelector:  "metadata.name=" + cluster.Name,
-				TimeoutSeconds: &defaults.WatchTimeoutSeconds,
-			},
-			)
-		if err != nil {
-			logrus.Debugf("Unable to watch cluster (%s), retrying", cluster.Name)
-			return false, nil
-		}
-
-		defer watchInterface.Stop()
-
-		checkFunc := shepherdclusters.IsProvisioningClusterReady
-
-		err = wait.WatchWait(watchInterface, checkFunc)
-		if err != nil {
+		if !clusterStatus.Ready || cluster.State.Name != "active" || cluster.State.Error == true {
 			lastErr = err
-			logrus.Debugf("Cluster (%s) not ready yet, retrying: %v", cluster.Name, err)
 			return false, nil
 		}
 
 		return true, nil
-	},
-	)
+	})
 	if err != nil {
-		logrus.Errorf("Cluster (%s) failed to become ready: %v", cluster.Name, err)
-		dumpProvisioningClusterState(ctx, client, cluster.Name, lastErr)
 		return err
 	}
 
 	logrus.Debugf("Waiting for all machines to be ready on cluster (%s)", cluster.Name)
 	err = nodestat.AllMachineReady(client, cluster.ID, defaults.FiveMinuteTimeout)
 	if err != nil {
-		logrus.Errorf("Machine readiness check failed for cluster (%s)", cluster.Name)
-		dumpProvisioningClusterState(ctx, client, cluster.Name, nil)
+		logrus.Errorf("Cluster (%s) failed to become ready: %v", cluster.Name, err)
+		dumpProvisioningClusterState(ctx, client, cluster.Name, lastErr)
 		return err
-	}
-
-	logrus.Debugf("Verifying cluster token (%s)", cluster.Name)
-	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, cluster.Name)
-	if err != nil {
-		return err
-	}
-
-	if !clusterToken {
-		return fmt.Errorf("cluster token is not valid")
 	}
 
 	return nil
@@ -413,10 +383,9 @@ func VerifyHostedCluster(t *testing.T, client *rancher.Client, cluster *manageme
 	reports.TimeoutRKEReport(cluster, err)
 	require.NoError(t, err)
 
-	clusterToken, err := clusters.CheckServiceAccountTokenSecret(client, cluster.Name)
+	err = clusters.VerifyServiceAccountTokenSecret(client, cluster.Name)
 	reports.TimeoutRKEReport(cluster, err)
 	require.NoError(t, err)
-	require.NotEmpty(t, clusterToken)
 
 	err = nodestat.AllManagementNodeReady(client, cluster.ID, defaults.ThirtyMinuteTimeout)
 	reports.TimeoutRKEReport(cluster, err)

--- a/actions/workloads/deployment/verify.go
+++ b/actions/workloads/deployment/verify.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"strconv"
 	"time"
 
-	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/charts"
+	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/defaults"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/workloads"
@@ -32,6 +33,7 @@ const (
 	Fleet              = "fleet-agent"
 	ClusterAgent       = "cattle-cluster-agent"
 	revisionAnnotation = "deployment.kubernetes.io/revision"
+	v3IDRegex          = "^c-[a-z0-9]{5}$"
 )
 
 // VerifyDeployment waits for a deployment to be ready in the downstream cluster
@@ -508,30 +510,36 @@ func VerifyDeploymentOrchestration(client *rancher.Client, clusterID, namespace,
 
 // VerifyClusterDeployments verifies that all required deployments are present and available in the cluster
 func VerifyClusterDeployments(client *rancher.Client, cluster *v1.SteveAPIObject) error {
-	status := &provv1.ClusterStatus{}
-	if err := v1.ConvertToK8sType(cluster.Status, status); err != nil {
+	clusterID := cluster.Name
+	isV3ID, err := regexp.MatchString(v3IDRegex, cluster.Name)
+	if err != nil {
 		return err
 	}
 
-	var downstreamClient *v1.Client
-	err := kwait.PollUntilContextTimeout(context.TODO(), 5*time.Second, defaults.FiveMinuteTimeout, false, func(ctx context.Context) (done bool, err error) {
-		downstreamClient, err = client.Steve.ProxyDownstream(status.ClusterName)
+	if !isV3ID {
+		clusterID, err = clusters.GetClusterIDByName(client, cluster.Name)
 		if err != nil {
-			return false, nil
+			return err
 		}
-
-		return true, nil
-	})
-
-	if downstreamClient == nil {
-		return fmt.Errorf("failed to get downstream steve client for cluster (%s)", cluster.Name)
 	}
 
-	deploymentClient := downstreamClient.SteveType(stevetypes.Deployment)
+	var downstreamClient *v1.Client
 	requiredDeployments := []string{ClusterAgent, Webhook, Fleet, SUC}
 	logrus.Debugf("Verifying all required deployments exist: %v", requiredDeployments)
-	err = kwait.PollUntilContextTimeout(context.TODO(), 5*time.Second, defaults.FifteenMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
-		clusterDeployments, err := deploymentClient.List(nil)
+	err = kwait.PollUntilContextTimeout(context.TODO(), 10*time.Second, defaults.FifteenMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
+		if slices.Contains(requiredDeployments, ClusterAgent) {
+			downstreamClient, err = client.Steve.ProxyDownstream(clusterID)
+			if err != nil {
+				return false, nil
+			}
+
+			client, err = client.ReLogin()
+			if err != nil {
+				return false, nil
+			}
+		}
+
+		clusterDeployments, err := downstreamClient.SteveType(stevetypes.Deployment).List(nil)
 		if err != nil {
 			return false, nil
 		}
@@ -561,7 +569,7 @@ func VerifyClusterDeployments(client *rancher.Client, cluster *v1.SteveAPIObject
 	logrus.Debug("Verifying all deployments")
 	var failedDeployments []appv1.Deployment
 	err = kwait.PollUntilContextTimeout(context.TODO(), 5*time.Second, defaults.TenMinuteTimeout, true, func(ctx context.Context) (done bool, err error) {
-		clusterDeployments, err := deploymentClient.List(nil)
+		clusterDeployments, err := downstreamClient.SteveType(stevetypes.Deployment).List(nil)
 		if err != nil {
 			return false, nil
 		}

--- a/actions/workloads/verify.go
+++ b/actions/workloads/verify.go
@@ -1,6 +1,8 @@
 package workloads
 
 import (
+	"regexp"
+
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
@@ -14,16 +16,23 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	v3IDRegex = "^c-[a-z0-9]{5}$"
+)
+
 // VerifyWorkloads verifies a variety of workloads on a cluster
 func VerifyWorkloads(client *rancher.Client, clusterName string, workloads Workloads) (*Workloads, error) {
-	client, err := client.ReLogin()
+	clusterID := clusterName
+	isV3ID, err := regexp.MatchString(v3IDRegex, clusterName)
 	if err != nil {
 		return nil, err
 	}
 
-	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
-	if err != nil {
-		return nil, err
+	if !isV3ID {
+		clusterID, err = clusters.GetClusterIDByName(client, clusterName)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if workloads.Deployment != nil {

--- a/actions/workloads/workloads.go
+++ b/actions/workloads/workloads.go
@@ -1,6 +1,8 @@
 package workloads
 
 import (
+	"regexp"
+
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/clusters"
 	projectsapi "github.com/rancher/tests/actions/projects"
@@ -32,9 +34,17 @@ type Workloads struct {
 
 // CreateWorkloads creates a variety of workloads on a cluster
 func CreateWorkloads(client *rancher.Client, clusterName string, workloads Workloads) (*Workloads, error) {
-	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	clusterID := clusterName
+	isV3ID, err := regexp.MatchString(v3IDRegex, clusterName)
 	if err != nil {
 		return nil, err
+	}
+
+	if !isV3ID {
+		clusterID, err = clusters.GetClusterIDByName(client, clusterName)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	logrus.Debugf("Creating a namespace on %s", clusterName)

--- a/validation/deleting/rke2/delete_machine_test.go
+++ b/validation/deleting/rke2/delete_machine_test.go
@@ -139,6 +139,10 @@ func (d *DeleteMachineTestSuite) TestDeleteMachine() {
 			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
 			err = pods.VerifyClusterPods(d.client, tt.cluster)
 			require.NoError(d.T(), err)
+
+			logrus.Infof("Verifying service account token secret (%s)", tt.cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(d.client, tt.cluster.Name)
+			require.NoError(d.T(), err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(d.client, d.cattleConfig)

--- a/validation/nodescaling/k3s/scaling_test.go
+++ b/validation/nodescaling/k3s/scaling_test.go
@@ -135,6 +135,10 @@ func (s *NodeScalingTestSuite) TestScalingNodePools() {
 			err = pods.VerifyClusterPods(s.client, tt.cluster)
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", tt.cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(s.client, tt.cluster.Name)
+			require.NoError(s.T(), err)
+
 			tt.nodeRoles.Quantity = -tt.scaleQuantity
 			logrus.Infof("Scaling down the node pool (%s)", tt.cluster.Name)
 			_, err = machinepools.ScaleMachinePool(s.client, tt.cluster, tt.nodeRoles)
@@ -150,6 +154,10 @@ func (s *NodeScalingTestSuite) TestScalingNodePools() {
 
 			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
 			err = pods.VerifyClusterPods(s.client, tt.cluster)
+			require.NoError(s.T(), err)
+
+			logrus.Infof("Verifying service account token secret (%s)", tt.cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(s.client, tt.cluster.Name)
 			require.NoError(s.T(), err)
 		})
 

--- a/validation/nodescaling/rke2/scaling_test.go
+++ b/validation/nodescaling/rke2/scaling_test.go
@@ -160,6 +160,10 @@ func (s *NodeScalingTestSuite) TestScalingNodePools() {
 			err = pods.VerifyClusterPods(s.client, tt.cluster)
 			require.NoError(s.T(), err)
 
+			logrus.Infof("Verifying service account token secret (%s)", tt.cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(s.client, tt.cluster.Name)
+			require.NoError(s.T(), err)
+
 			tt.nodeRoles.Quantity = -tt.scaleQuantity
 			logrus.Infof("Scaling down the node pool (%s)", tt.cluster.Name)
 			_, err = machinepools.ScaleMachinePool(s.client, tt.cluster, tt.nodeRoles)
@@ -175,6 +179,10 @@ func (s *NodeScalingTestSuite) TestScalingNodePools() {
 
 			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
 			err = pods.VerifyClusterPods(s.client, tt.cluster)
+			require.NoError(s.T(), err)
+
+			logrus.Infof("Verifying service account token secret (%s)", tt.cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(s.client, tt.cluster.Name)
 			require.NoError(s.T(), err)
 		})
 

--- a/validation/provisioning/k3s/ace_test.go
+++ b/validation/provisioning/k3s/ace_test.go
@@ -121,6 +121,10 @@ func TestACE(t *testing.T) {
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)
 			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(tt.client, cluster.Name)
+			require.NoError(t, err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, k.cattleConfig)

--- a/validation/provisioning/k3s/custom_test.go
+++ b/validation/provisioning/k3s/custom_test.go
@@ -118,6 +118,10 @@ func TestCustom(t *testing.T) {
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)
 			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(tt.client, cluster.Name)
+			require.NoError(t, err)
 		})
 
 		params := provisioning.GetCustomSchemaParams(tt.client, k.cattleConfig)

--- a/validation/provisioning/k3s/data_directories_test.go
+++ b/validation/provisioning/k3s/data_directories_test.go
@@ -123,6 +123,10 @@ func TestDataDirectories(t *testing.T) {
 			err = pods.VerifyClusterPods(tt.client, cluster)
 			require.NoError(t, err)
 
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(tt.client, cluster.Name)
+			require.NoError(t, err)
+
 			logrus.Infof("Verifying cluster data directories (%s)", cluster.Name)
 			provisioning.VerifyDataDirectories(t, k.client, cluster)
 		})

--- a/validation/provisioning/k3s/dynamic_custom_test.go
+++ b/validation/provisioning/k3s/dynamic_custom_test.go
@@ -115,6 +115,10 @@ func TestDynamicCustom(t *testing.T) {
 				err = pods.VerifyClusterPods(tt.client, cluster)
 				require.NoError(t, err)
 
+				logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+				err = clusters.VerifyServiceAccountTokenSecret(tt.client, cluster.Name)
+				require.NoError(t, err)
+
 				logrus.Infof("Verifying cloud provider %s", cluster.Name)
 				cloudprovider.VerifyCloudProvider(t, tt.client, defaults.K3S, clusterConfig, cluster, nil)
 

--- a/validation/provisioning/k3s/dynamic_node_driver_test.go
+++ b/validation/provisioning/k3s/dynamic_node_driver_test.go
@@ -113,6 +113,10 @@ func TestDynamicNodeDriver(t *testing.T) {
 				err = pods.VerifyClusterPods(tt.client, cluster)
 				require.NoError(t, err)
 
+				logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+				err = clusters.VerifyServiceAccountTokenSecret(tt.client, cluster.Name)
+				require.NoError(t, err)
+
 				logrus.Infof("Verifying cloud provider %s", cluster.Name)
 				cloudprovider.VerifyCloudProvider(t, tt.client, defaults.K3S, clusterConfig, cluster, nil)
 

--- a/validation/provisioning/k3s/hardened_test.go
+++ b/validation/provisioning/k3s/hardened_test.go
@@ -111,6 +111,10 @@ func TestHardened(t *testing.T) {
 			err = pods.VerifyClusterPods(tt.client, cluster)
 			require.NoError(t, err)
 
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(tt.client, cluster.Name)
+			require.NoError(t, err)
+
 			chartName := charts.ComplianceName
 			chartNamespace := charts.ComplianceNamespace
 

--- a/validation/provisioning/k3s/hostname_truncation_test.go
+++ b/validation/provisioning/k3s/hostname_truncation_test.go
@@ -117,6 +117,10 @@ func TestHostnameTruncation(t *testing.T) {
 			err = pods.VerifyClusterPods(tt.client, cluster)
 			require.NoError(t, err)
 
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(tt.client, cluster.Name)
+			require.NoError(t, err)
+
 			logrus.Infof("Verifying hostname truncation (%s)", cluster.Name)
 			provisioning.VerifyHostnameLength(t, k.client, cluster)
 		})

--- a/validation/provisioning/k3s/node_driver_test.go
+++ b/validation/provisioning/k3s/node_driver_test.go
@@ -118,6 +118,10 @@ func TestNodeDriver(t *testing.T) {
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)
 			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(tt.client, cluster.Name)
+			require.NoError(t, err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, k.cattleConfig)

--- a/validation/provisioning/k3s/psact_test.go
+++ b/validation/provisioning/k3s/psact_test.go
@@ -116,6 +116,10 @@ func TestPSACT(t *testing.T) {
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(tt.client, cluster)
 			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(tt.client, cluster.Name)
+			require.NoError(t, err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, k.cattleConfig)

--- a/validation/provisioning/k3s/template_test.go
+++ b/validation/provisioning/k3s/template_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/charts"
+	"github.com/rancher/tests/actions/clusters"
 	actionsDefaults "github.com/rancher/tests/actions/config/defaults"
 	configDefaults "github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/logging"
@@ -126,6 +127,10 @@ func TestTemplate(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(k.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(k.client, cluster.Name)
 			require.NoError(t, err)
 		})
 	}

--- a/validation/provisioning/rke2/ace_test.go
+++ b/validation/provisioning/rke2/ace_test.go
@@ -122,6 +122,10 @@ func TestACE(t *testing.T) {
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(t, err)
 
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
+			require.NoError(t, err)
+
 			logrus.Infof("Verifying ACE (%s)", cluster.Name)
 			provisioning.VerifyACE(t, r.client, cluster)
 		})

--- a/validation/provisioning/rke2/agent_customization_test.go
+++ b/validation/provisioning/rke2/agent_customization_test.go
@@ -152,6 +152,10 @@ func TestAgentCustomization(t *testing.T) {
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
+			require.NoError(t, err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/rke2/cloud_provider_test.go
+++ b/validation/provisioning/rke2/cloud_provider_test.go
@@ -118,6 +118,10 @@ func TestAWSCloudProvider(t *testing.T) {
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(t, err)
 
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
+			require.NoError(t, err)
+
 			logrus.Infof("Verifying cloud provider (%s)", cluster.Name)
 			provider.VerifyCloudProviderFunc(t, r.client, cluster)
 		})
@@ -183,6 +187,10 @@ func TestVSphereCloudProvider(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying cloud provider (%s)", cluster.Name)
@@ -251,6 +259,10 @@ func TestHarvesterCloudProvider(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying cloud provider (%s)", cluster.Name)

--- a/validation/provisioning/rke2/cni_test.go
+++ b/validation/provisioning/rke2/cni_test.go
@@ -117,6 +117,10 @@ func TestCNI(t *testing.T) {
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
+			require.NoError(t, err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/rke2/custom_test.go
+++ b/validation/provisioning/rke2/custom_test.go
@@ -126,6 +126,10 @@ func TestCustom(t *testing.T) {
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
+			require.NoError(t, err)
 		})
 
 		params := provisioning.GetCustomSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/rke2/data_directories_test.go
+++ b/validation/provisioning/rke2/data_directories_test.go
@@ -123,6 +123,10 @@ func TestDataDirectories(t *testing.T) {
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(t, err)
 
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
+			require.NoError(t, err)
+
 			logrus.Infof("Verifying cluster data directories (%s)", cluster.Name)
 			provisioning.VerifyDataDirectories(t, r.client, cluster)
 		})

--- a/validation/provisioning/rke2/dynamic_custom_test.go
+++ b/validation/provisioning/rke2/dynamic_custom_test.go
@@ -119,6 +119,10 @@ func TestDynamicCustom(t *testing.T) {
 				err = pods.VerifyClusterPods(r.client, cluster)
 				require.NoError(t, err)
 
+				logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+				err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
+				require.NoError(t, err)
+
 				logrus.Infof("Verifying cloud provider on cluster (%s)", cluster.Name)
 				cloudprovider.VerifyCloudProvider(t, tt.client, defaults.RKE2, clusterConfig, cluster, nil)
 

--- a/validation/provisioning/rke2/dynamic_node_driver_test.go
+++ b/validation/provisioning/rke2/dynamic_node_driver_test.go
@@ -117,6 +117,10 @@ func TestDynamicNodeDriver(t *testing.T) {
 				err = pods.VerifyClusterPods(r.client, cluster)
 				require.NoError(t, err)
 
+				logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+				err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
+				require.NoError(t, err)
+
 				logrus.Infof("Verifying cloud provider on cluster (%s)", cluster.Name)
 				cloudprovider.VerifyCloudProvider(t, tt.client, defaults.RKE2, clusterConfig, cluster, nil)
 

--- a/validation/provisioning/rke2/hardened_test.go
+++ b/validation/provisioning/rke2/hardened_test.go
@@ -112,6 +112,10 @@ func TestHardened(t *testing.T) {
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(t, err)
 
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
+			require.NoError(t, err)
+
 			chartName := charts.ComplianceName
 			chartNamespace := charts.ComplianceNamespace
 

--- a/validation/provisioning/rke2/hostname_truncation_test.go
+++ b/validation/provisioning/rke2/hostname_truncation_test.go
@@ -116,6 +116,10 @@ func TestHostnameTruncation(t *testing.T) {
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(t, err)
 
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
+			require.NoError(t, err)
+
 			logrus.Infof("Verifying hostname truncation (%s)", cluster.Name)
 			provisioning.VerifyHostnameLength(t, r.client, cluster)
 		})

--- a/validation/provisioning/rke2/ingress_test.go
+++ b/validation/provisioning/rke2/ingress_test.go
@@ -125,6 +125,10 @@ func TestIngress(t *testing.T) {
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
+			require.NoError(t, err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/rke2/node_driver_test.go
+++ b/validation/provisioning/rke2/node_driver_test.go
@@ -139,6 +139,10 @@ func TestNodeDriver(t *testing.T) {
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
+			require.NoError(t, err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, r.cattleConfig)

--- a/validation/provisioning/rke2/psact_test.go
+++ b/validation/provisioning/rke2/psact_test.go
@@ -133,6 +133,10 @@ func TestPSACT(t *testing.T) {
 			err = pods.VerifyClusterPods(r.client, cluster)
 			require.NoError(t, err)
 
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
+			require.NoError(t, err)
+
 			logrus.Infof("Verifying PSACT (%s)", cluster.Name)
 			provisioning.VerifyPSACT(t, r.client, cluster)
 

--- a/validation/provisioning/rke2/template_test.go
+++ b/validation/provisioning/rke2/template_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rancher/shepherd/pkg/namegenerator"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/charts"
+	"github.com/rancher/tests/actions/clusters"
 	actionsDefaults "github.com/rancher/tests/actions/config/defaults"
 	configDefaults "github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/logging"
@@ -126,6 +127,10 @@ func TestTemplate(t *testing.T) {
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 			err = pods.VerifyClusterPods(r.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(r.client, cluster.Name)
 			require.NoError(t, err)
 		})
 	}


### PR DESCRIPTION
Description: The goal of this PR is to add support for imported clusters to our rancher/test validations. The reason this was not previously supported is due to the ID/Name differences between imported and custom/node driver clusters. In addition I've removed the check
Changes:
* Update various bits of logic to support v3 structured IDs. 
* Fixed an intermittent bug that causes VerifyClusterDeployments to not properly get the client due to the cluster not being ready yet. 
* Updated the verify cluster ready logic to be more modular and adjusted the API's used to verify state. This was done to avoid issues using the validation logic on imported clusters.