### PR TITLE
Do not run ACE tests for registries workflow

### DIFF
--- a/.github/workflows/registries-cluster-provisioning.yml
+++ b/.github/workflows/registries-cluster-provisioning.yml
@@ -305,6 +305,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: registries
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -627,6 +628,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: registries
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -950,6 +952,7 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: registries
+          run_ace: "false"
 
       - name: Cleanup Infrastructure
         if: always()


### PR DESCRIPTION
This pull request updates the registries workflow to exclude ACE tests from its execution. By not running ACE tests in this workflow, it streamlines the process and prevents unnecessary test runs.