### PR TITLE
Improve image capture logic

### DIFF
--- a/actions/workloads/pods/verify.go
+++ b/actions/workloads/pods/verify.go
@@ -153,7 +153,7 @@ func VerifyClusterPods(client *rancher.Client, cluster *v1.SteveAPIObject) error
 	)
 
 	for _, pod := range badPodsMap {
-		images := getPodImages(pod)
+		images := GetPodImages(pod)
 		podState := "NotReady"
 		if state, ok := pod.Annotations["podState"]; ok {
 			podState = state
@@ -174,8 +174,8 @@ func VerifyClusterPods(client *rancher.Client, cluster *v1.SteveAPIObject) error
 	return err
 }
 
-// getPodImages grabs all container images from a pod.
-func getPodImages(pod *v1.SteveAPIObject) []string {
+// GetPodImages grabs all container images from a pod.
+func GetPodImages(pod *v1.SteveAPIObject) []string {
 	var images []string
 
 	statusMap, ok := pod.Status.(map[string]interface{})

--- a/scripts/capture_images/capture_images.go
+++ b/scripts/capture_images/capture_images.go
@@ -7,16 +7,18 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
-	"strings"
+	"slices"
+	"sort"
 	"sync"
 	"syscall"
 
 	"github.com/rancher/shepherd/clients/rancher"
-	"github.com/rancher/shepherd/extensions/clusters"
+	clusterV3 "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/kubeconfig"
-	"github.com/rancher/shepherd/extensions/kubectl"
 	"github.com/rancher/shepherd/extensions/rancherversion"
 	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/workloads/pods"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,10 +26,8 @@ import (
 )
 
 const (
-	logBufferSize            = "2MB"
-	kubernetesVersionCommand = "kubectl version -o json | jq -r '\"kubernetes:\" + .serverVersion.gitVersion'"
-	imagesVersionsCommand    = "kubectl get pods --all-namespaces -o jsonpath=\"{..image}\" |tr -s '[[:space:]]' '\n' |sort |uniq"
-	imagesPath               = "/app/images/"
+	localClusterName = "local"
+	imageReportPath  = "/app/image-report/image-report.txt"
 )
 
 var (
@@ -35,14 +35,26 @@ var (
 	existingRegex = regexp.MustCompile(`Container image "([^"]+)" already present on machine`)
 )
 
-type ClusterInfo struct {
-	Name string
-	ID   string
+// writeImageSet writes a set of image names (in the form of keys on a map) to a file in sorted fashion.
+func writeImageSet(imageSet map[string]string, file *os.File) {
+	var sortedImages []string
+
+	for image, value := range imageSet {
+		sortedImages = append(sortedImages, image+value)
+	}
+
+	sort.Slice(sortedImages, func(i, j int) bool {
+		return sortedImages[i] < sortedImages[j]
+	})
+
+	for _, image := range sortedImages {
+		file.WriteString(image + "\n")
+	}
 }
 
 // Connects to the specified Rancher managed Kubernetes cluster, monitoring and parsing its events while the test
-// is run. Writes all pulled image names to a file.
-func connectAndMonitor(client *rancher.Client, sigChan chan struct{}, clusterID string, file *os.File) error {
+// is run. Stores all unique used image names within a provided map.
+func connectAndMonitor(client *rancher.Client, sigChan chan struct{}, clusterID string, imageSet map[string]string) error {
 	clientConfig, err := kubeconfig.GetKubeconfig(client, clusterID)
 	if err != nil {
 		return fmt.Errorf("Failed building client config from string: %v", err)
@@ -89,14 +101,18 @@ func connectAndMonitor(client *rancher.Client, sigChan chan struct{}, clusterID 
 			matches := pulledRegex.FindStringSubmatch(k8sEvent.Message)
 
 			if len(matches) > 1 {
-				file.WriteString(fmt.Sprintf("%s (pulled during test)\n", matches[1]))
+				imageSet[matches[1]] = "(pulled during test)"
 				continue
 			}
 
 			matches = existingRegex.FindStringSubmatch(k8sEvent.Message)
 
-			if len(matches) > 1 {
-				file.WriteString(fmt.Sprintf("%s \n", matches[1]))
+			if len(matches) <= 1 {
+				continue
+			}
+
+			if _, ok := imageSet[matches[1]]; !ok {
+				imageSet[matches[1]] = ""
 			}
 		}
 	}
@@ -104,7 +120,13 @@ func connectAndMonitor(client *rancher.Client, sigChan chan struct{}, clusterID 
 
 func main() {
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGTERM)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	reportFile, err := os.Create(imageReportPath)
+	if err != nil {
+		panic(fmt.Errorf("Error creating report file: %w", err))
+	}
+	defer reportFile.Close()
 
 	client, err := rancher.NewClient("", session.NewSession())
 	if err != nil {
@@ -112,74 +134,73 @@ func main() {
 	}
 
 	clusterName := client.RancherConfig.ClusterName
-	clusterList := []ClusterInfo{}
 
+	allClusters, err := client.Management.Cluster.List(nil)
+	if err != nil {
+		panic(fmt.Errorf("Failed getting cluster objects: %w", err))
+	}
+
+	var targetClusters []clusterV3.Cluster
 	if clusterName != "" {
-		localClusterID, err := clusters.GetClusterIDByName(client, "local")
-		if err != nil {
-			panic(fmt.Errorf("Error getting local cluster ID: %w", err))
-		}
-
-		clusterList = append(clusterList, ClusterInfo{Name: "local", ID: localClusterID})
-
-		if clusterName != "local" {
-			clusterID, err := clusters.GetClusterIDByName(client, clusterName)
-			if err != nil {
-				panic(fmt.Errorf("Error getting local cluster ID: %w", err))
+		for _, cluster := range allClusters.Data {
+			if slices.Contains([]string{localClusterName, clusterName}, cluster.Name) {
+				targetClusters = append(targetClusters, cluster)
 			}
-
-			clusterList = append(clusterList, ClusterInfo{clusterName, clusterID})
 		}
 	} else {
-		allClusters, err := client.Management.Cluster.List(nil)
+		targetClusters = allClusters.Data
+	}
+
+	config, err := rancherversion.RequestRancherVersion(client.RancherConfig.Host)
+	if err != nil {
+		log.Panicln(fmt.Errorf("Error getting Rancher information: %w", err))
+	}
+
+	reportFile.WriteString(fmt.Sprintf("rancher:%s\n", config.RancherVersion))
+	reportFile.WriteString(fmt.Sprintf("rancher-commit:%s\n", config.GitCommit))
+	reportFile.WriteString(fmt.Sprintf("is-prime:%t\n", config.IsPrime))
+
+	for _, cluster := range targetClusters {
+		reportFile.WriteString("Kubernetes version on " + cluster.Name + " cluster: " + cluster.Version.GitVersion + "\n")
+
+		downstreamClient, err := client.Steve.ProxyDownstream(cluster.ID)
 		if err != nil {
-			panic(fmt.Errorf("Failed getting local cluster ID: %w", err))
+			panic(fmt.Errorf("Failed creating downstream client for cluster %s: %w", cluster.Name, err))
 		}
 
-		for _, cluster := range allClusters.Data {
-			clusterList = append(clusterList, ClusterInfo{cluster.Name, cluster.ID})
-		}
-	}
-
-	c, err := clusters.NewClusterMeta(client, clusterName)
-	if err != nil {
-		panic(fmt.Errorf("Failed to create file for versions: %v", err))
-	}
-
-	versions, err := captureVersions(client, c.ID)
-	if err != nil {
-		panic(fmt.Errorf("Failed to create file for versions: %v", err))
-	}
-
-	file, err := os.Create(imagesPath + "version-information")
-	if err != nil {
-		panic(fmt.Errorf("Failed to create file for version-information: %v", err))
-	}
-	defer file.Close()
-	file.Write([]byte(versions + "\n"))
-
-	filesMap := make(map[string]*os.File)
-	for _, clusterInfo := range clusterList {
-		file, err := os.Create(imagesPath + clusterInfo.Name)
+		steveClient := downstreamClient.SteveType(stevetypes.Pod)
+		clusterPods, err := steveClient.List(nil)
 		if err != nil {
-			panic(fmt.Errorf("Failed to create file for image names: %v", err))
+			panic(fmt.Errorf("Failed getting pods for cluster %s: %w", cluster.Name, err))
 		}
-		defer file.Close()
-		filesMap[clusterInfo.Name] = file
+
+		clusterImageSet := make(map[string]string)
+
+		for _, pod := range clusterPods.Data {
+			for _, image := range pods.GetPodImages(&pod) {
+				clusterImageSet[image] = ""
+			}
+		}
+
+		reportFile.WriteString("Images present on the " + cluster.Name + " cluster previous to the test run:\n\n")
+		writeImageSet(clusterImageSet, reportFile)
+		reportFile.WriteString("\n")
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(len(clusterList))
+	wg.Add(len(targetClusters))
 
 	var channelList []chan struct{}
+	imageSet := make(map[string]map[string]string)
 
-	for _, clusterInfo := range clusterList {
+	for _, clusterInfo := range targetClusters {
 		doneChan := make(chan struct{})
 		channelList = append(channelList, doneChan)
 
+		imageSet[clusterInfo.Name] = make(map[string]string)
+
 		go func() {
-			file = filesMap[clusterInfo.Name]
-			err := connectAndMonitor(client, doneChan, clusterInfo.ID, file)
+			err := connectAndMonitor(client, doneChan, clusterInfo.ID, imageSet[clusterInfo.Name])
 			if err != nil {
 				panic(fmt.Errorf("Failed to capture used images: %v", err))
 			}
@@ -192,32 +213,11 @@ func main() {
 	for _, channel := range channelList {
 		channel <- struct{}{}
 	}
-
 	wg.Wait()
-}
 
-// captureVersions gets the images, rancher and kubernetes versions on the cluster
-func captureVersions(client *rancher.Client, clusterID string) (string, error) {
-	var b strings.Builder
-
-	config, err := rancherversion.RequestRancherVersion(client.RancherConfig.Host)
-	if err != nil {
-		return "", err
+	for clusterName, images := range imageSet {
+		reportFile.WriteString("Images used within cluster " + clusterName + ":\n\n")
+		writeImageSet(images, reportFile)
+		reportFile.WriteString("\n")
 	}
-
-	b.WriteString(fmt.Sprintf("rancher:%s\n", config.RancherVersion))
-	b.WriteString(fmt.Sprintf("rancher-commit:%s\n", config.GitCommit))
-	b.WriteString(fmt.Sprintf("is-prime:%t\n", config.IsPrime))
-
-	versionsCommand := []string{
-		"sh", "-c", fmt.Sprintf("%s && %s", kubernetesVersionCommand, imagesVersionsCommand),
-	}
-
-	log, err := kubectl.Command(client, nil, clusterID, versionsCommand, logBufferSize)
-	if err != nil {
-		return "", err
-	}
-
-	b.WriteString(log)
-	return b.String(), nil
 }

--- a/validation/Jenkinsfile
+++ b/validation/Jenkinsfile
@@ -7,6 +7,7 @@ node {
       job_name = job_names[job_names.size() - 1]
     }
     def testContainer = "${job_name}${env.BUILD_NUMBER}_test"
+    def reporterContainer = "${job_name}${env.BUILD_NUMBER}_reporter"
     def imageName = "rancher-validation-${job_name}${env.BUILD_NUMBER}"
     def testsDir = "github.com/rancher/tests/validation/${env.TEST_PACKAGE}"
     def testResultsOut = "results.xml"
@@ -128,46 +129,48 @@ node {
                   writeFile file: "${envFile}", text: envText+env.ENV_VARIABLE
                 }
               }
+
               stage('Run Validation Tests') {
-                sh "mkdir -p ./validation/images"
-                try {
-                  if (env.CAPTURE_IMAGES == "true") {
-                    sh """
-                        docker run -d --name imageCapturer \
-                        -v ./validation/config.yaml:/app/config.yaml \
-                        -v ./validation/images/:/app/images \
-                        -t ${imageName} sh -c 'go build ../scripts/capture_images/capture_images.go && CATTLE_TEST_CONFIG=/app/config.yaml ./capture_images'
-                    """
-                    sh 'grep -m 1 "Listening to events on cluster" <(docker logs -f imageCapturer)'
-                  }
-
+                if (env.CAPTURE_IMAGES == "true") {
+                  sh "mkdir -p ./validation/image-report"
                   sh """
-                    docker run --name ${testContainer} -v ./validation/images/:/app/images -t --env-file ${envFile} ${imageName} \
-                    sh -c "/root/go/bin/gotestsum --format standard-verbose --packages=${testsDir} --junitfile ${testResultsOut} --jsonfile ${testResultsJSON} -- -tags=${TAGS} ${GOTEST_TESTCASE} -timeout=${timeout} -v; \
-                    ${rootPath}pipeline/scripts/${reporterScript}; \
-                    if [ -f ${rootPath}reporter ]; then ${rootPath}reporter; else echo \\"Reporter script not present\\"; fi"
-                  """
+                      docker run -d --name imageCapturer \
+                      -v ./validation/image-report:/app/image-report \
+                      -v ./validation/config.yaml:/app/config.yaml \
+                      -t ${imageName} sh -c 'go build -o /app/capturer ../scripts/capture_images/capture_images.go && CATTLE_TEST_CONFIG=/app/config.yaml exec /app/capturer'
+                    """
 
-                  if (env.CAPTURE_IMAGES == "true") {
-                    stage('Showing images used on this run') {
-                      sh "docker kill --signal SIGTERM imageCapturer && docker wait imageCapturer"
-                      final imagefiles = sh(script: 'ls -1 ./validation/images', returnStdout: true).split("\n").toList()
-                      if (imagefiles.isEmpty()) {
-                        echo "No image list found, showing docker logs:"
-                        final logs = sh("docker logs imageCapturer", returnStdout: true)
-                        echo "${logs}"
-                      } else {
-                        imagefiles.each { file ->
-                          echo "Images used within cluster ${file}"
-                          def content = readFile("./validation/images/${file}")
-                          echo "${content}"
-                        }
-                      }
-                      sh "docker rm imageCapturer"
-                    }
-                  }
+                  sh 'grep -qm 1 "Listening to events on cluster" <(docker logs -f imageCapturer)'
+                }
+
+                try {
+                  sh """
+                    docker run --name ${testContainer} -t --env-file ${envFile} ${imageName} \
+                    sh -c "/root/go/bin/gotestsum --format standard-verbose --packages=${testsDir} --junitfile ${testResultsOut} \
+                    --jsonfile ${testResultsJSON} -- -tags=${TAGS} ${GOTEST_TESTCASE} -timeout=${timeout} -v"
+                  """
+                  sh "mkdir -p ./results && docker cp ${testContainer}:${rootPath}${testResultsJSON} ./results"
                 } catch(err) {
-                  echo 'Test run had failures. Collecting results...'
+                  echo "Test run had failures: " + err + "\nCollecting results..."
+                }
+
+                if (env.CAPTURE_IMAGES == "true") {
+                  stage('Showing images used on this run') {
+                    sh "docker kill --signal SIGTERM imageCapturer && docker wait imageCapturer"
+                    def content = readFile("./validation/image-report/image-report.txt")
+                    echo "${content}"
+                    sh "docker rm imageCapturer"
+                  }
+                }
+
+                try {
+                  sh """
+                    docker run --name ${reporterContainer} -t --env-file ${envFile} \
+                    -v ./validation/image-report:/app/image-report -v ./results:/app/results ${imageName} \
+                    sh -c "${rootPath}/pipeline/scripts/${reporterScript}; if [ -f ./reporter ]; then ./reporter; else echo 'Reporter script not present'; fi"
+                  """
+                } catch(err) {
+                  echo "Qase report had failures: " + err + "\nCollecting results..."
                 }
               }
               stage('Test Report') {
@@ -175,11 +178,13 @@ node {
                 step([$class: 'JUnitResultArchiver', testResults: "**/${testResultsOut}"])
                 sh "docker stop ${testContainer}"
                 sh "docker rm -v ${testContainer}"
+                sh "docker rm -v ${reporterContainer}"
                 sh "docker rmi -f ${imageName}"
               }
             } catch(err) {
                 sh "docker stop ${testContainer}"
                 sh "docker rm -v ${testContainer}"
+                sh "docker rm -v ${reporterContainer}"
                 sh "docker rmi -f ${imageName}"
             } // catch error
           } // dir

--- a/validation/pipeline/qase/reporter-v2/main.go
+++ b/validation/pipeline/qase/reporter-v2/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -37,7 +36,8 @@ const (
 	requestLimit = 100
 	// Doc: https://developers.qase.io/reference/create-run
 	descriptionLimit = 10000
-	imagesPath       = "/app/images/"
+	imageReportPath  = "/app/image-report/image-report.txt"
+	testResultsJSON  = "/app/results/results.json"
 )
 
 func main() {
@@ -126,7 +126,7 @@ func getAllAutomationTestCases(qaseService *qase.Service) (map[string]upstream.T
 
 // readTestResults converts the results.json file into an output object
 func readTestResults() ([]testresult.GoTestOutput, error) {
-	file, err := os.Open(qase.TestResultsJSON)
+	file, err := os.Open(testResultsJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -347,36 +347,11 @@ func createRunDescription(buildUrl string) string {
 
 // getVersionInformation gets versions and commits id from cluster
 func getVersionInformation() string {
-
-	files, err := os.ReadDir(imagesPath)
+	// Prepare the command: docker logs imageCapturer
+	data, err := os.ReadFile(imageReportPath)
 	if err != nil {
-		logrus.Warning(fmt.Errorf("Failed to get files: %v", err))
-		return ""
+		logrus.Warning(fmt.Errorf("Failed to read file: %v", err))
 	}
 
-	var b strings.Builder
-
-	for _, file := range files {
-		path := filepath.Join(imagesPath, file.Name())
-
-		data, err := os.ReadFile(path)
-		if err != nil {
-			logrus.Warning(fmt.Errorf("Failed to read file: %v", err))
-			continue
-		}
-
-		s := string(data)
-		lines := strings.Split(s, "\n")
-		slices.Sort(lines)
-		compactLines := slices.Compact(lines)
-		s = strings.Join(compactLines, "\n")
-
-		b.WriteString(fmt.Sprintf("Images used within %s", file.Name()))
-		b.WriteString("\n")
-		b.WriteString(s)
-		b.WriteString("\n")
-		b.WriteString("\n")
-	}
-
-	return b.String()
+	return string(data)
 }

--- a/validation/pipeline/qase/reporter/main.go
+++ b/validation/pipeline/qase/reporter/main.go
@@ -33,7 +33,7 @@ const (
 	testSource           = "GoValidation"
 	multiSubTestPattern  = `(\w+/\w+/\w+){1,}`
 	subtestPattern       = `(\w+/\w+){1,1}`
-	testResultsJSON      = "results.json"
+	testResultsJSON      = "/app/results/results.json"
 )
 
 var (


### PR DESCRIPTION
This makes a few changes to the capture images logic, both on the go script and the Jenkinsfile. These changes amount to:
 - Ensure we report all the images;
 - Simplfies the process overall by writing a full report on a single file instead of having a separate file for each cluster. As a part of this simplification the order of operations had to be changed from: (1- run tests, 2- qase report, 3- stop imageCapturer and show images) to (1- run tests, 2- stop imageCapturer and show images, 3-qase report). This way we can be sure we all the images have been recorded on the file before creating the qase report.
 - Changes the format of the images output, more info on the specific changes on private channels;
 - Show kubernetes version and previous existing images for all the clusters and use pure shepherd instead of kubectl to get this information;