### PR TITLE
Add additional test cases for dual-stack downstream clusters

### DIFF
--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -191,8 +191,8 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -224,8 +224,10 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             networking:
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
+              ipv6FirstClusterCIDR: "${{ vars.IPV6_FIRST_DUALSTACK_CLUSTER_CIDR }}"
+              ipv6FirstServiceCIDR: "${{ vars.IPV6_FIRST_DUALSTACK_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
             advanced:
               machineGlobalConfig:
@@ -540,8 +542,8 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -573,8 +575,10 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             networking:
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
+              ipv6FirstClusterCIDR: "${{ vars.IPV6_FIRST_DUALSTACK_CLUSTER_CIDR }}"
+              ipv6FirstServiceCIDR: "${{ vars.IPV6_FIRST_DUALSTACK_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
             advanced:
               machineGlobalConfig:
@@ -888,8 +892,8 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -922,8 +926,10 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             networking:
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
+              ipv6FirstClusterCIDR: "${{ vars.IPV6_FIRST_DUALSTACK_CLUSTER_CIDR }}"
+              ipv6FirstServiceCIDR: "${{ vars.IPV6_FIRST_DUALSTACK_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
             advanced:
               machineGlobalConfig:

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -191,8 +191,8 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -540,8 +540,8 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -888,8 +888,8 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -191,8 +191,8 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.IPV6_AWS_USER }}"
-              clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               enablePrimaryIPv6: true
               httpProtocolIPv6: "enabled"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
@@ -226,8 +226,8 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             networking:
-              clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             advanced:
               machineGlobalConfig:
@@ -542,8 +542,8 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.IPV6_AWS_USER }}"
-              clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               enablePrimaryIPv6: true
               httpProtocolIPv6: "enabled"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
@@ -577,8 +577,8 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             networking:
-              clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             advanced:
               machineGlobalConfig:
@@ -892,8 +892,8 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.IPV6_AWS_USER }}"
-              clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               enablePrimaryIPv6: true
               httpProtocolIPv6: "enabled"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
@@ -928,8 +928,8 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             networking:
-              clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             advanced:
               machineGlobalConfig:

