### PR TITLE
Fix registry check to ensure standalone registry is not nil

### DIFF
--- a/validation/recurring/infrastructure/setuprancher/createRancherServer.go
+++ b/validation/recurring/infrastructure/setuprancher/createRancherServer.go
@@ -72,7 +72,7 @@ func main() {
 
 		infraConfig.UpdateAgentEnvVar(cattleConfig, "HTTP_PROXY", "http://"+proxyBastion+":3228")
 		infraConfig.UpdateAgentEnvVar(cattleConfig, "HTTPS_PROXY", "http://"+proxyBastion+":3228")
-	case terraformConfig.StandaloneRegistry.ECRURI != "":
+	case terraformConfig.StandaloneRegistry != nil && terraformConfig.StandaloneRegistry.ECRURI != "":
 		var authRegistry, nonAuthRegistry, globalRegistry string
 
 		client, authRegistry, nonAuthRegistry, globalRegistry, err = setupRegistryRancher(t, testSession)


### PR DESCRIPTION
### Description
Post release prime UI check failed as it is expecting standalone registry to not be empty. Updating the conditional to ensure this is not an issue.