### PR TITLE
Add S3 bucket helper and S3 snapshot test

### DIFF
--- a/validation/provisioning/resources/s3Bucket/s3Bucket.go
+++ b/validation/provisioning/resources/s3Bucket/s3Bucket.go
@@ -1,0 +1,81 @@
+package s3
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/sirupsen/logrus"
+)
+
+// CreateBucket creates an S3 bucket in the given region.
+func CreateBucket(bucketName, region string) error {
+	logrus.Infof("Creating S3 bucket: %s in region: %s", bucketName, region)
+
+	cfg, err := config.LoadDefaultConfig(context.TODO(),
+		config.WithRegion(region),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	client := awss3.NewFromConfig(cfg)
+
+	_, err = client.CreateBucket(context.TODO(), &awss3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create bucket %s: %w", bucketName, err)
+	}
+
+	logrus.Infof("Successfully created S3 bucket: %s", bucketName)
+	return nil
+}
+
+// DeleteBucket deletes all objects in a bucket and then deletes the bucket itself.
+func DeleteBucket(bucketName, region string) error {
+	logrus.Infof("Deleting S3 bucket: %s", bucketName)
+
+	cfg, err := config.LoadDefaultConfig(context.TODO(),
+		config.WithRegion(region),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	client := awss3.NewFromConfig(cfg)
+
+	// Step 1: List all objects in the bucket
+	listResp, err := client.ListObjectsV2(context.TODO(), &awss3.ListObjectsV2Input{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list objects in bucket %s: %w", bucketName, err)
+	}
+
+	// Step 2: Delete all objects
+	for _, obj := range listResp.Contents {
+		logrus.Debugf("Deleting object: %s", *obj.Key)
+
+		_, err := client.DeleteObject(context.TODO(), &awss3.DeleteObjectInput{
+			Bucket: aws.String(bucketName),
+			Key:    obj.Key,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to delete object %s: %w", *obj.Key, err)
+		}
+	}
+
+	// Step 3: Delete the bucket
+	_, err = client.DeleteBucket(context.TODO(), &awss3.DeleteBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete bucket %s: %w", bucketName, err)
+	}
+
+	logrus.Infof("Successfully deleted S3 bucket: %s", bucketName)
+	return nil
+}

--- a/validation/snapshot/k3s/snapshot_s3_restore_test.go
+++ b/validation/snapshot/k3s/snapshot_s3_restore_test.go
@@ -3,9 +3,12 @@
 package k3s
 
 import (
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	extClusters "github.com/rancher/shepherd/extensions/clusters"
@@ -13,12 +16,14 @@ import (
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/cloudcredentials"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/etcdsnapshot"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
+	s3resources "github.com/rancher/tests/validation/provisioning/resources/s3Bucket"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -27,15 +32,27 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const (
+	s3Region   = "us-east-2"
+	s3Endpoint = "s3.us-east-2.amazonaws.com"
+)
+
 type S3SnapshotRestoreTestSuite struct {
 	suite.Suite
 	session      *session.Session
 	client       *rancher.Client
 	cattleConfig map[string]any
 	cluster      *v1.SteveAPIObject
+	clusterConfig *clusters.ClusterConfig
+	bucketName    string
 }
 
 func (s *S3SnapshotRestoreTestSuite) TearDownSuite() {
+	if s.bucketName != "" {
+		err := s3resources.DeleteBucket(s.bucketName, s3Region)
+		require.NoError(s.T(), err)
+	}
+
 	s.session.Cleanup()
 }
 
@@ -68,6 +85,8 @@ func (s *S3SnapshotRestoreTestSuite) SetupSuite() {
 	rancherConfig := new(rancher.Config)
 	operations.LoadObjectFromMap(defaults.RancherConfigKey, s.cattleConfig, rancherConfig)
 
+	provider := provisioning.CreateProvider(clusterConfig.Provider)
+
 	if rancherConfig.ClusterName == "" {
 		provider := provisioning.CreateProvider(clusterConfig.Provider)
 		machineConfigSpec := provider.LoadMachineConfigFunc(s.cattleConfig)
@@ -83,6 +102,72 @@ func (s *S3SnapshotRestoreTestSuite) SetupSuite() {
 		s.cluster, err = client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + s.client.RancherConfig.ClusterName)
 		require.NoError(s.T(), err)
 	}
+
+	s.bucketName = fmt.Sprintf("k3s-s3-restore-%d", time.Now().Unix())
+	err = s3resources.CreateBucket(s.bucketName, s3Region)
+	require.NoError(s.T(), err)
+
+	err = s.configureClusterS3(provider)
+	require.NoError(s.T(), err)
+
+	err = etcdsnapshot.VerifyS3Config(s.client, s.cluster.Name)
+	require.NoError(s.T(), err)
+}
+
+func (s *S3SnapshotRestoreTestSuite) configureClusterS3(provider provisioning.Provider) error {
+	credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
+
+	cloudCredential, err := provider.CloudCredFunc(s.client, credentialSpec)
+	if err != nil {
+		return err
+	}
+
+	cluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).ByID(s.cluster.ID)
+	if err != nil {
+		return err
+	}
+
+	spec, ok := cluster.Object["spec"].(map[string]interface{})
+	if !ok || spec == nil {
+		spec = map[string]interface{}{}
+		cluster.Object["spec"] = spec
+	}
+
+	rkeConfig, ok := spec["rkeConfig"].(map[string]interface{})
+	if !ok || rkeConfig == nil {
+		rkeConfig = map[string]interface{}{}
+		spec["rkeConfig"] = rkeConfig
+	}
+
+	etcdConfig := &rkev1.ETCD{
+		S3: &rkev1.ETCDSnapshotS3{
+			Bucket:              s.bucketName,
+			CloudCredentialName: cloudCredential.Name,
+			Endpoint:            s3Endpoint,
+			Region:              s3Region,
+			SkipSSLVerify:       true,
+		},
+	}
+
+	rkeConfig["etcd"] = map[string]interface{}{
+		"s3": map[string]interface{}{
+			"bucket":              etcdConfig.S3.Bucket,
+			"cloudCredentialName": etcdConfig.S3.CloudCredentialName,
+			"endpoint":            etcdConfig.S3.Endpoint,
+			"region":              etcdConfig.S3.Region,
+			"skipSSLVerify":       etcdConfig.S3.SkipSSLVerify,
+		},
+	}
+
+	updatedCluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).Update(cluster, cluster.Object)
+	if err != nil {
+		return err
+	}
+
+	s.cluster = updatedCluster
+	logrus.Infof("Configured S3 backup target for cluster %s with bucket %s", s.cluster.Name, s.bucketName)
+
+	return nil
 }
 
 func (s *S3SnapshotRestoreTestSuite) TestS3SnapshotRestore() {

--- a/validation/snapshot/rke2/snapshot_s3_restore_test.go
+++ b/validation/snapshot/rke2/snapshot_s3_restore_test.go
@@ -3,9 +3,12 @@
 package rke2
 
 import (
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	extClusters "github.com/rancher/shepherd/extensions/clusters"
@@ -13,12 +16,14 @@ import (
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/cloudcredentials"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/etcdsnapshot"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/qase"
+	s3resources "github.com/rancher/tests/validation/provisioning/resources/s3Bucket"
 	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	"github.com/sirupsen/logrus"
@@ -27,15 +32,27 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const (
+	s3Region   = "us-east-2"
+	s3Endpoint = "s3.us-east-2.amazonaws.com"
+)
+
 type S3SnapshotRestoreTestSuite struct {
 	suite.Suite
 	session      *session.Session
 	client       *rancher.Client
 	cattleConfig map[string]any
 	cluster      *v1.SteveAPIObject
+	clusterConfig *clusters.ClusterConfig
+	bucketName    string
 }
 
 func (s *S3SnapshotRestoreTestSuite) TearDownSuite() {
+	if s.bucketName != "" {
+		err := s3resources.DeleteBucket(s.bucketName, s3Region)
+		require.NoError(s.T(), err)
+	}
+
 	s.session.Cleanup()
 }
 
@@ -68,6 +85,8 @@ func (s *S3SnapshotRestoreTestSuite) SetupSuite() {
 	rancherConfig := new(rancher.Config)
 	operations.LoadObjectFromMap(defaults.RancherConfigKey, s.cattleConfig, rancherConfig)
 
+	provider := provisioning.CreateProvider(s.clusterConfig.Provider)
+
 	if rancherConfig.ClusterName == "" {
 		provider := provisioning.CreateProvider(clusterConfig.Provider)
 		machineConfigSpec := provider.LoadMachineConfigFunc(s.cattleConfig)
@@ -83,6 +102,72 @@ func (s *S3SnapshotRestoreTestSuite) SetupSuite() {
 		s.cluster, err = client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + s.client.RancherConfig.ClusterName)
 		require.NoError(s.T(), err)
 	}
+
+	s.bucketName = fmt.Sprintf("rke2-s3-restore-%d", time.Now().Unix())
+	err = s3resources.CreateBucket(s.bucketName, s3Region)
+	require.NoError(s.T(), err)
+
+	err = s.configureClusterS3(provider)
+	require.NoError(s.T(), err)
+
+	err = etcdsnapshot.VerifyS3Config(s.client, s.cluster.Name)
+	require.NoError(s.T(), err)
+}
+
+func (s *S3SnapshotRestoreTestSuite) configureClusterS3(provider provisioning.Provider) error {
+	credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
+
+	cloudCredential, err := provider.CloudCredFunc(s.client, credentialSpec)
+	if err != nil {
+		return err
+	}
+
+	cluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).ByID(s.cluster.ID)
+	if err != nil {
+		return err
+	}
+
+	spec, ok := cluster.Object["spec"].(map[string]interface{})
+	if !ok || spec == nil {
+		spec = map[string]interface{}{}
+		cluster.Object["spec"] = spec
+	}
+
+	rkeConfig, ok := spec["rkeConfig"].(map[string]interface{})
+	if !ok || rkeConfig == nil {
+		rkeConfig = map[string]interface{}{}
+		spec["rkeConfig"] = rkeConfig
+	}
+
+	etcdConfig := &rkev1.ETCD{
+		S3: &rkev1.ETCDSnapshotS3{
+			Bucket:              s.bucketName,
+			CloudCredentialName: cloudCredential.Name,
+			Endpoint:            s3Endpoint,
+			Region:              s3Region,
+			SkipSSLVerify:       true,
+		},
+	}
+
+	rkeConfig["etcd"] = map[string]interface{}{
+		"s3": map[string]interface{}{
+			"bucket":              etcdConfig.S3.Bucket,
+			"cloudCredentialName": etcdConfig.S3.CloudCredentialName,
+			"endpoint":            etcdConfig.S3.Endpoint,
+			"region":              etcdConfig.S3.Region,
+			"skipSSLVerify":       etcdConfig.S3.SkipSSLVerify,
+		},
+	}
+
+	updatedCluster, err := s.client.Steve.SteveType(stevetypes.Provisioning).Update(cluster, cluster.Object)
+	if err != nil {
+		return err
+	}
+
+	s.cluster = updatedCluster
+	logrus.Infof("Configured S3 backup target for cluster %s with bucket %s", s.cluster.Name, s.bucketName)
+
+	return nil
 }
 
 func (s *S3SnapshotRestoreTestSuite) TestS3SnapshotRestore() {


### PR DESCRIPTION
Enable the snapshot_restore_s3_test.go to run in recurring pipelines by scoping the S3 configuration to the test itself, avoiding global configuration that affects all snapshot tests.