### PR TITLE
Update tfp go.mod and disable ACE tests for IPv6

### DIFF
--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -319,6 +319,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: ipv6
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -667,6 +668,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: ipv6
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1015,6 +1017,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: ipv6
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -321,6 +321,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: ipv6
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -671,6 +672,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: ipv6
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1021,6 +1023,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: ipv6
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()

--- a/actions/go.mod
+++ b/actions/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/qase-tms/qase-go/qase-api-client v1.2.1
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/shepherd v0.0.0-20260430211500-1f50d155268e
-	github.com/rancher/tfp-automation v0.0.0-20260428144157-a2d4a5a258c7
+	github.com/rancher/tfp-automation v0.0.0-20260511161348-eba5b5f6722e
 )
 
 require (

--- a/actions/go.sum
+++ b/actions/go.sum
@@ -302,8 +302,8 @@ github.com/rancher/shepherd v0.0.0-20260430211500-1f50d155268e h1:bJxwvGCA6t8sy3
 github.com/rancher/shepherd v0.0.0-20260430211500-1f50d155268e/go.mod h1:SJtW8Jqv0rphZzsGnvB965YdyR2FqFtB+TbbzVLt8F4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078 h1:1MJSgYkgXhr/Zc5idJkKa10SiBQd0HVtbxVOBoghlzY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078/go.mod h1:CV2Soy/Skw8/SA9dDJVgpeHxoEdtjYkNpNy6xvvC5kA=
-github.com/rancher/tfp-automation v0.0.0-20260428144157-a2d4a5a258c7 h1:DZ9EFKlH2II3wEDGm1Xxvujf49ggj1xjh/UQ5rX/fyk=
-github.com/rancher/tfp-automation v0.0.0-20260428144157-a2d4a5a258c7/go.mod h1:9ij9CpAwyGUSskTl0hW/OWUbiDPgLm53aGbZaZoB/hM=
+github.com/rancher/tfp-automation v0.0.0-20260511161348-eba5b5f6722e h1:vuZ5ixzRXANPjdMVaHs1yYukrhFRjM+AhJ8hkw29ifY=
+github.com/rancher/tfp-automation v0.0.0-20260511161348-eba5b5f6722e/go.mod h1:79uoBsfL1qRhdhfaE2q2dwGcMlBzdLDQxoJx87WYz0Q=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=
 github.com/rancher/wrangler v1.1.2/go.mod h1:2k9MyhlBdjcutcBGoOJSUAz0HgDAXnMjv81d3n/AaQc=
 github.com/rancher/wrangler/v3 v3.3.1 h1:YFqRfhxjuLNudUrvWrn+64wUPZ8pnn2KWbTsha75JLg=

--- a/go.mod
+++ b/go.mod
@@ -70,9 +70,9 @@ require (
 	github.com/qase-tms/qase-go/qase-api-client v1.2.1
 	github.com/rancher/rancher v0.0.0-20251223145833-24cecce3325e
 	github.com/rancher/shepherd v0.0.0-20260430211500-1f50d155268e
-	github.com/rancher/tests/actions v0.0.0-20260428161326-24be08863f41
+	github.com/rancher/tests/actions v0.0.0-20260429161627-c59ac182d972
 	github.com/rancher/tests/interoperability v0.0.0
-	github.com/rancher/tfp-automation v0.0.0-20260428221133-c497d6f81a7e
+	github.com/rancher/tfp-automation v0.0.0-20260511161348-eba5b5f6722e
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2196,8 +2196,8 @@ github.com/rancher/shepherd v0.0.0-20260430211500-1f50d155268e h1:bJxwvGCA6t8sy3
 github.com/rancher/shepherd v0.0.0-20260430211500-1f50d155268e/go.mod h1:SJtW8Jqv0rphZzsGnvB965YdyR2FqFtB+TbbzVLt8F4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078 h1:1MJSgYkgXhr/Zc5idJkKa10SiBQd0HVtbxVOBoghlzY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078/go.mod h1:CV2Soy/Skw8/SA9dDJVgpeHxoEdtjYkNpNy6xvvC5kA=
-github.com/rancher/tfp-automation v0.0.0-20260428221133-c497d6f81a7e h1:roGvGtfrjIPrdgOgo/q1r4QXUu1xBCbGRuuMHBb7m1E=
-github.com/rancher/tfp-automation v0.0.0-20260428221133-c497d6f81a7e/go.mod h1:Yg7aNmieGRXX/h4MbYiwNrK55B8kCTkeyyTAgCtCRIk=
+github.com/rancher/tfp-automation v0.0.0-20260511161348-eba5b5f6722e h1:vuZ5ixzRXANPjdMVaHs1yYukrhFRjM+AhJ8hkw29ifY=
+github.com/rancher/tfp-automation v0.0.0-20260511161348-eba5b5f6722e/go.mod h1:79uoBsfL1qRhdhfaE2q2dwGcMlBzdLDQxoJx87WYz0Q=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/interoperability/airgap/airgap.go
+++ b/interoperability/airgap/airgap.go
@@ -9,24 +9,20 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/token"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
-	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/pipeline"
 	"github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework"
 	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
-	"github.com/rancher/tfp-automation/tests/extensions/provisioning"
 	"github.com/stretchr/testify/require"
 )
 
 func TfpSetupSuite(t *testing.T) (map[string]any, *rancher.Config, *terraform.Options, *config.TerraformConfig, *config.TerratestConfig) {
 	testSession := session.NewSession()
 	cattleConfig := shepherdConfig.LoadConfigFromFile(os.Getenv(shepherdConfig.ConfigEnvironmentKey))
-	configMap, err := provisioning.UniquifyTerraform(cattleConfig)
-	require.NoError(t, err)
 
-	rancherConfig, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(configMap)
+	rancherConfig, terraformConfig, terratestConfig, _ := config.LoadTFPConfigs(cattleConfig)
 
 	adminUser := &management.User{
 		Username: "admin",
@@ -45,21 +41,10 @@ func TfpSetupSuite(t *testing.T) (map[string]any, *rancher.Config, *terraform.Op
 	client.RancherConfig.AdminPassword = rancherConfig.AdminPassword
 	client.RancherConfig.Host = terraformConfig.Standalone.RancherHostname
 
-	_, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, rancherConfig.AdminToken, configMap)
-	require.NoError(t, err)
-
-	_, err = operations.ReplaceValue([]string{"rancher", "adminPassword"}, rancherConfig.AdminPassword, configMap)
-	require.NoError(t, err)
-	_, err = operations.ReplaceValue([]string{"rancher", "host"}, rancherConfig.Host, configMap)
-	require.NoError(t, err)
-
 	err = pipeline.PostRancherInstall(client, client.RancherConfig.AdminPassword)
 	require.NoError(t, err)
 
 	client.RancherConfig.Host = rancherConfig.Host
-
-	_, err = operations.ReplaceValue([]string{"rancher", "host"}, rancherConfig.Host, configMap)
-	require.NoError(t, err)
 
 	_, keyPath := rancher2.SetKeyPath(keypath.RancherKeyPath, terratestConfig.PathToRepo, "aws")
 	terraformOptions := framework.Setup(t, terraformConfig, terratestConfig, keyPath)

--- a/interoperability/go.mod
+++ b/interoperability/go.mod
@@ -67,8 +67,8 @@ require (
 	github.com/rancher/qa-infra-automation v0.0.0-20260507233117-6c698fa52007
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/shepherd v0.0.0-20260430211500-1f50d155268e
-	github.com/rancher/tests/actions v0.0.0-20260427222935-93821bd449b4
-	github.com/rancher/tfp-automation v0.0.0-20260428144157-a2d4a5a258c7
+	github.com/rancher/tests/actions v0.0.0-20260429161627-c59ac182d972
+	github.com/rancher/tfp-automation v0.0.0-20260511161348-eba5b5f6722e
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.45.0
@@ -81,7 +81,6 @@ require (
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.55.8 // indirect

--- a/interoperability/go.sum
+++ b/interoperability/go.sum
@@ -1341,6 +1341,7 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.26.0
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
@@ -2087,8 +2088,8 @@ github.com/rancher/shepherd v0.0.0-20260430211500-1f50d155268e h1:bJxwvGCA6t8sy3
 github.com/rancher/shepherd v0.0.0-20260430211500-1f50d155268e/go.mod h1:SJtW8Jqv0rphZzsGnvB965YdyR2FqFtB+TbbzVLt8F4=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078 h1:1MJSgYkgXhr/Zc5idJkKa10SiBQd0HVtbxVOBoghlzY=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20250930163923-f2c9e60b1078/go.mod h1:CV2Soy/Skw8/SA9dDJVgpeHxoEdtjYkNpNy6xvvC5kA=
-github.com/rancher/tfp-automation v0.0.0-20260428144157-a2d4a5a258c7 h1:DZ9EFKlH2II3wEDGm1Xxvujf49ggj1xjh/UQ5rX/fyk=
-github.com/rancher/tfp-automation v0.0.0-20260428144157-a2d4a5a258c7/go.mod h1:9ij9CpAwyGUSskTl0hW/OWUbiDPgLm53aGbZaZoB/hM=
+github.com/rancher/tfp-automation v0.0.0-20260511161348-eba5b5f6722e h1:vuZ5ixzRXANPjdMVaHs1yYukrhFRjM+AhJ8hkw29ifY=
+github.com/rancher/tfp-automation v0.0.0-20260511161348-eba5b5f6722e/go.mod h1:79uoBsfL1qRhdhfaE2q2dwGcMlBzdLDQxoJx87WYz0Q=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=


### PR DESCRIPTION
### Description
Updating the tfp-automation go.mod entries to get the latest changes. Additionally, the IPv6 test cases are failing as they are running ACE tests when they should not. The proxy tests had the same issue.