### PR TITLE
Fix template client timeout/nil cluster

### DIFF
--- a/actions/clusters/clusters.go
+++ b/actions/clusters/clusters.go
@@ -1,9 +1,11 @@
 package clusters
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
@@ -15,6 +17,7 @@ import (
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/steve"
 	"github.com/rancher/tests/actions/machinepools"
@@ -22,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -982,4 +986,33 @@ func DeleteInitMachine(client *rancher.Client, clusterID string) error {
 	}
 
 	return nil
+}
+
+func GetClusterByName(client *rancher.Client, clusterName string) (*v1.SteveAPIObject, error) {
+	var cluster *v1.SteveAPIObject
+	var clientErr error
+
+	err := kwait.PollUntilContextTimeout(context.TODO(), 10*time.Second, defaults.FiveMinuteTimeout, false, func(ctx context.Context) (done bool, err error) {
+		adminClient, adminClientErr := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
+		if adminClientErr != nil {
+			logrus.Warningf("Unable to get admin cluster client (%s) retrying", clusterName)
+			clientErr = adminClientErr
+			return false, nil
+		}
+
+		clientErr = nil
+		cluster, err = adminClient.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + clusterName)
+		if err != nil {
+			logrus.Warningf("Unable to get cluster (%s) retrying", clusterName)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		logrus.Warning(clientErr)
+		return nil, err
+	}
+
+	return cluster, nil
 }

--- a/actions/provisioning/creates.go
+++ b/actions/provisioning/creates.go
@@ -186,33 +186,12 @@ func CreateProvisioningCluster(client *rancher.Client, provider Provider, creden
 	}
 
 	logrus.Debugf("Get cluster object (%s)", clusterName)
-	var createdCluster *v1.SteveAPIObject
-	var clientErr error
-	err = kwait.PollUntilContextTimeout(context.TODO(), 10*time.Second, defaults.FiveMinuteTimeout, false, func(ctx context.Context) (done bool, err error) {
-		adminClient, err := rancher.NewClient(client.RancherConfig.AdminToken, client.Session)
-		if err != nil {
-			logrus.Warningf("Unable to get admin cluster client (%s) retrying", clusterName)
-			clientErr = err
-			return false, nil
-		}
-
-		createdCluster, err = adminClient.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetDefault + "/" + clusterName)
-		if err != nil {
-			logrus.Warningf("Unable to get cluster (%s) retrying", clusterName)
-			return false, nil
-		}
-
-		return true, nil
-	})
+	createdCluster, err := clusters.GetClusterByName(client, clusterName)
 	if err != nil {
-		return createdCluster, err
+		return nil, err
 	}
 
-	if clientErr != nil && createdCluster == nil {
-		return createdCluster, clientErr
-	}
-
-	return createdCluster, clientErr
+	return createdCluster, nil
 }
 
 // CreateProvisioningCustomCluster provisions a non-rke1 cluster using a 3rd party client for its nodes, then runs verify checks

--- a/validation/provisioning/k3s/template_test.go
+++ b/validation/provisioning/k3s/template_test.go
@@ -112,7 +112,7 @@ func TestTemplate(t *testing.T) {
 			err = charts.InstallTemplateChart(k.client, k.templateConfig.Repo.ObjectMeta.Name, k.templateConfig.TemplateName, templateClusterName, k8sversions[0], k.cloudCredentials)
 			require.NoError(t, err)
 
-			cluster, err := k.client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + templateClusterName)
+			cluster, err := clusters.GetClusterByName(k.client, templateClusterName)
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)

--- a/validation/provisioning/rke2/template_test.go
+++ b/validation/provisioning/rke2/template_test.go
@@ -112,7 +112,7 @@ func TestTemplate(t *testing.T) {
 			err = charts.InstallTemplateChart(r.client, r.templateConfig.Repo.ObjectMeta.Name, r.templateConfig.TemplateName, templateClusterName, k8sversions[0], r.cloudCredentials)
 			require.NoError(t, err)
 
-			cluster, err := r.client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + templateClusterName)
+			cluster, err := clusters.GetClusterByName(r.client, templateClusterName)
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)


### PR DESCRIPTION
Changes:
* Created a function to get a cluster with retries
* Updated a few locations that require the above function.