### PR TITLE
aditional s3 check

### DIFF
--- a/actions/etcdsnapshot/creates.go
+++ b/actions/etcdsnapshot/creates.go
@@ -430,6 +430,22 @@ func CreateAndValidateSnapshotV2Prov(client *rancher.Client, podTemplate *corev1
 	return cluster, snapshotToRestore, postDeploymentResp, postServiceResp, err
 }
 
+// This function validates that spec.rkeConfig.etcd.s3 is not null for S3-specific snapshot tests.
+func VerifyS3Config(client *rancher.Client, clusterName string) error {
+	cluster, _, err := clusters.GetProvisioningClusterByName(client, clusterName, namespaces.FleetDefault)
+	if err != nil {
+		return err
+	}
+
+	if cluster.Spec.RKEConfig.ETCD.S3 == nil {
+		return fmt.Errorf("expected S3 configuration for cluster %s but spec.rkeConfig.etcd.s3 is empty", clusterName)
+	}
+
+	logrus.Infof("Verified S3 configuration exists for cluster %s", clusterName)
+
+	return nil
+}
+
 // RestoreAndValidateSnapshotV2Prov restores a given snapshot for a v2prov cluster and validates its resources
 // after the restore against the original cluster object
 func RestoreAndValidateSnapshotV2Prov(client *rancher.Client, snapshotID string, etcdRestore *Config, cluster *apisV1.Cluster, clusterID string) error {

--- a/validation/snapshot/k3s/snapshot_s3_restore_test.go
+++ b/validation/snapshot/k3s/snapshot_s3_restore_test.go
@@ -75,6 +75,9 @@ func (s *S3SnapshotRestoreTestSuite) SetupSuite() {
 		logrus.Info("Provisioning K3S cluster")
 		s.cluster, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.K3SClusterType.String(), provider, *clusterConfig, machineConfigSpec, nil, false, false)
 		require.NoError(s.T(), err)
+
+		err = etcdsnapshot.VerifyS3Config(s.client, s.cluster.Name)
+		require.NoError(s.T(), err)
 	} else {
 		logrus.Infof("Using existing cluster %s", rancherConfig.ClusterName)
 		s.cluster, err = client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + s.client.RancherConfig.ClusterName)

--- a/validation/snapshot/rke2/snapshot_s3_restore_test.go
+++ b/validation/snapshot/rke2/snapshot_s3_restore_test.go
@@ -75,6 +75,9 @@ func (s *S3SnapshotRestoreTestSuite) SetupSuite() {
 		logrus.Info("Provisioning RKE2 cluster")
 		s.cluster, err = resources.ProvisionRKE2K3SCluster(s.T(), standardUserClient, extClusters.RKE2ClusterType.String(), provider, *clusterConfig, machineConfigSpec, nil, false, false)
 		require.NoError(s.T(), err)
+
+		err = etcdsnapshot.VerifyS3Config(s.client, s.cluster.Name)
+		require.NoError(s.T(), err)
 	} else {
 		logrus.Infof("Using existing cluster %s", rancherConfig.ClusterName)
 		s.cluster, err = client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + s.client.RancherConfig.ClusterName)


### PR DESCRIPTION
This PR adds a post-provisioning validation to S3 snapshot restore tests to ensure the cluster was created with ETCD S3 configuration enabled.