### PR TITLE
Save test results only on scheduled runs

### DIFF
--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -392,13 +392,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-cluster-provisioning-v2-15-${{ github.run_id }}
@@ -758,13 +758,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-cluster-provisioning-v2-14-${{ github.run_id }}
@@ -1125,13 +1125,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"cluster-provisioning\", \"job\": \"v2-13\" }" > test-result-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-cluster-provisioning-v2-13-${{ github.run_id }}

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -372,13 +372,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-dualstack-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-dualstack-cluster-provisioning-v2-15-${{ github.run_id }}
@@ -717,13 +717,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-dualstack-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-dualstack-cluster-provisioning-v2-14-${{ github.run_id }}
@@ -1062,13 +1062,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-cluster-provisioning\", \"job\": \"v2-13\" }" > test-result-dualstack-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-dualstack-cluster-provisioning-v2-13-${{ github.run_id }}

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -371,13 +371,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-rancher-ipv6-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-15-${{ github.run_id }}
@@ -715,13 +715,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-rancher-ipv6-cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-14-${{ github.run_id }}
@@ -1059,13 +1059,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-rancher-ipv6-cluster-provisioning\", \"job\": \"v2-13\" }" > test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-13-${{ github.run_id }}

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -373,13 +373,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"ipv6-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-ipv6-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-ipv6-cluster-provisioning-v2-15-${{ github.run_id }}
@@ -719,13 +719,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"ipv6-cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-ipv6-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-ipv6-cluster-provisioning-v2-14-${{ github.run_id }}
@@ -1065,13 +1065,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"ipv6-cluster-provisioning\", \"job\": \"v2-13\" }" > test-result-ipv6-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-ipv6-cluster-provisioning-v2-13-${{ github.run_id }}

--- a/.github/workflows/post-release-prime.yml
+++ b/.github/workflows/post-release-prime.yml
@@ -298,13 +298,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"post-release-prime-test\", \"job\": \"v2-14\" }" > test-result-post-release-prime-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-post-release-prime-test-v2-14-${{ github.run_id }}
@@ -551,13 +551,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"post-release-prime-test\", \"job\": \"v2-13\" }" > test-result-post-release-prime-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-post-release-prime-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/prime-recurring-tests.yml
+++ b/.github/workflows/prime-recurring-tests.yml
@@ -342,13 +342,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"prime-recurring-test\", \"job\": \"v2-15\" }" > test-result-prime-recurring-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-prime-recurring-test-v2-15-${{ github.run_id }}

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -398,13 +398,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-cluster-provisioning-test\", \"job\": \"v2-15\" }" > test-result-rancher-upgrade-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-rancher-upgrade-cluster-provisioning-test-v2-15-${{ github.run_id }}
@@ -770,13 +770,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-cluster-provisioning-test\", \"job\": \"v2-14\" }" > test-result-rancher-upgrade-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-rancher-upgrade-cluster-provisioning-test-v2-14-${{ github.run_id }}
@@ -1143,13 +1143,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-cluster-provisioning-test\", \"job\": \"v2-13\" }" > test-result-rancher-upgrade-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-rancher-upgrade-cluster-provisioning-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -387,13 +387,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"recurring-dualstack-test\", \"job\": \"v2-15\" }" > test-result-recurring-dualstack-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-recurring-dualstack-test-v2-15-${{ github.run_id }}
@@ -747,13 +747,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"recurring-dualstack-test\", \"job\": \"v2-14\" }" > test-result-recurring-dualstack-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-recurring-dualstack-test-v2-14-${{ github.run_id }}
@@ -1107,13 +1107,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"recurring-dualstack-test\", \"job\": \"v2-13\" }" > test-result-recurring-dualstack-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-recurring-dualstack-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -388,13 +388,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"recurring-ipv6-test\", \"job\": \"v2-15\" }" > test-result-recurring-ipv6-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-recurring-ipv6-test-v2-15-${{ github.run_id }}
@@ -749,13 +749,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"recurring-ipv6-test\", \"job\": \"v2-14\" }" > test-result-recurring-ipv6-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-recurring-ipv6-test-v2-14-${{ github.run_id }}
@@ -1110,13 +1110,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"recurring-ipv6-test\", \"job\": \"v2-13\" }" > test-result-recurring-ipv6-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-recurring-ipv6-test-v2-13-${{ github.run_id }}

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -390,13 +390,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"recurring-test\", \"job\": \"v2-15\" }" > test-result-recurring-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-recurring-test-v2-15-${{ github.run_id }}
@@ -754,13 +754,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"recurring-test\", \"job\": \"v2-14\" }" > test-result-recurring-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-recurring-test-v2-14-${{ github.run_id }}
@@ -1119,13 +1119,13 @@ jobs:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: |
           echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"recurring-test\", \"job\": \"v2-13\" }" > test-result-recurring-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
-        if: always()
+        if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
           name: test-result-recurring-test-v2-13-${{ github.run_id }}


### PR DESCRIPTION
### Description
Thinking further through the recent weekly report results, we want to limit this to strictly just scheduled runs. We often test PR changes in GHA, so this will quickly create meaningless results. We want to ensure that the data we are parsing is strictly from scheduled runs only.