### PR TITLE
Remove compliance parameter in GHA workflows

### DIFF
--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -227,7 +227,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -575,7 +574,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -223,7 +223,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
@@ -556,7 +555,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
@@ -889,7 +887,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -223,7 +223,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
@@ -555,7 +554,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
@@ -887,7 +885,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -225,7 +225,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
@@ -559,7 +558,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
@@ -893,7 +891,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -235,7 +235,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -590,7 +589,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -233,7 +233,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
@@ -581,7 +580,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
@@ -929,7 +927,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -235,7 +235,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
@@ -584,7 +583,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
@@ -933,7 +931,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             networking:
               clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -231,7 +231,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             registries:
               rke2Registries:
                 mirrors:
@@ -583,7 +582,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            compliance: true
             registries:
               rke2Registries:
                 mirrors:


### PR DESCRIPTION
### Description
In our GHA workflows, we are setting `compliance: true`. This is already being handled inside of the `hardened_test.go`, so we should not be doing this here.

We have custom cluster provisioning tests that we DO NOT want to be hardened, so having this will harden every custom cluster. This PR fixes that.