### PR TITLE
Temporarily remove v2.13 schedule for IPv6/dual-stack

### DIFF
--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -707,7 +707,6 @@ jobs:
 
   v2-13:
     if: |
-      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13'))
     name: ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -705,7 +705,6 @@ jobs:
 
   v2-13:
     if: |
-      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13'))
     name: ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -709,7 +709,6 @@ jobs:
 
   v2-13:
     if: |
-      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13'))
     name: ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -737,7 +737,6 @@ jobs:
 
   v2-13:
     if: |
-      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13'))
     name: ${{ github.event.inputs.rancher_version }}

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -739,7 +739,6 @@ jobs:
 
   v2-13:
     if: |
-      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13'))
     name: ${{ github.event.inputs.rancher_version }}


### PR DESCRIPTION
### Description
As discussed offline, temporarily removing IPv6/dual-stack from scheduling for the 2.13 Rancher release line. This is due to known limitation for the staging registry to have it; we will have to wait until support is given.