### PR TITLE
Update ACE logic in custom action

### DIFF
--- a/.github/actions/run-hostbusters-provisioning/action.yaml
+++ b/.github/actions/run-hostbusters-provisioning/action.yaml
@@ -11,6 +11,10 @@ inputs:
     description: "Test tags to run (comma-separated)"
     required: false
     default: "recurring"
+  run_ace:
+    description: "Whether to run ACE tests"
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -37,57 +41,61 @@ runs:
           ./validation/reporter
         fi
 
-        gotestsum --format standard-verbose \
-          --packages=github.com/rancher/tests/validation/provisioning/k3s \
-          --junitfile results.xml \
-          --jsonfile results_k3s_ace.json \
-          -- -timeout=3h -tags=ace -v
+        if [[ "${{ inputs.run_ace }}" == "true" ]]; then
+          gotestsum --format standard-verbose \
+            --packages=github.com/rancher/tests/validation/provisioning/k3s \
+            --junitfile results.xml \
+            --jsonfile results_k3s_ace.json \
+            -- -timeout=3h -tags=ace -v
 
-        k3s_ace_exit=$?
-        echo "k3s_ace_exit=$k3s_ace_exit" >> "$GITHUB_ENV"
-        cp results_k3s_ace.json results.json
-  
-        if [[ "${{ inputs.reporting }}" == "true" ]]; then
-          ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-          ./validation/reporter
-        fi
+          k3s_ace_exit=$?
+          echo "k3s_ace_exit=$k3s_ace_exit" >> "$GITHUB_ENV"
+          cp results_k3s_ace.json results.json
+    
+          if [[ "${{ inputs.reporting }}" == "true" ]]; then
+            ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
+            ./validation/reporter
+          fi
 
-        gotestsum --format standard-verbose \
-          --packages=github.com/rancher/tests/validation/provisioning/rke2 \
-          --junitfile results.xml \
-          --jsonfile results_rke2_ace.json \
-          -- -timeout=3h -tags=ace -v
+          gotestsum --format standard-verbose \
+            --packages=github.com/rancher/tests/validation/provisioning/rke2 \
+            --junitfile results.xml \
+            --jsonfile results_rke2_ace.json \
+            -- -timeout=3h -tags=ace -v
 
-        rke2_ace_exit=$?
-        echo "rke2_ace_exit=$rke2_ace_exit" >> "$GITHUB_ENV"
-        cp results_rke2_ace.json results.json
-  
-        if [[ "${{ inputs.reporting }}" == "true" ]]; then
-          ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
-          ./validation/reporter
+          rke2_ace_exit=$?
+          echo "rke2_ace_exit=$rke2_ace_exit" >> "$GITHUB_ENV"
+          cp results_rke2_ace.json results.json
+    
+          if [[ "${{ inputs.reporting }}" == "true" ]]; then
+            ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
+            ./validation/reporter
+          fi
         fi
 
     - name: Show failed tests
       shell: bash
       run: |
-        declare -A suites=(
-          [provisioning_exit]="Provisioning:results_provisioning.json"
-          [k3s_ace_exit]="K3S ACE:results_k3s_ace.json"
-          [rke2_ace_exit]="RKE2 ACE:results_rke2_ace.json"
-        )
-
         failed=0
 
-        for exit_code in "${!suites[@]}"; do
-          IFS=: read suite_name results_file <<< "${suites[$exit_code]}"
-          exit_val="${!exit_code}"
+        if [ "${provisioning_exit:-}" != "" ] && [ "$provisioning_exit" -ne 0 ]; then
+          echo "Failed Provisioning tests:"
+          jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' results_provisioning.json
+          failed=1
+        fi
 
-          if [ "$exit_val" != "" ] && [ "$exit_val" -ne 0 ]; then
-            echo "Failed $suite_name tests:"
-            jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' "$results_file"
+        if [[ "${{ inputs.run_ace }}" == "true" ]]; then
+          if [ "${k3s_ace_exit:-}" != "" ] && [ "$k3s_ace_exit" -ne 0 ]; then
+            echo "Failed K3S ACE tests:"
+            jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' results_k3s_ace.json
             failed=1
           fi
-        done
+          if [ "${rke2_ace_exit:-}" != "" ] && [ "$rke2_ace_exit" -ne 0 ]; then
+            echo "Failed RKE2 ACE tests:"
+            jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' results_rke2_ace.json
+            failed=1
+          fi
+        fi
 
         if [ "$failed" -eq 1 ]; then
           exit 1

--- a/.github/workflows/airgap-cluster-provisioning.yml
+++ b/.github/workflows/airgap-cluster-provisioning.yml
@@ -289,6 +289,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: airgap
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -596,6 +597,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: airgap
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -904,6 +906,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: airgap
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/proxy-cluster-provisioning.yml
+++ b/.github/workflows/proxy-cluster-provisioning.yml
@@ -350,6 +350,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: proxy
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -730,6 +731,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: proxy
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1111,6 +1113,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: proxy
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
@@ -296,6 +296,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: airgap
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -610,6 +611,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: airgap
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -925,6 +927,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: airgap
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
@@ -355,6 +355,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: proxy
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -740,6 +741,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: proxy
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1126,6 +1128,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: proxy
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()


### PR DESCRIPTION
### Description
For proxy and airgap, we need to ensure that ACE does not run with the typical `run-hostbusters-provisioning` custom action. This is because these two areas have specifics when it comes to ACE that need to be separated.