### PR TITLE
Update Collie tests to remove RKE1 extension references

### DIFF
--- a/validation/rbac/README.md
+++ b/validation/rbac/README.md
@@ -1,7 +1,8 @@
 # Rbac
 
 ## Getting Started
-Your GO suite should be set to `-run ^Test<>TestSuite$`. For example to run the rbac_additional_test.go, set the GO suite to `-run ^TestRBACAdditionalTestSuite$` You can find specific tests by checking the test file you plan to run.
+Your GO suite should be set to `-run ^Test<>TestSuite$`. 
+You can find specific tests by checking the test file you plan to run.
 In your config file, set the following:
 
 ```json
@@ -13,12 +14,6 @@ In your config file, set the following:
   "cleanup": false/optional,
 }
 ```
-
-For the rbac_additional_test.go run, we need the following paramters to be passed in the config file as we create an rke1 cluster
-Please use the following links to continue adding to your config for provisioning tests:
- [Define your test](../provisioning/rke1/README.md#provisioning-input)
-(#Provisioning-Input)
- [Configure providers to use for Node Driver Clusters](../provisioning/rke1/README.md#NodeTemplateConfigs)
 
 # RBAC input
 rbacInput is needed to the run the TestRBACDynamicInput tests, specifically username, password and a cluster/project role. role takes the following as input only. Role takes a single value. 

--- a/validation/rbac/clusterandprojectroles/README.md
+++ b/validation/rbac/clusterandprojectroles/README.md
@@ -52,9 +52,3 @@ awsMachineConfigs:
    rootSize: "80"                            
    securityGroup: ["<securityGroup>"]
 ```
-
-For more info, please use the following links to continue adding to your config for provisioning tests:
- [Define your test](../provisioning/rke1/README.md#provisioning-input)
-(#Provisioning-Input)
-
-

--- a/validation/rbac/psa/deprecated_restrictedadmin_test.go
+++ b/validation/rbac/psa/deprecated_restrictedadmin_test.go
@@ -79,8 +79,7 @@ func (rb *PSATestSuite) ValidatePSARA(role string, customRole bool) {
 }
 
 func (rb *PSATestSuite) ValidateEditPsactClusterRA(role string, psact string) {
-	_, err := editPsactCluster(rb.nonAdminUserClient, rb.clusterName, rbac.DefaultNamespace, psact)
-
+	err := editPsactCluster(rb.nonAdminUserClient, rb.clusterName, rbac.DefaultNamespace, psact)
 	require.NoError(rb.T(), err)
 	err = psadeploy.CreateNginxDeployment(rb.nonAdminUserClient, rb.clusterID, psact)
 	require.NoError(rb.T(), err)

--- a/validation/rbac/psa/psa.go
+++ b/validation/rbac/psa/psa.go
@@ -94,69 +94,27 @@ func deletePSALabels(labels map[string]string) {
 	}
 }
 
-func editPsactCluster(client *rancher.Client, clustername string, namespace string, psact string) (clusterType string, err error) {
-	clusterID, err := clusters.GetClusterIDByName(client, clustername)
+func editPsactCluster(client *rancher.Client, clustername string, namespace string, psact string) error {
+	clusterObj, existingSteveAPIObj, err := clusters.GetProvisioningClusterByName(client, clustername, namespace)
 	if err != nil {
-		return "", err
+		return err
 	}
-	//Check if the downstream cluster is RKE2/K3S or RKE1
-	if strings.Contains(clusterID, "c-m-") {
-		clusterType = "RKE2K3S"
-		clusterObj, existingSteveAPIObj, err := clusters.GetProvisioningClusterByName(client, clustername, namespace)
-		if err != nil {
-			return "", err
-		}
 
-		clusterObj.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName = psact
-		_, err = clusters.UpdateK3SRKE2Cluster(client, existingSteveAPIObj, clusterObj)
-		if err != nil {
-			return clusterType, err
-		}
-		updatedClusterObj, _, err := clusters.GetProvisioningClusterByName(client, clustername, namespace)
-		if err != nil {
-			return "", err
-		}
-		if updatedClusterObj.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName != psact {
-			errorMsg := "psact value was not changed, Expected: " + psact + ", Actual: " + updatedClusterObj.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName
-			return clusterType, errors.New(errorMsg)
-		}
-	} else {
-		clusterType = "RKE"
-		if psact == "" {
-			psact = " "
-		}
-		existingCluster, err := client.Management.Cluster.ByID(clusterID)
-		if err != nil {
-			return "", err
-		}
-
-		updatedCluster := &management.Cluster{
-			Name: existingCluster.Name,
-			DefaultPodSecurityAdmissionConfigurationTemplateName: psact,
-		}
-		_, err = client.Management.Cluster.Update(existingCluster, updatedCluster)
-		if err != nil {
-			return clusterType, err
-		}
-
-		err = clusters.WaitForActiveRKE1Cluster(client, clusterID)
-		if err != nil {
-			return "", err
-		}
-
-		modifiedCluster, err := client.Management.Cluster.ByID(clusterID)
-		if err != nil {
-			return "", err
-		}
-		if psact == " " {
-			psact = ""
-		}
-		if modifiedCluster.DefaultPodSecurityAdmissionConfigurationTemplateName != psact {
-			errorMsg := "psact value was not changed, Expected: " + psact + ", Actual: " + modifiedCluster.DefaultPodSecurityAdmissionConfigurationTemplateName
-			return clusterType, errors.New(errorMsg)
-		}
+	clusterObj.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName = psact
+	_, err = clusters.UpdateK3SRKE2Cluster(client, existingSteveAPIObj, clusterObj)
+	if err != nil {
+		return err
 	}
-	return clusterType, nil
+
+	updatedClusterObj, _, err := clusters.GetProvisioningClusterByName(client, clustername, namespace)
+	if err != nil {
+		return err
+	}
+	if updatedClusterObj.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName != psact {
+		return fmt.Errorf("psact value was not changed, Expected: %s, Actual: %s", psact, updatedClusterObj.Spec.DefaultPodSecurityAdmissionConfigurationTemplateName)
+	}
+
+	return nil
 }
 
 func getAndConvertNamespace(namespace *v1.SteveAPIObject, steveAdminClient *v1.Client) (*coreV1.Namespace, error) {

--- a/validation/rbac/psa/psa_test.go
+++ b/validation/rbac/psa/psa_test.go
@@ -48,7 +48,7 @@ type PSATestSuite struct {
 
 func (rb *PSATestSuite) TearDownSuite() {
 	// reset the PSACT
-	_, err := editPsactCluster(rb.client, rb.clusterName, rbac.DefaultNamespace, "")
+	err := editPsactCluster(rb.client, rb.clusterName, rbac.DefaultNamespace, "")
 	require.NoError(rb.T(), err)
 	rb.session.Cleanup()
 }
@@ -261,7 +261,7 @@ func (rb *PSATestSuite) ValidateAdditionalPSA(role string) {
 }
 
 func (rb *PSATestSuite) ValidateEditPsactCluster(role string, psact string) {
-	clusterType, err := editPsactCluster(rb.nonAdminUserClient, rb.clusterName, rbac.DefaultNamespace, psact)
+	err := editPsactCluster(rb.nonAdminUserClient, rb.clusterName, rbac.DefaultNamespace, psact)
 	switch role {
 	case rbac.ClusterOwner.String():
 		require.NoError(rb.T(), err)
@@ -269,14 +269,7 @@ func (rb *PSATestSuite) ValidateEditPsactCluster(role string, psact string) {
 		require.NoError(rb.T(), err)
 	case rbac.ClusterMember.String(), rbac.ProjectOwner.String(), rbac.ProjectMember.String(), rbac.ReadOnly.String():
 		require.Error(rb.T(), err)
-		if clusterType == "RKE2K3S" {
-			assert.Equal(rb.T(), "Resource type [provisioning.cattle.io.cluster] is not updatable", err.Error())
-		} else {
-			errStatus := strings.Split(err.Error(), ".")[1]
-			rgx := regexp.MustCompile(`\[(.*?)\]`)
-			errorMsg := rgx.FindStringSubmatch(errStatus)
-			assert.Equal(rb.T(), "403 Forbidden", errorMsg[1])
-		}
+		assert.Equal(rb.T(), "Resource type [provisioning.cattle.io.cluster] is not updatable", err.Error())
 	}
 }
 


### PR DESCRIPTION
Removing references to RKE1 extensions in our tests to align with updates in this Shepherd PR: https://github.com/rancher/shepherd/pull/536