### PR TITLE
Add UI offline preferred setting test to airgap

### DIFF
--- a/actions/networking/pageStatus.go
+++ b/actions/networking/pageStatus.go
@@ -1,0 +1,70 @@
+package networking
+
+import (
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/sirupsen/logrus"
+)
+
+// GetPageStatus is a function that will attempt to load the Rancher UI's ui.min.js file from both the /v3 and /v1 API endpoints.
+func GetPageStatus(rancherConfig *rancher.Config, setting string) error {
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	// We want to check both the /v3 and /v1 endpoints. Dynamic and local (true) should be reachable;
+	// remote (false) should not be reachable.
+	endpoints := []string{"/v3", "/v1"}
+	for _, endpoint := range endpoints {
+		url := "https://" + rancherConfig.Host + "/api-ui/1.1.11/ui.min.js"
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return err
+		}
+
+		req.Header.Set("Authorization", "Bearer "+rancherConfig.AdminToken)
+		start := time.Now()
+		resp, err := client.Do(req)
+		elapsed := time.Since(start)
+
+		defer func(resp *http.Response) {
+			if resp != nil {
+				resp.Body.Close()
+			}
+		}(resp)
+
+		if setting == "dynamic" || setting == "true" {
+			if err != nil {
+				logrus.Errorf("error loading ui.min.js for %s: %v", endpoint, err)
+			}
+
+			if resp.StatusCode != 200 {
+				logrus.Errorf("unexpected status code %d for %s", resp.StatusCode, endpoint)
+			}
+
+			if elapsed >= 10*time.Second {
+				logrus.Errorf("request to %s took too long: %s", endpoint, elapsed)
+			}
+		} else if setting == "false" {
+			if err != nil {
+				return err
+			}
+
+			if resp.StatusCode != 200 {
+				logrus.Errorf("unexpected status code %d for %s", resp.StatusCode, endpoint)
+			}
+
+			if elapsed < 10*time.Second {
+				logrus.Errorf("request to %s was expected to take longer: %s", endpoint, elapsed)
+			}
+		}
+	}
+
+	return nil
+}

--- a/validation/provisioning/airgap/README.md
+++ b/validation/provisioning/airgap/README.md
@@ -15,6 +15,24 @@ The above command will connect your client node to the same network that your ai
 ## Test Cases
 All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults)
 
+### ACE Test
+
+#### Description: 
+ACE(Authorized Cluster Endpoint) test verifies that a custom cluster can be provisioned with ACE enabled
+
+#### Required Configurations: 
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Custom Cluster Config](#custom-cluster)
+
+#### Table Tests
+1. `K3S_Airgap_ACE`
+2. `RKE2_Airgap_ACE`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/airgap --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestAirgapK3SACE -timeout=1h -v`
+2. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/airgap --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestAirgapRKE2ACE -timeout=1h -v`
+
 ### Custom Test
 
 #### Description: 
@@ -33,6 +51,24 @@ Custom test verfies that various custom cluster configurations provision properl
 #### Run Commands:
 1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/airgap --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestCustomRKE2Airgap -timeout=1h -v`
 2. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/airgap --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestCustomK3SAirgap -timeout=1h -v`
+
+### UI Offline Preferred Setting Test
+
+#### Description: 
+UI Offline Preferred Setting test that tests accessbility to v1 and v3 endpoints with various UI offline preferred settings.
+
+#### Required Configurations: 
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Custom Cluster Config](#custom-cluster)
+
+#### Table Tests
+1. `UI_Offline_Preferred_Dynamic`
+2. `UI_Offline_Preferred_Local`
+3. `UI_Offline_Preferred_Remote`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/airgap --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestUIOfflinePreferred -timeout=1h -v`
 
 ## Configurations
 

--- a/validation/provisioning/airgap/schemas/hostbusters_schemas.yaml
+++ b/validation/provisioning/airgap/schemas/hostbusters_schemas.yaml
@@ -81,6 +81,11 @@
       "14": Validation
       "18": Hostbusters
 
+- projects:
+  - RRT
+  - RM
+  suite: Go Automation/Provisioning/Airgap/ACE
+  cases:
   - description: Provisions an 3 node 1etcd/1cp/1worker airgap custom cluster and runs ACE validation
     title: RKE2_Airgap_ACE
     priority: 4
@@ -138,6 +143,74 @@
       expectedresult: ""
       data: ""
       position: 3
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
+- projects:
+  - RRT
+  - RM
+  suite: Go Automation/Provisioning/Airgap/UIOfflinePreferred
+  cases:
+  - description: Tests accessing v1 and v3 endpoints with the dynamic setting
+    title: UI_Offline_Preferred_Dynamic
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Change setting to dynamic
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Access v1 and v3 endpoints and verify response
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
+  - description: Tests accessing v1 and v3 endpoints with the local setting
+    title: UI_Offline_Preferred_Local
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Change setting to local
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Access v1 and v3 endpoints and verify response
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
+  - description: Tests accessing v1 and v3 endpoints with the remote setting
+    title: UI_Offline_Preferred_Remote
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Change setting to remote
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Access v1 and v3 endpoints and verify response
+      expectedresult: ""
+      data: ""
+      position: 2
       attachments: []
     custom_field:
       "14": Validation

--- a/validation/provisioning/airgap/ui_offline_preferred_test.go
+++ b/validation/provisioning/airgap/ui_offline_preferred_test.go
@@ -1,0 +1,62 @@
+//go:build validation || (recurring && airgap) || airgap
+
+package airgap
+
+import (
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/networking"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	uiOfflinePreferred = "ui-offline-preferred"
+)
+
+func TestUIOfflinePreferred(t *testing.T) {
+	r := airgapSetup(t, defaults.K3S)
+
+	defaultSetting, err := r.client.Management.Setting.ByID(uiOfflinePreferred)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		client  *rancher.Client
+		setting string
+	}{
+		{"UI_Offline_Preferred_Dynamic", r.client, "dynamic"},
+		{"UI_Offline_Preferred_Local", r.client, "true"},
+		{"UI_Offline_Preferred_Remote", r.client, "false"},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			if r.tunnel != nil {
+				r.tunnel.StopBastionSSHTunnel()
+			}
+		})
+
+		t.Run(tt.name, func(t *testing.T) {
+			setting, err := tt.client.Management.Setting.ByID(uiOfflinePreferred)
+			require.NoError(t, err)
+
+			setting.Value = tt.setting
+
+			updatedSetting, err := tt.client.Management.Setting.Update(defaultSetting, setting)
+			require.NoError(t, err)
+
+			networking.GetPageStatus(r.rancherConfig, updatedSetting.Value)
+		})
+
+		params := provisioning.GetCustomSchemaParams(tt.client, r.cattleConfig)
+		err := qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}


### PR DESCRIPTION
### Description
To put the bow on porting over airgap tests from `rancher/tfp-automation`, porting over the UI offline preferred setting test to `rancher/tests` as well.