### PR TITLE
Address the Qase reporting for cluster provisioning workflows

### DIFF
--- a/.github/actions/run-hostbusters-provisioning/action.yaml
+++ b/.github/actions/run-hostbusters-provisioning/action.yaml
@@ -24,13 +24,13 @@ runs:
 
         gotestsum --format standard-verbose \
           --packages=github.com/rancher/tests/validation/provisioning/... \
-          --junitfile results_provisioning.xml \
-          --jsonfile results_provisioning.json \
+          --junitfile results.xml \
+          --jsonfile results.json \
           -- -timeout=3h -tags=${{ inputs.tags }} -v
 
         provisioning_exit=$?
         echo "provisioning_exit=$provisioning_exit" >> "$GITHUB_ENV"
-
+  
         if [[ "${{ inputs.reporting }}" == "true" ]]; then
           ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
           ./validation/reporter
@@ -41,7 +41,7 @@ runs:
         failed=0
         if [ "$provisioning_exit" -ne 0 ]; then
           echo "Failed Provisioning tests:"
-          jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' results_provisioning.json
+          jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' results.json
           failed=1
         fi
 

--- a/validation/pipeline/qase/reporter-v2/main.go
+++ b/validation/pipeline/qase/reporter-v2/main.go
@@ -190,7 +190,7 @@ func parseTestResults(outputs []testresult.GoTestOutput) map[string]*testresult.
 func reportTestQases(qaseService *qase.Service, testRunID int32) error {
 	resultsOutputs, err := readTestResults()
 	if err != nil {
-		return nil
+		return err
 	}
 
 	goTestResults := parseTestResults(resultsOutputs)


### PR DESCRIPTION
### Description
Cluster provisioning workflows were not reporting because we need to have the `results.json` named as such. Additionally, adding a warning message to ensure this does not happen again.