### PR TITLE
Fix ACE test

### DIFF
--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -390,7 +390,7 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-channel: ${{ secrets.SLACK_CHANNEL }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-  
+
   v2-14:
     if: |
       github.event_name == 'schedule' ||

--- a/actions/provisioning/verify.go
+++ b/actions/provisioning/verify.go
@@ -554,19 +554,37 @@ func VerifyACELocalUnavailable(t *testing.T, rancherClient *rancher.Client, clus
 	var controlPlaneIP string
 
 	for _, node := range nodes.Items {
-		if node.Labels["node-role.kubernetes.io/control-plane"] == "true" {
-			for _, addr := range node.Status.Addresses {
-				if addr.Type == corev1.NodeExternalIP {
-					controlPlaneIP = addr.Address
-					break
-				}
-			}
-			if controlPlaneIP != "" {
-				break
+
+		var externalIP, hostname string
+
+		for _, addr := range node.Status.Addresses {
+			switch addr.Type {
+			case corev1.NodeExternalIP:
+				externalIP = addr.Address
+			case corev1.NodeHostName:
+				hostname = addr.Address
 			}
 		}
+
+		candidates := []string{externalIP, hostname}
+
+		for _, ip := range candidates {
+			if ip == "" {
+				continue
+			}
+			if strings.HasPrefix(ip, "172.") || strings.HasPrefix(ip, "192.") || strings.HasPrefix(ip, "10.") {
+				continue
+			}
+
+			controlPlaneIP = ip
+			break
+		}
+
+		if controlPlaneIP != "" {
+			break
+		}
 	}
-	require.NotEmpty(t, controlPlaneIP, "could not find controlplane node IP")
+	require.NotEmpty(t, controlPlaneIP, "no usable public IP found on any node")
 
 	scpCmd := exec.Command(
 		"ssh",

--- a/validation/provisioning/k3s/ace_test.go
+++ b/validation/provisioning/k3s/ace_test.go
@@ -130,7 +130,6 @@ func TestACE(t *testing.T) {
 
 		if cluster != nil {
 			extClusters.DeleteK3SRKE2Cluster(k.client, cluster.ID)
-			provisioning.VerifyDeleteRKE2K3SCluster(t, k.client, cluster.ID)
 		}
 
 		k.session.Cleanup()

--- a/validation/provisioning/rke2/ace_test.go
+++ b/validation/provisioning/rke2/ace_test.go
@@ -131,7 +131,6 @@ func TestACE(t *testing.T) {
 
 		if cluster != nil {
 			extClusters.DeleteK3SRKE2Cluster(r.client, cluster.ID)
-			provisioning.VerifyDeleteRKE2K3SCluster(t, r.client, cluster.ID)
 		}
 
 		r.session.Cleanup()


### PR DESCRIPTION
Ensures public IP is grabbed from local, to then fetch kubeconfig. If no public IP is found, check the next node until a usable IP is targeted.

Recent failures seen overnight were due to missing public IP on the targeted node.  This enhancement, now will check the next node in search of a public IP, if unable to retrieve it from the first node thats fetched