### PR TITLE
Conditionally skip AWS cloud provider test

### DIFF
--- a/validation/provisioning/rke2/cloud_provider_test.go
+++ b/validation/provisioning/rke2/cloud_provider_test.go
@@ -30,6 +30,7 @@ type cloudProviderTest struct {
 	session            *session.Session
 	standardUserClient *rancher.Client
 	cattleConfig       map[string]any
+	rancherConfig      *rancher.Config
 }
 
 func cloudProviderSetup(t *testing.T) cloudProviderTest {
@@ -55,6 +56,9 @@ func cloudProviderSetup(t *testing.T) cloudProviderTest {
 
 	r.cattleConfig, err = defaults.SetK8sDefault(client, defaults.RKE2, r.cattleConfig)
 	require.NoError(t, err)
+
+	r.rancherConfig = new(rancher.Config)
+	operations.LoadObjectFromMap(defaults.RancherConfigKey, r.cattleConfig, r.rancherConfig)
 
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	require.NoError(t, err)
@@ -94,6 +98,10 @@ func TestAWSCloudProvider(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
+			if *r.rancherConfig.Insecure {
+				t.Skip("Known issue: https://github.com/rancher/rancher/issues/54617")
+			}
 
 			clusterConfig.CloudProvider = providers.AWS
 			clusterConfig.MachinePools = tt.machinePools


### PR DESCRIPTION
### Description
From offline debugging of the AWS cloud provider, it was noted that this is a legitimate but that is being found in how this Rancher configuration is setup. As such, adding a conditional skip if this is an insecure Rancher (more details can be found in the reported bug).