### PR TITLE
Update VerifyServiceAccountToken to handle imported/hosted clusters

### DIFF
--- a/actions/clusters/verify.go
+++ b/actions/clusters/verify.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"regexp"
 
 	"github.com/rancher/shepherd/clients/rancher"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
@@ -12,6 +13,7 @@ import (
 )
 
 const (
+	v3IDPattern             = `^c-[a-z0-9]{5}$`
 	LabelWorker             = "labelSelector=node-role.kubernetes.io/worker=true"
 	SmallerPoolMessageError = "Machine pool cluster size is smaller than expected pool size"
 )
@@ -38,11 +40,20 @@ func VerifyNodePoolSize(steveClient *steveV1.Client, labelSelector string, poolS
 	return nil
 }
 
-// VerifyServiceAccountTokenSecret verifies if a serviceAccountTokenSecret exists or not in the cluster.
+// VerifyServiceAccountTokenSecret is a helper function that checks if the ServiceAccountTokenSecret exists on the cluster
 func VerifyServiceAccountTokenSecret(client *rancher.Client, clusterName string) error {
-	clusterID, err := clusters.GetClusterIDByName(client, clusterName)
+	clusterID := clusterName
+
+	matchesClusterIDPattern, err := regexp.MatchString(v3IDPattern, clusterName)
 	if err != nil {
 		return err
+	}
+
+	if !matchesClusterIDPattern {
+		clusterID, err = clusters.GetClusterIDByName(client, clusterName)
+		if err != nil {
+			return err
+		}
 	}
 
 	cluster, err := client.Management.Cluster.ByID(clusterID)

--- a/actions/provisioning/verify.go
+++ b/actions/provisioning/verify.go
@@ -134,6 +134,10 @@ func VerifyClusterReady(client *rancher.Client, cluster *steveV1.SteveAPIObject)
 		}
 
 		cluster, err = client.Steve.SteveType(stevetypes.Provisioning).ByID(cluster.ID)
+		if err != nil {
+			return false, nil
+		}
+
 		clusterStatus := &provv1.ClusterStatus{}
 		err = steveV1.ConvertToK8sType(cluster.Status, clusterStatus)
 		if err != nil {


### PR DESCRIPTION
Description: These changes are needed so I can continue my consolidation work across tfp-automation and rancher/tests. 

Changes:
* Added a regex to the VerifyServiceAccountToken check.
* Added an error return which should have existed 😓 