### PR TITLE
Updating Tests

### DIFF
--- a/actions/kubeapi/workloads/deployments/deployments.go
+++ b/actions/kubeapi/workloads/deployments/deployments.go
@@ -129,9 +129,10 @@ func WaitForDeploymentActive(client *rancher.Client, clusterID, namespaceName, d
 		}
 
 		if deployment.Spec.Replicas != nil &&
-			*deployment.Spec.Replicas == deployment.Status.UpdatedReplicas &&
-			*deployment.Spec.Replicas == deployment.Status.ReadyReplicas &&
-			*deployment.Spec.Replicas == deployment.Status.AvailableReplicas {
+			*deployment.Spec.Replicas == deployment.Status.AvailableReplicas &&
+			(deployment.Spec.Paused ||
+				(*deployment.Spec.Replicas == deployment.Status.UpdatedReplicas &&
+					*deployment.Spec.Replicas == deployment.Status.ReadyReplicas)) {
 			return true, nil
 		}
 

--- a/actions/kubeapi/workloads/deployments/update.go
+++ b/actions/kubeapi/workloads/deployments/update.go
@@ -2,6 +2,7 @@ package deployments
 
 import (
 	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/charts"
 	clusterapi "github.com/rancher/tests/actions/kubeapi/clusters"
 	appv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +32,34 @@ func UpdateDeployment(client *rancher.Client, clusterID, namespaceName string, d
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	return updatedDeployment, err
+}
+
+// UpdateOrchestration is a helper function to update a orchestration in a cluster. If waitForDeployment is true, the function will wait for the deployment to be active
+func UpdateOrchestration(client *rancher.Client, clusterID, namespaceName string, deployment *appv1.Deployment, waitForDeployment bool) (*appv1.Deployment, error) {
+	wranglerContext, err := clusterapi.GetClusterWranglerContext(client, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	latestDeployment, err := wranglerContext.Apps.Deployment().Get(namespaceName, deployment.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	deployment.ResourceVersion = latestDeployment.ResourceVersion
+
+	updatedDeployment, err := wranglerContext.Apps.Deployment().Update(deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	if waitForDeployment {
+		err = charts.WatchAndWaitDeployments(client, clusterID, namespaceName, metav1.ListOptions{
+			FieldSelector: "metadata.name=" + updatedDeployment.Name,
+		})
 	}
 
 	return updatedDeployment, err

--- a/actions/kubeapi/workloads/deployments/update.go
+++ b/actions/kubeapi/workloads/deployments/update.go
@@ -60,6 +60,9 @@ func UpdateOrchestration(client *rancher.Client, clusterID, namespaceName string
 		err = charts.WatchAndWaitDeployments(client, clusterID, namespaceName, metav1.ListOptions{
 			FieldSelector: "metadata.name=" + updatedDeployment.Name,
 		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return updatedDeployment, err

--- a/actions/kubeapi/workloads/deployments/update.go
+++ b/actions/kubeapi/workloads/deployments/update.go
@@ -2,7 +2,6 @@ package deployments
 
 import (
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/extensions/charts"
 	clusterapi "github.com/rancher/tests/actions/kubeapi/clusters"
 	appv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,37 +28,6 @@ func UpdateDeployment(client *rancher.Client, clusterID, namespaceName string, d
 
 	if waitForDeployment {
 		err = WaitForDeploymentActive(client, clusterID, namespaceName, deployment.Name)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return updatedDeployment, err
-}
-
-// UpdateOrchestration is a helper function to update a orchestration in a cluster. If waitForDeployment is true, the function will wait for the deployment to be active
-func UpdateOrchestration(client *rancher.Client, clusterID, namespaceName string, deployment *appv1.Deployment, waitForDeployment bool) (*appv1.Deployment, error) {
-	wranglerContext, err := clusterapi.GetClusterWranglerContext(client, clusterID)
-	if err != nil {
-		return nil, err
-	}
-
-	latestDeployment, err := wranglerContext.Apps.Deployment().Get(namespaceName, deployment.Name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	deployment.ResourceVersion = latestDeployment.ResourceVersion
-
-	updatedDeployment, err := wranglerContext.Apps.Deployment().Update(deployment)
-	if err != nil {
-		return nil, err
-	}
-
-	if waitForDeployment {
-		err = charts.WatchAndWaitDeployments(client, clusterID, namespaceName, metav1.ListOptions{
-			FieldSelector: "metadata.name=" + updatedDeployment.Name,
-		})
 		if err != nil {
 			return nil, err
 		}

--- a/actions/workloads/deployment/verify.go
+++ b/actions/workloads/deployment/verify.go
@@ -435,15 +435,7 @@ func VerifyDeploymentOrchestration(client *rancher.Client, clusterID, namespace,
 
 	logrus.Debugf("Pausing orchestration on deployment: %s", deployment.Name)
 	deployment.Spec.Paused = true
-	deployment, err = deploymentapi.UpdateDeployment(client, clusterID, deployment.Namespace, deployment, false)
-	if err != nil {
-		return err
-	}
-
-	logrus.Debugf("Waiting orchestration on deployment: %s", deployment.Name)
-	err = charts.WatchAndWaitDeployments(client, clusterID, deployment.Namespace, metav1.ListOptions{
-		FieldSelector: "metadata.name=" + deployment.Name,
-	})
+	deployment, err = deploymentapi.UpdateDeployment(client, clusterID, deployment.Namespace, deployment, true)
 	if err != nil {
 		return err
 	}
@@ -468,15 +460,7 @@ func VerifyDeploymentOrchestration(client *rancher.Client, clusterID, namespace,
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{newContainerTemplate}
 
 	logrus.Debugf("Updating deployment (%s) image: %s replicas: %v", deployment.Name, redisImageName, replicas)
-	deployment, err = deploymentapi.UpdateDeployment(client, clusterID, deployment.Namespace, deployment, false)
-	if err != nil {
-		return err
-	}
-
-	logrus.Debugf("Waiting orchestration on deployment: %s", deployment.Name)
-	err = charts.WatchAndWaitDeployments(client, clusterID, deployment.Namespace, metav1.ListOptions{
-		FieldSelector: "metadata.name=" + deployment.Name,
-	})
+	deployment, err = deploymentapi.UpdateDeployment(client, clusterID, deployment.Namespace, deployment, true)
 	if err != nil {
 		return err
 	}
@@ -499,15 +483,7 @@ func VerifyDeploymentOrchestration(client *rancher.Client, clusterID, namespace,
 
 	logrus.Debug("Resuming orchestration")
 	deployment.Spec.Paused = false
-	deployment, err = deploymentapi.UpdateDeployment(client, clusterID, deployment.Namespace, deployment, false)
-	if err != nil {
-		return err
-	}
-
-	logrus.Debugf("Waiting orchestration on deployment: %s", deployment.Name)
-	err = charts.WatchAndWaitDeployments(client, clusterID, deployment.Namespace, metav1.ListOptions{
-		FieldSelector: "metadata.name=" + deployment.Name,
-	})
+	deployment, err = deploymentapi.UpdateDeployment(client, clusterID, deployment.Namespace, deployment, true)
 	if err != nil {
 		return err
 	}

--- a/actions/workloads/deployment/verify.go
+++ b/actions/workloads/deployment/verify.go
@@ -435,7 +435,7 @@ func VerifyDeploymentOrchestration(client *rancher.Client, clusterID, namespace,
 
 	logrus.Debugf("Pausing orchestration on deployment: %s", deployment.Name)
 	deployment.Spec.Paused = true
-	deployment, err = deploymentapi.UpdateDeployment(client, clusterID, deployment.Namespace, deployment, true)
+	deployment, err = deploymentapi.UpdateOrchestration(client, clusterID, deployment.Namespace, deployment, true)
 	if err != nil {
 		return err
 	}
@@ -460,7 +460,7 @@ func VerifyDeploymentOrchestration(client *rancher.Client, clusterID, namespace,
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{newContainerTemplate}
 
 	logrus.Debugf("Updating deployment (%s) image: %s replicas: %v", deployment.Name, redisImageName, replicas)
-	deployment, err = deploymentapi.UpdateDeployment(client, clusterID, deployment.Namespace, deployment, true)
+	deployment, err = deploymentapi.UpdateOrchestration(client, clusterID, deployment.Namespace, deployment, true)
 	if err != nil {
 		return err
 	}
@@ -483,7 +483,7 @@ func VerifyDeploymentOrchestration(client *rancher.Client, clusterID, namespace,
 
 	logrus.Debug("Resuming orchestration")
 	deployment.Spec.Paused = false
-	deployment, err = deploymentapi.UpdateDeployment(client, clusterID, deployment.Namespace, deployment, true)
+	deployment, err = deploymentapi.UpdateOrchestration(client, clusterID, deployment.Namespace, deployment, true)
 
 	logrus.Debugf("Verifying that the deployment image was updated to %s", redisImageName)
 	err = VerifyDeploymentScale(client, clusterID, deployment.Namespace, deployment, redisImageName, int(replicas))

--- a/actions/workloads/deployment/verify.go
+++ b/actions/workloads/deployment/verify.go
@@ -484,6 +484,9 @@ func VerifyDeploymentOrchestration(client *rancher.Client, clusterID, namespace,
 	logrus.Debug("Resuming orchestration")
 	deployment.Spec.Paused = false
 	deployment, err = deploymentapi.UpdateOrchestration(client, clusterID, deployment.Namespace, deployment, true)
+	if err != nil {
+		return err
+	}
 
 	logrus.Debugf("Verifying that the deployment image was updated to %s", redisImageName)
 	err = VerifyDeploymentScale(client, clusterID, deployment.Namespace, deployment, redisImageName, int(replicas))

--- a/actions/workloads/deployment/verify.go
+++ b/actions/workloads/deployment/verify.go
@@ -435,7 +435,15 @@ func VerifyDeploymentOrchestration(client *rancher.Client, clusterID, namespace,
 
 	logrus.Debugf("Pausing orchestration on deployment: %s", deployment.Name)
 	deployment.Spec.Paused = true
-	deployment, err = deploymentapi.UpdateOrchestration(client, clusterID, deployment.Namespace, deployment, true)
+	deployment, err = deploymentapi.UpdateDeployment(client, clusterID, deployment.Namespace, deployment, false)
+	if err != nil {
+		return err
+	}
+
+	logrus.Debugf("Waiting orchestration on deployment: %s", deployment.Name)
+	err = charts.WatchAndWaitDeployments(client, clusterID, deployment.Namespace, metav1.ListOptions{
+		FieldSelector: "metadata.name=" + deployment.Name,
+	})
 	if err != nil {
 		return err
 	}
@@ -460,7 +468,15 @@ func VerifyDeploymentOrchestration(client *rancher.Client, clusterID, namespace,
 	deployment.Spec.Template.Spec.Containers = []corev1.Container{newContainerTemplate}
 
 	logrus.Debugf("Updating deployment (%s) image: %s replicas: %v", deployment.Name, redisImageName, replicas)
-	deployment, err = deploymentapi.UpdateOrchestration(client, clusterID, deployment.Namespace, deployment, true)
+	deployment, err = deploymentapi.UpdateDeployment(client, clusterID, deployment.Namespace, deployment, false)
+	if err != nil {
+		return err
+	}
+
+	logrus.Debugf("Waiting orchestration on deployment: %s", deployment.Name)
+	err = charts.WatchAndWaitDeployments(client, clusterID, deployment.Namespace, metav1.ListOptions{
+		FieldSelector: "metadata.name=" + deployment.Name,
+	})
 	if err != nil {
 		return err
 	}
@@ -483,7 +499,15 @@ func VerifyDeploymentOrchestration(client *rancher.Client, clusterID, namespace,
 
 	logrus.Debug("Resuming orchestration")
 	deployment.Spec.Paused = false
-	deployment, err = deploymentapi.UpdateOrchestration(client, clusterID, deployment.Namespace, deployment, true)
+	deployment, err = deploymentapi.UpdateDeployment(client, clusterID, deployment.Namespace, deployment, false)
+	if err != nil {
+		return err
+	}
+
+	logrus.Debugf("Waiting orchestration on deployment: %s", deployment.Name)
+	err = charts.WatchAndWaitDeployments(client, clusterID, deployment.Namespace, metav1.ListOptions{
+		FieldSelector: "metadata.name=" + deployment.Name,
+	})
 	if err != nil {
 		return err
 	}

--- a/validation/networking/connectivity/network_policy_test.go
+++ b/validation/networking/connectivity/network_policy_test.go
@@ -73,11 +73,14 @@ func (n *NetworkPolicyTestSuite) SetupSuite() {
 	require.NoError(n.T(), err)
 }
 
+// The NetworkPolicy name must follow RFC 1123 rules: it should contain only lowercase alphanumeric characters, -, or .
+// and must start and end with an alphanumeric character, and match the regex:
+// [a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*
 func (n *NetworkPolicyTestSuite) TestPingPodsFromCPNode() {
 	networkPolicyTests := []struct {
 		name string
 	}{
-		{"Network_Policy_Connectivity"},
+		{"Network-Policy-Connectivity"},
 	}
 
 	for _, networkPolicyTest := range networkPolicyTests {
@@ -86,7 +89,7 @@ func (n *NetworkPolicyTestSuite) TestPingPodsFromCPNode() {
 			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, n.cattleConfig, workloadConfigs)
 
 			workloadConfigs.DaemonSet.ObjectMeta.Namespace = n.namespace.Name
-			workloadConfigs.DaemonSet.ObjectMeta.GenerateName = strings.ToLower(networkPolicyTest.name) + "-"
+			workloadConfigs.DaemonSet.ObjectMeta.GenerateName = strings.ToLower(networkPolicyTest.name)
 
 			logrus.Infof("Creating daemonset with name prefix: %s", workloadConfigs.DaemonSet.ObjectMeta.GenerateName)
 			testDaemonset, err := daemonset.CreateDaemonSetFromConfig(n.downstreamClient, n.cluster.ID, workloadConfigs.DaemonSet)


### PR DESCRIPTION
This pull request improves deployment orchestration verification and ensures compliance with naming conventions in network policy tests. The main changes include updating deployment update calls to use synchronous orchestration and adding explicit waiting for deployment readiness, as well as correcting network policy names to follow RFC 1123 standards.

**Deployment orchestration improvements:**

* Updated all calls to `deploymentapi.UpdateDeployment` in `verify.go` to pass `false` for the orchestration parameter, ensuring synchronous updates for pausing, updating, and resuming deployments. [[1]](diffhunk://#diff-5a0f24aece9a24febbdd2fa9072d16441c9ae7024c265e806074edca6af5f0bdL438-R446) [[2]](diffhunk://#diff-5a0f24aece9a24febbdd2fa9072d16441c9ae7024c265e806074edca6af5f0bdL463-R479) [[3]](diffhunk://#diff-5a0f24aece9a24febbdd2fa9072d16441c9ae7024c265e806074edca6af5f0bdL486-R513)
* Added calls to `charts.WatchAndWaitDeployments` after each deployment update to explicitly wait for the deployment to reach the desired state before proceeding, improving reliability of orchestration verification. [[1]](diffhunk://#diff-5a0f24aece9a24febbdd2fa9072d16441c9ae7024c265e806074edca6af5f0bdL438-R446) [[2]](diffhunk://#diff-5a0f24aece9a24febbdd2fa9072d16441c9ae7024c265e806074edca6af5f0bdL463-R479) [[3]](diffhunk://#diff-5a0f24aece9a24febbdd2fa9072d16441c9ae7024c265e806074edca6af5f0bdL486-R513)

**Network policy test improvements:**

* Updated the network policy test name in `TestPingPodsFromCPNode` to use a hyphen instead of an underscore, ensuring compliance with RFC 1123 naming rules.
* Modified the `GenerateName` for daemonsets in the test to remove the trailing hyphen and use the lowercased test name directly, further ensuring valid resource names.