### PR TITLE
Add tests for legacy token compatibility to ext tokens

### DIFF
--- a/actions/tokens/exttokens/ext_tokens.go
+++ b/actions/tokens/exttokens/ext_tokens.go
@@ -191,3 +191,33 @@ func AuthenticateWithExtToken(baseURL, tokenName, tokenValue, apiPath string) er
 	}
 	return nil
 }
+
+// DeleteLegacyTokenWithExtToken sends a raw HTTP DELETE request to the /v3/tokens endpoint using an ext token for Bearer authentication.
+func DeleteLegacyTokenWithExtToken(client *rancher.Client, legacyTokenID string, extTokenValue string) error {
+	deleteURL := fmt.Sprintf("https://%s/v3/tokens/%s", client.RancherConfig.Host, legacyTokenID)
+
+	req, err := http.NewRequest(http.MethodDelete, deleteURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", extTokenValue))
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to execute HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("expected status code 200 or 204, got %d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/validation/auth/tokens/legacy_token_manager_ext_compatibility_test.go
+++ b/validation/auth/tokens/legacy_token_manager_ext_compatibility_test.go
@@ -1,0 +1,91 @@
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !2.8 && !2.9 && !2.10 && !2.11  && !2.12  && !2.13  && !2.14
+
+package tokens
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/rbac"
+	"github.com/rancher/tests/actions/settings"
+	exttokenapi "github.com/rancher/tests/actions/tokens/exttokens"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type LegacyTokenManagerExtTokenCompatibilityTest struct {
+	suite.Suite
+	client             *rancher.Client
+	session            *session.Session
+	defaultExtTokenTTL int64
+}
+
+func (t *LegacyTokenManagerExtTokenCompatibilityTest) TearDownSuite() {
+	t.session.Cleanup()
+}
+
+func (t *LegacyTokenManagerExtTokenCompatibilityTest) SetupSuite() {
+	t.session = session.NewSession()
+
+	client, err := rancher.NewClient("", t.session)
+	require.NoError(t.T(), err)
+	t.client = client
+
+	log.Info("Getting default TTL value to be used in tests")
+	defaultTTLString, err := settings.GetGlobalSettingDefaultValue(t.client, settings.AuthTokenMaxTTLMinutes)
+	require.NoError(t.T(), err)
+	defaultTTLInt, err := strconv.Atoi(defaultTTLString)
+	require.NoError(t.T(), err)
+	defaultTTL := int64(defaultTTLInt * 60000)
+	t.defaultExtTokenTTL = defaultTTL
+}
+
+func (t *LegacyTokenManagerExtTokenCompatibilityTest) TestAuthenticateWithLegacyTokenManagerUsingExtToken() {
+	subSession := t.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create ext token as standard user")
+	_, standardUserClient, err := rbac.SetupUser(t.client, rbac.StandardUser.String())
+	require.NoError(t.T(), err)
+	standardUserExtToken, err := exttokenapi.CreateExtToken(standardUserClient, t.defaultExtTokenTTL)
+	require.NoError(t.T(), err)
+
+	log.Info("Create an R_SESS cookie containing the ext token value and use it to authenticate a request against the legacy token manager endpoint")
+	standardUserTokenValue := standardUserExtToken.Status.Value
+	baseURL := fmt.Sprintf("https://%s", standardUserClient.RancherConfig.Host)
+	legacyTokenAPIPath := "/v3/tokens/"
+	err = exttokenapi.AuthenticateWithExtToken(baseURL, standardUserExtToken.Name, standardUserTokenValue, legacyTokenAPIPath)
+	require.NoError(t.T(), err)
+}
+
+func (t *LegacyTokenManagerExtTokenCompatibilityTest) TestDeleteLegacyTokenUsingExtToken() {
+	subSession := t.session.NewSession()
+	defer subSession.Cleanup()
+
+	log.Info("Create legacy token for the standard user")
+	_, standardUserClient, err := rbac.SetupUser(t.client, rbac.StandardUser.String())
+	require.NoError(t.T(), err)
+	standardUserLegacyToken, err := standardUserClient.Management.Token.Create(&management.Token{
+		Description: "legacy token for standard user",
+		UserID:      standardUserClient.UserID,
+	})
+	require.NoError(t.T(), err)
+	log.Infof("Legacy token %s created for standard user %s", standardUserLegacyToken.ID, standardUserClient.UserID)
+
+	log.Info("Create ext token for the standard user")
+	standardUserExtToken, err := exttokenapi.CreateExtToken(standardUserClient, t.defaultExtTokenTTL)
+	require.NoError(t.T(), err)
+
+	log.Info("Using the standard users ext token send a request to delete the standard users legacy token")
+	err = exttokenapi.DeleteLegacyTokenWithExtToken(standardUserClient, standardUserLegacyToken.ID, standardUserExtToken.Status.BearerToken)
+	require.NoError(t.T(), err)
+}
+
+func TestLegacyTokenManagerExtTokenCompatibilityTest(t *testing.T) {
+	suite.Run(t, new(LegacyTokenManagerExtTokenCompatibilityTest))
+}


### PR DESCRIPTION
This PR adds test cases to verify the legacy token manager(v3) can accept ext tokens as auth tokens([rancher/rancher #54338](https://github.com/rancher/rancher/issues/54338)).