### PR TITLE
Fix weeklyTestsReports path in generate_weekly_chart.go

### DIFF
--- a/validation/weeklyTestsReports/generate_weekly_chart.go
+++ b/validation/weeklyTestsReports/generate_weekly_chart.go
@@ -18,10 +18,10 @@ import (
 )
 
 const (
-	headerPath   = "validation/weeklyReports/assets/workflow_header.html"
-	templatePath = "validation/weeklyReports/assets/template.html"
+	headerPath   = "validation/weeklyTestsReports/assets/workflow_header.html"
+	templatePath = "validation/weeklyTestsReports/assets/template.html"
 
-	assetsSrcDir = "validation/weeklyReports/assets"
+	assetsSrcDir = "validation/weeklyTestsReports/assets"
 	assetsDstDir = "results/assets"
 	resultsDir   = "results"
 


### PR DESCRIPTION
This PR updates the file path for weeklyTestsReports in generate_weekly_chart.go to ensure the correct location is used when generating weekly test reports.