### PR TITLE
Fixing downstream cluster cleanup  issue

### DIFF
--- a/validation/pipeline/scripts/destroy_qa_infra.sh
+++ b/validation/pipeline/scripts/destroy_qa_infra.sh
@@ -32,15 +32,6 @@ fi
 # --- Terraform Steps ---
 echo "--- Terraform Destroy ---"
 
-# Select the Terraform workspace
-tofu -chdir="$TERRAFORM_DIR" workspace select "$WORKSPACE_NAME"
-if [ $? -ne 0 ]; then
-    echo "Error: Terraform workspace select failed."
-    exit 1
-fi
-
-export TF_WORKSPACE="$WORKSPACE_NAME"
-
 # Destroy the Terraform infrastructure
 tofu -chdir="$TERRAFORM_DIR" destroy -auto-approve -var-file="$TFVARS_FILE"
 if [ $? -ne 0 ]; then

--- a/validation/pipeline/scripts/destroy_qa_infra.sh
+++ b/validation/pipeline/scripts/destroy_qa_infra.sh
@@ -14,6 +14,8 @@ DOWNSTREAM_TFVARS_FILE="downstream-cluster.tfvars"
 GENERATED_TFVARS_FILE="$REPO_ROOT/ansible/rancher/default-ha/generated.tfvars"
 : "${BUILD_DOWNSTREAM_CLUSTER:=true}"
 
+export TF_WORKSPACE="$WORKSPACE_NAME"
+
 if [[ "$BUILD_DOWNSTREAM_CLUSTER" == "true" ]]; then
     # --- Rancher Cluster Module Destroy ---
     echo "--- Rancher Cluster Module Destroy ---"


### PR DESCRIPTION
The downstream clusters for PIT, recurring daily, and weekly jobs were not being destroyed

This PR aims to fix downstream cluster cleanup in the QA infra teardown pipeline by ensuring the correct OpenTofu/Terraform workspace is used during destroy.

Changes:

Export TF_WORKSPACE early in the destroy script so downstream (rancher/cluster) teardown runs against the intended workspace.