--- a/actions/provisioninginput/config.go
+++ b/actions/provisioninginput/config.go
@@ -129,6 +129,8 @@ type Networking struct {
 	TLSSan                   []string                        `json:"tlsSan,omitempty" yaml:"tlsSan,omitempty"`
 	LocalClusterAuthEndpoint *rkev1.LocalClusterAuthEndpoint `json:"localClusterAuthEndpoint,omitempty" yaml:"localClusterAuthEndpoint,omitempty"`
 	StackPreference          string                          `json:"stackPreference,omitempty" yaml:"stackPreference,omitempty"`
+	IPV6FirstClusterCIDR     string                          `json:"ipv6FirstClusterCIDR,omitempty" yaml:"ipv6FirstClusterCIDR,omitempty"`
+	IPV6FirstServiceCIDR     string                          `json:"ipv6FirstServiceCIDR,omitempty" yaml:"ipv6FirstServiceCIDR,omitempty"`
 }
 
 type Advanced struct {

--- a/validation/provisioning/dualstack/README.md
+++ b/validation/provisioning/dualstack/README.md
@@ -50,9 +50,15 @@ Node driver test verfies that various node driver cluster configurations provisi
 1. `RKE2_Dual_Stack_Node_Driver_CIDR`
 2. `RKE2_Dual_Stack_Node_Driver_Dual_Stack_Preference`
 3. `RKE2_Dual_Stack_Node_Driver_CIDR_Dual_Stack_Preference`
-4. `K3S_Dual_Stack_Node_Driver_CIDR`
-5. `K3S_Dual_Stack_Node_Driver_Dual_Stack_Preference`
-6. `K3S_Dual_Stack_Node_Driver_CIDR_Dual_Stack_Preference`
+4. `RKE2_Dual_Stack_Node_Driver_CIDR_IPv6_First_Dual_Stack_Preference`
+5. `RKE2_Dual_Stack_Node_Driver_CIDR_IPv6_Address_Only`
+6. `RKE2_Dual_Stack_Node_Driver_CIDR_IPv6_Address_Only_IPv6_First`
+7. `K3S_Dual_Stack_Node_Driver_CIDR`
+8. `K3S_Dual_Stack_Node_Driver_Dual_Stack_Preference`
+9. `K3S_Dual_Stack_Node_Driver_CIDR_Dual_Stack_Preference`
+10. `K3S_Dual_Stack_Node_Driver_CIDR_IPv6_First_Dual_Stack_Preference`
+11. `K3S_Dual_Stack_Node_Driver_CIDR_IPv6_Address_Only`
+12. `K3S_Dual_Stack_Node_Driver_CIDR_IPv6_Address_Only_IPv6_First`
 
 #### Run Commands:
 `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/dualstack --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestNodeDriverRKE2 -timeout=1h -v` \

--- a/validation/provisioning/dualstack/defaults/defaults.yaml
+++ b/validation/provisioning/dualstack/defaults/defaults.yaml
@@ -12,5 +12,4 @@ awsMachineConfigs:
   awsMachineConfig:
   - enablePrimaryIPv6: true
     httpProtocolIpv6: "enabled"
-    ipv6AddressOnly: true
     ipv6AddressCount: "1"

--- a/validation/provisioning/dualstack/k3s_custom_test.go
+++ b/validation/provisioning/dualstack/k3s_custom_test.go
@@ -4,6 +4,7 @@ package dualstack
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/rancher/shepherd/clients/ec2"
@@ -98,6 +99,12 @@ func TestCustomK3SDualstack(t *testing.T) {
 		StackPreference: "dual",
 	}
 
+	ipv6FirstDualStackPreference := &provisioninginput.Networking{
+		ClusterCIDR:     clusterConfig.Networking.IPV6FirstClusterCIDR,
+		ServiceCIDR:     clusterConfig.Networking.IPV6FirstServiceCIDR,
+		StackPreference: "dual",
+	}
+
 	tests := []struct {
 		name         string
 		client       *rancher.Client
@@ -108,6 +115,7 @@ func TestCustomK3SDualstack(t *testing.T) {
 		{"K3S_Dual_Stack_Custom_IPv4_Stack_Preference", k.standardUserClient, nodeRolesStandard, ipv4StackPreference},
 		{"K3S_Dual_Stack_Custom_Dual_Stack_Preference", k.standardUserClient, nodeRolesStandard, dualStackPreference},
 		{"K3S_Dual_Stack_Custom_CIDR_Dual_Stack_Preference", k.standardUserClient, nodeRolesStandard, cidrDualStackPreference},
+		{"K3S_Dual_Stack_Custom_CIDR_IPv6_First_Dual_Stack_Preference", k.standardUserClient, nodeRolesStandard, ipv6FirstDualStackPreference},
 	}
 
 	for _, tt := range tests {
@@ -124,6 +132,10 @@ func TestCustomK3SDualstack(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
+			if strings.Contains(tt.name, "IPv6_First") {
+				t.Skip("Skipping test due to issue with AWS ipv6 address only provisioning; see GH issue: https://github.com/rancher/rancher/issues/54944")
+			}
 
 			externalNodeProvider := provisioning.ExternalNodeProviderSetup(clusterConfig.NodeProvider)
 

--- a/validation/provisioning/dualstack/k3s_node_driver_test.go
+++ b/validation/provisioning/dualstack/k3s_node_driver_test.go
@@ -4,6 +4,7 @@ package dualstack
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/rancher/shepherd/clients/rancher"
@@ -84,6 +85,12 @@ func TestNodeDriverK3S(t *testing.T) {
 		StackPreference: "dual",
 	}
 
+	ipv6FirstDualStackPreference := &provisioninginput.Networking{
+		ClusterCIDR:     clusterConfig.Networking.IPV6FirstClusterCIDR,
+		ServiceCIDR:     clusterConfig.Networking.IPV6FirstServiceCIDR,
+		StackPreference: "dual",
+	}
+
 	tests := []struct {
 		name         string
 		client       *rancher.Client
@@ -92,6 +99,9 @@ func TestNodeDriverK3S(t *testing.T) {
 	}{
 		{"K3S_Dual_Stack_Node_Driver_CIDR", k.standardUserClient, nodeRolesStandard, cidr},
 		{"K3S_Dual_Stack_Node_Driver_CIDR_Dual_Stack_Preference", k.standardUserClient, nodeRolesStandard, cidrDualStackPreference},
+		{"K3S_Dual_Stack_Node_Driver_CIDR_IPv6_First_Dual_Stack_Preference", k.standardUserClient, nodeRolesStandard, ipv6FirstDualStackPreference},
+		{"K3S_Dual_Stack_Node_Driver_CIDR_IPv6_Address_Only", k.standardUserClient, nodeRolesStandard, cidrDualStackPreference},
+		{"K3S_Dual_Stack_Node_Driver_CIDR_IPv6_Address_Only_IPv6_First", k.standardUserClient, nodeRolesStandard, ipv6FirstDualStackPreference},
 	}
 
 	for _, tt := range tests {
@@ -113,6 +123,12 @@ func TestNodeDriverK3S(t *testing.T) {
 			provider := provisioning.CreateProvider(clusterConfig.Provider)
 			credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
 			machineConfigSpec := provider.LoadMachineConfigFunc(k.cattleConfig)
+
+			// Needed to ensure we are testing use-case with IPv6 address only set and without it set in the other test cases.
+			if strings.Contains(tt.name, "IPv6_Address_Only") || strings.Contains(tt.name, "IPv6_First") {
+				machineConfigSpec.AmazonEC2MachineConfigs.AWSMachineConfig[0].Ipv6AddressOnly = true
+				t.Skip("Skipping test due to issue with AWS ipv6 address only provisioning; see GH issue: https://github.com/rancher/rancher/issues/54944")
+			}
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)

--- a/validation/provisioning/dualstack/rke2_custom_test.go
+++ b/validation/provisioning/dualstack/rke2_custom_test.go
@@ -4,6 +4,7 @@ package dualstack
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/rancher/shepherd/clients/ec2"
@@ -98,6 +99,12 @@ func TestCustomRKE2Dualstack(t *testing.T) {
 		StackPreference: "dual",
 	}
 
+	ipv6FirstDualStackPreference := &provisioninginput.Networking{
+		ClusterCIDR:     clusterConfig.Networking.IPV6FirstClusterCIDR,
+		ServiceCIDR:     clusterConfig.Networking.IPV6FirstServiceCIDR,
+		StackPreference: "dual",
+	}
+
 	tests := []struct {
 		name         string
 		client       *rancher.Client
@@ -108,6 +115,7 @@ func TestCustomRKE2Dualstack(t *testing.T) {
 		{"RKE2_Dual_Stack_Custom_IPv4_Stack_Preference", r.standardUserClient, nodeRolesStandard, ipv4StackPreference},
 		{"RKE2_Dual_Stack_Custom_Dual_Stack_Preference", r.standardUserClient, nodeRolesStandard, dualStackPreference},
 		{"RKE2_Dual_Stack_Custom_CIDR_Dual_Stack_Preference", r.standardUserClient, nodeRolesStandard, cidrDualStackPreference},
+		{"RKE2_Dual_Stack_Custom_CIDR_IPv6_First_Dual_Stack_Preference", r.standardUserClient, nodeRolesStandard, ipv6FirstDualStackPreference},
 	}
 
 	for _, tt := range tests {
@@ -123,6 +131,10 @@ func TestCustomRKE2Dualstack(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
+			if strings.Contains(tt.name, "IPv6_First") {
+				t.Skip("Skipping test due to issue with AWS ipv6 address only provisioning; see GH issue: https://github.com/rancher/rancher/issues/54944")
+			}
 
 			externalNodeProvider := provisioning.ExternalNodeProviderSetup(clusterConfig.NodeProvider)
 

--- a/validation/provisioning/dualstack/rke2_node_driver_test.go
+++ b/validation/provisioning/dualstack/rke2_node_driver_test.go
@@ -4,6 +4,7 @@ package dualstack
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/rancher/shepherd/clients/rancher"
@@ -84,6 +85,12 @@ func TestNodeDriverRKE2(t *testing.T) {
 		StackPreference: "dual",
 	}
 
+	ipv6FirstDualStackPreference := &provisioninginput.Networking{
+		ClusterCIDR:     clusterConfig.Networking.IPV6FirstClusterCIDR,
+		ServiceCIDR:     clusterConfig.Networking.IPV6FirstServiceCIDR,
+		StackPreference: "dual",
+	}
+
 	tests := []struct {
 		name         string
 		client       *rancher.Client
@@ -92,6 +99,9 @@ func TestNodeDriverRKE2(t *testing.T) {
 	}{
 		{"RKE2_Dual_Stack_Node_Driver_CIDR", r.standardUserClient, nodeRolesStandard, cidr},
 		{"RKE2_Dual_Stack_Node_Driver_CIDR_Dual_Stack_Preference", r.standardUserClient, nodeRolesStandard, cidrDualStackPreference},
+		{"RKE2_Dual_Stack_Node_Driver_CIDR_IPv6_First_Dual_Stack_Preference", r.standardUserClient, nodeRolesStandard, ipv6FirstDualStackPreference},
+		{"RKE2_Dual_Stack_Node_Driver_CIDR_IPv6_Address_Only", r.standardUserClient, nodeRolesStandard, cidrDualStackPreference},
+		{"RKE2_Dual_Stack_Node_Driver_CIDR_IPv6_Address_Only_IPv6_First", r.standardUserClient, nodeRolesStandard, ipv6FirstDualStackPreference},
 	}
 
 	for _, tt := range tests {
@@ -113,6 +123,12 @@ func TestNodeDriverRKE2(t *testing.T) {
 			provider := provisioning.CreateProvider(clusterConfig.Provider)
 			credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
 			machineConfigSpec := provider.LoadMachineConfigFunc(r.cattleConfig)
+
+			// Needed to ensure we are testing use-case with IPv6 address only set and without it set in the other test cases.
+			if strings.Contains(tt.name, "IPv6_Address_Only") || strings.Contains(tt.name, "IPv6_First") {
+				machineConfigSpec.AmazonEC2MachineConfigs.AWSMachineConfig[0].Ipv6AddressOnly = true
+				t.Skip("Skipping test due to issue with AWS ipv6 address only provisioning; see GH issue: https://github.com/rancher/rancher/issues/54944")
+			}
 
 			logrus.Info("Provisioning cluster")
 			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)

--- a/validation/provisioning/dualstack/schemas/hostbusters_schemas.yaml
+++ b/validation/provisioning/dualstack/schemas/hostbusters_schemas.yaml
@@ -107,6 +107,32 @@
       "14": Validation
       "18": Hostbusters
 
+  - description: Provisions an 8 node 3 etcd/2 cp/3 worker custom cluster with cluster/service CIDRs set and stack preference set to dual
+    title: RKE2_Dual_Stack_Custom_CIDR_IPv6_First_Dual_Stack_Preference
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Provision a rke2 custom cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
   - description: Provisions an 8 node 3 etcd/2 cp/3 worker custom cluster with cluster/service CIDRs set
     title: K3S_Dual_Stack_Custom_CIDR
     priority: 4
@@ -211,6 +237,32 @@
       "14": Validation
       "18": Hostbusters
 
+  - description: Provisions an 8 node 3 etcd/2 cp/3 worker custom cluster with cluster/service CIDRs set and stack preference set to dual
+    title: K3S_Dual_Stack_Custom_CIDR_IPv6_First_Dual_Stack_Preference
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Provision a k3s custom cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
 - projects:
   - RRT
   - RM
@@ -268,6 +320,84 @@
       "14": Validation
       "18": Hostbusters
 
+  - description: Provisions an 8 node 3etcd/2cp/3worker node driver cluster with cluster/service CIDR defined and stack preference set to dual
+    title: RKE2_Dual_Stack_Node_Driver_CIDR_IPv6_First_Dual_Stack_Preference
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Provision a rke2 node driver cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
+  - description: Provisions an 8 node 3 etcd/2 cp/3 worker node driver cluster with cluster/service CIDRs set and stack preference set to dual
+    title: RKE2_Dual_Stack_Node_Driver_CIDR_IPv6_Address_Only
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Provision a rke2 node driver cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
+  - description: Provisions an 8 node 3 etcd/2 cp/3 worker node driver cluster with cluster/service CIDRs set and stack preference set to dual
+    title: RKE2_Dual_Stack_Node_Driver_CIDR_IPv6_Address_Only_IPv6_First
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Provision a rke2 node driver cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
   - description: Provisions an 8 node 3etcd/2cp/3worker node driver cluster with cluster/service CIDR defined
     title: K3S_Dual_Stack_Node_Driver_CIDR
     priority: 4
@@ -296,6 +426,84 @@
 
   - description: Provisions an 8 node 3etcd/2cp/3worker node driver cluster with cluster/service CIDR defined and stack preference set to dual
     title: K3S_Dual_Stack_Node_Driver_CIDR_Dual_Stack_Preference
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Provision a k3s node driver cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
+  - description: Provisions an 8 node 3etcd/2cp/3worker node driver cluster with cluster/service CIDR defined and stack preference set to dual
+    title: K3S_Dual_Stack_Node_Driver_CIDR_IPv6_First_Dual_Stack_Preference
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Provision a k3s node driver cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
+  - description: Provisions an 8 node 3 etcd/2 cp/3 worker node driver cluster with cluster/service CIDRs set and stack preference set to dual
+    title: K3S_Dual_Stack_Node_Driver_CIDR_IPv6_Address_Only
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Provision a k3s node driver cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
+  - description: Provisions an 8 node 3 etcd/2 cp/3 worker node driver cluster with cluster/service CIDRs set and stack preference set to dual
+    title: K3S_Dual_Stack_Node_Driver_CIDR_IPv6_Address_Only_IPv6_First
     priority: 4
     type: 8
     is_flaky: 0


### PR DESCRIPTION
### Description
In a recent issue validation, in speaking further with dev, it was noted that we should have additional test coverage for dual-stack downstream clusters. Specifically, the following:
- Provisioning with IPv6 CIDRs defined first before IPv4
- Provisioning with `ipv6AddressOnly` set to false
- Provisioning with `ipv6AddressOnly` set to true

This PR adds that coverage. Until the issues are ready for validating, this PR purposely skips the IPv6 address only use-cases. When the issue is fixed, then a separate PR will be created to address it.