### PR TITLE
Allow parameterized logging in GHA workflows

### DIFF
--- a/.github/workflows/airgap-cluster-provisioning.yml
+++ b/.github/workflows/airgap-cluster-provisioning.yml
@@ -223,6 +223,9 @@ jobs:
               rke2Registries:
                 configs: {}
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
@@ -524,7 +527,10 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             registries:
               rke2Registries:
-                 configs: {}
+                configs: {}
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
 
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"
@@ -828,7 +834,10 @@ jobs:
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             registries:
               rke2Registries:
-                 configs: {}
+                configs: {}
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
 
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"

--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -247,6 +247,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -614,6 +617,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -982,6 +988,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -244,6 +244,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -589,6 +592,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -934,6 +940,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -244,6 +244,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -588,6 +591,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -932,6 +938,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -246,6 +246,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -592,6 +595,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -938,6 +944,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"

--- a/.github/workflows/prime-recurring-tests.yml
+++ b/.github/workflows/prime-recurring-tests.yml
@@ -229,6 +229,9 @@ jobs:
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -528,6 +531,9 @@ jobs:
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"

--- a/.github/workflows/proxy-cluster-provisioning.yml
+++ b/.github/workflows/proxy-cluster-provisioning.yml
@@ -256,6 +256,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -632,6 +635,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -1009,6 +1015,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"

--- a/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
@@ -230,6 +230,9 @@ jobs:
               rke2Registries:
                  configs: {}
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
@@ -540,6 +543,9 @@ jobs:
               rke2Registries:
                  configs: {}
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
@@ -851,6 +857,9 @@ jobs:
               rke2Registries:
                  configs: {}
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsEC2Configs:
             region: "${{ secrets.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -254,6 +254,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -626,6 +629,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -999,6 +1005,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"

--- a/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
@@ -263,6 +263,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -644,6 +647,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -1026,6 +1032,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -254,6 +254,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -614,6 +617,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -974,6 +980,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -256,6 +256,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -617,6 +620,9 @@ jobs:
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -977,6 +983,9 @@ jobs:
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
                     insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"

--- a/.github/workflows/recurring-proxy-tests.yml
+++ b/.github/workflows/recurring-proxy-tests.yml
@@ -251,6 +251,9 @@ jobs:
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -623,6 +626,9 @@ jobs:
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -996,6 +1002,9 @@ jobs:
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -242,6 +242,9 @@ jobs:
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -606,6 +609,9 @@ jobs:
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
 
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
@@ -970,6 +976,9 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
 
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"

--- a/validation/certificates/defaults/defaults.yaml
+++ b/validation/certificates/defaults/defaults.yaml
@@ -53,6 +53,3 @@ awsMachineConfigs:
     zone: "a"
     retries: "5"
     rootSize: "100"
-
-logging:
-   level: "info"

--- a/validation/deleting/defaults/defaults.yaml
+++ b/validation/deleting/defaults/defaults.yaml
@@ -44,6 +44,3 @@ awsMachineConfigs:
     sshUser: "<required>"
     vpcId: "<required>"
     retries: "5"
-
-logging:
-   level: "info"

--- a/validation/nodescaling/defaults/defaults.yaml
+++ b/validation/nodescaling/defaults/defaults.yaml
@@ -64,6 +64,3 @@ awsEC2Configs:
       awsUser: "<required>"
       volumeSize: 100
       roles: ["etcd", "controlplane", "worker"]
-
-logging:
-   level: "info"

--- a/validation/prime/autoscaling/defaults/defaults.yaml
+++ b/validation/prime/autoscaling/defaults/defaults.yaml
@@ -24,6 +24,3 @@ awsMachineConfigs:
     vpcId: "<required>"
     retries: "5"
     zone: "a"
-
-logging:
-   level: "info"

--- a/validation/provisioning/airgap/defaults/defaults.yaml
+++ b/validation/provisioning/airgap/defaults/defaults.yaml
@@ -57,8 +57,5 @@ awsEC2Configs:
       volumeSize: 100
       roles: ["windows"]
 
-logging:
-   level: "info"
-
 terraform:
   airgapBastion: "<required>"

--- a/validation/provisioning/proxy/defaults/defaults.yaml
+++ b/validation/provisioning/proxy/defaults/defaults.yaml
@@ -86,9 +86,6 @@ awsEC2Configs:
       volumeSize: 100
       roles: ["windows"]
 
-logging:
-   level: "info"
-
 terraform:
   proxy:
     proxyBastion: "<required>"

--- a/validation/snapshot/defaults/defaults.yaml
+++ b/validation/snapshot/defaults/defaults.yaml
@@ -85,6 +85,3 @@ awsEC2Configs:
       awsUser: "<required>"
       volumeSize: 100
       roles: ["windows"]
-
-logging:
-   level: "info"

--- a/validation/upgrade/defaults/defaults.yaml
+++ b/validation/upgrade/defaults/defaults.yaml
@@ -85,6 +85,3 @@ awsEC2Configs:
       awsUser: "<required>"
       volumeSize: 100
       roles: ["windows"]
-      
-logging:
-   level: "info"


### PR DESCRIPTION
### Description
One enhancement that we should add to our GHA workflows is to ensure that we parameterize our logging level. Right now, it defaults to `info` in our `defaults.yaml` files. However, it would be better to parameterize in GHA and to be able to edit the logging level in Github directly.

This allows much more flexibility and will help when troubleshooting various issues.