### PR TITLE
Add Slack notification for when all release tests pass

### DIFF
--- a/.github/actions/check-rancher-tag-result/action.yaml
+++ b/.github/actions/check-rancher-tag-result/action.yaml
@@ -34,34 +34,76 @@ runs:
           exit 0
         fi
 
-        PREV_TAG="${{ inputs.previous_rancher_tag }}"
-        if [[ -z "$PREV_TAG" ]]; then
-          echo "No previous tag provided, running all workflows."
-          workflows=(${DISPATCH_WORKFLOW_LIST//,/ })
-          failed_workflows=("${workflows[@]}")
-        else
-          echo "Previous tag is: $PREV_TAG"
-          workflows=(${DISPATCH_WORKFLOW_LIST//,/ })
-          failed_workflows=()
+        # Extract major.minor.patch (e.g., v2.14.1) from the tag. This is important because we do not want to skip the first
+        # alpha of a new minor release.
+        PATCH_LINE=$(echo "$TAG" | grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+')
+        TAG_LIST=$(curl -s https://api.github.com/repos/rancher/rancher/releases | jq -r '.[].tag_name' | grep -E "^$PATCH_LINE" | sort -V)
+        TAGS_TO_CHECK=()
 
-          for wf in "${workflows[@]}"; do
-            run_ids=$(gh run list --workflow "$wf" --branch main --json databaseId -L 30 | jq -r '.[].databaseId')
-            found_success=""
+        for t in $TAG_LIST; do
+          TAGS_TO_CHECK+=("$t")
+          [[ "$t" == "$TAG" ]] && break
+        done
 
+        workflows=(${DISPATCH_WORKFLOW_LIST//,/ })
+        failed_workflows=()
+
+        # For the post-release workflows, skip for alphas or RCs.
+        for wf in "${workflows[@]}"; do
+          if [[ "$wf" == post-release* ]]; then
+            if [[ "$TAG" == *-alpha* || "$TAG" == *-rc* ]]; then
+              continue
+            fi
+          fi
+
+          most_recent_passed_tag=""
+          found_skipped=""
+
+          # Fetch all runs for this workflow once, then filter in-memory for tags/jobs
+          runs_json=$(gh run list --workflow "$wf" --branch main --json databaseId,headBranch,headSha,conclusion,status,name,displayTitle -L 50)
+          run_ids=$(echo "$runs_json" | jq -r '.[].databaseId')
+
+          declare -A run_json_cache
+          for run_id in $run_ids; do
+            run_json_cache[$run_id]="$(gh run view "$run_id" --json status,conclusion,jobs,headSha,headBranch,displayTitle)"
+          done
+
+          for (( idx=${#TAGS_TO_CHECK[@]}-1 ; idx>=0 ; idx-- )); do
+            prev_tag="${TAGS_TO_CHECK[$idx]}"
             for run_id in $run_ids; do
-              jobs_json=$(gh run view "$run_id" --json jobs)
-              if echo "$jobs_json" | jq -e --arg tag "$PREV_TAG" '.jobs[]? | select(.name == $tag and .conclusion == "success")' > /dev/null; then
-                echo "Found successful job for workflow $wf with previous tag $PREV_TAG in run $run_id."
-                found_success=1
-                break
+              run_json="${run_json_cache[$run_id]}"
+              run_status=$(echo "$run_json" | jq -r '.status // empty')
+              run_conclusion=$(echo "$run_json" | jq -r '.conclusion // empty')
+              jobs_json=$(echo "$run_json" | jq -c '.jobs // []')
+
+              # If the workflow run itself is skipped for this tag, count as skipped
+              if [[ "$run_conclusion" == "skipped" ]]; then
+                found_skipped=1
+                continue
+              fi
+
+              # If there are jobs, check them as before
+              if [[ "$jobs_json" != "[]" ]]; then
+                if echo "$jobs_json" | jq -e --arg tag "$prev_tag" '.[]? | select(.name == $tag and .conclusion == "success")' > /dev/null; then
+                  most_recent_passed_tag="$prev_tag"
+                  break 2
+                fi
+                if echo "$jobs_json" | jq -e --arg tag "$prev_tag" '.[]? | select(.name == $tag and .conclusion == "skipped")' > /dev/null; then
+                  found_skipped=1
+                fi
               fi
             done
-            if [[ -z "$found_success" ]]; then
-              echo "No successful job found for workflow $wf with previous tag $PREV_TAG, will re-run for tag $TAG"
-              failed_workflows+=("$wf")
-            fi
           done
-        fi
+
+          if [[ -n "$most_recent_passed_tag" ]]; then
+            echo "Most recent successful tag for workflow $wf is: $most_recent_passed_tag."
+          elif [[ -n "$found_skipped" ]]; then
+            echo "Workflow $wf was skipped for all tags, ignoring."
+          else
+            echo "No successful job found for workflow $wf for any previous tag, will re-run for tag $TAG"
+            failed_workflows+=("$wf")
+          fi
+        done
 
         cleaned_failed_workflows=()
 

--- a/.github/workflows/airgap-cluster-provisioning.yml
+++ b/.github/workflows/airgap-cluster-provisioning.yml
@@ -157,7 +157,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -215,7 +215,7 @@ jobs:
             bastionUser: "${{ secrets.AWS_USER }}"
             bastionWindowsUser: "${{ secrets.AWS_WINDOWS_USER }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -464,7 +464,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -522,7 +522,7 @@ jobs:
             bastionUser: "${{ secrets.AWS_USER }}"
             bastionWindowsUser: "${{ secrets.AWS_WINDOWS_USER }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -771,7 +771,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -830,7 +830,7 @@ jobs:
             bastionUser: "${{ secrets.AWS_USER }}"
             bastionWindowsUser: "${{ secrets.AWS_WINDOWS_USER }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/check-rancher-tag.yml
+++ b/.github/workflows/check-rancher-tag.yml
@@ -184,3 +184,107 @@ jobs:
       rancher_version: ${{ needs.check-latest-rancher-tag.outputs.latest_tag_v213 }}
       rancher_chart_version: ${{ needs.set-latest-chart-version.outputs.chart_version_v213 }}
       workflow_list: ${{ (github.event.inputs.override == 'true' && needs.get-dispatch-workflow-list.outputs.workflow_list) || needs.check-individual-tests-v213.outputs.failed_workflows_v213 }}
+
+  notify-slack-v214:
+    needs: [check-individual-tests-v214, check-latest-rancher-tag]
+    runs-on: ubuntu-latest
+    if: ${{ needs.check-individual-tests-v214.outputs.failed_workflows_v214 == '' && needs.check-latest-rancher-tag.outputs.latest_tag_v214 != '' }}
+    steps:
+       - name: Configure AWS credentials
+         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+         with:
+           role-to-assume: ${{ secrets.IAM_ROLE }}
+           aws-region: ${{ secrets.AWS_REGION }}
+
+       - name: Check if Slack notification already sent
+         id: check_marker
+         run: |
+          TAG="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v214 }}"
+          BASE_TAG=$(echo "$TAG" | grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+')
+          MARKER_FILE="slack_notified_${BASE_TAG}.txt"
+
+          echo "BASE_TAG=$BASE_TAG" >> $GITHUB_ENV
+
+          if aws s3 ls "s3://${{ secrets.RANCHER_TAG_BUCKET }}/$MARKER_FILE" > /dev/null 2>&1; then
+            echo "Notification already sent for $BASE_TAG. Skipping."
+            echo "skip_slack=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip_slack=false" >> $GITHUB_OUTPUT
+          fi
+      
+       - name: Send Slack notification for v2.14
+         if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
+         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 #v3
+         with:
+          webhook: ${{ secrets.HB_TEAM_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "*[rancher/tests]* :alert:\n`${{ env.BASE_TAG }}` Release Testing Completed :white_check_mark:"
+            }
+      
+       - name: Configure AWS credentials
+         if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
+         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+         with:
+           role-to-assume: ${{ secrets.IAM_ROLE }}
+           aws-region: ${{ secrets.AWS_REGION }}
+
+       - name: Write Slack notification marker to S3
+         if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
+         run: |
+          MARKER_FILE="slack_notified_${BASE_TAG}.txt"
+          echo "notified" > $MARKER_FILE
+          aws s3 cp "$MARKER_FILE" "s3://${{ secrets.RANCHER_TAG_BUCKET }}/$MARKER_FILE"
+
+  notify-slack-v213:
+    needs: [check-individual-tests-v213, check-latest-rancher-tag]
+    runs-on: ubuntu-latest
+    if: ${{ needs.check-individual-tests-v213.outputs.failed_workflows_v213 == '' && needs.check-latest-rancher-tag.outputs.latest_tag_v213 != '' }}
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Check if Slack notification already sent
+        id: check_marker
+        run: |
+          TAG="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v213 }}"
+          BASE_TAG=$(echo "$TAG" | grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+')
+          MARKER_FILE="slack_notified_${BASE_TAG}.txt"
+
+          echo "BASE_TAG=$BASE_TAG" >> $GITHUB_ENV
+
+          if aws s3 ls "s3://${{ secrets.RANCHER_TAG_BUCKET }}/$MARKER_FILE" > /dev/null 2>&1; then
+            echo "Notification already sent for $BASE_TAG. Skipping."
+            echo "skip_slack=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip_slack=false" >> $GITHUB_OUTPUT
+          fi
+    
+      - name: Send Slack notification for v2.13
+        if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 #v3
+        with:
+          webhook: ${{ secrets.HB_TEAM_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "*[rancher/tests]* :alert:\n`${{ env.BASE_TAG }}` Release Testing Completed :white_check_mark:"
+            }
+    
+      - name: Configure AWS credentials
+        if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Write Slack notification marker to S3
+        if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
+        run: |
+          MARKER_FILE="slack_notified_${BASE_TAG}.txt"
+          echo "notified" > $MARKER_FILE
+          aws s3 cp "$MARKER_FILE" "s3://${{ secrets.RANCHER_TAG_BUCKET }}/$MARKER_FILE"

--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -180,7 +180,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -236,7 +236,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -556,7 +556,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -612,7 +612,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -932,7 +932,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -989,7 +989,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -174,7 +174,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -226,7 +226,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -528,7 +528,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -580,7 +580,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -881,7 +881,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -934,7 +934,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -174,7 +174,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -226,7 +226,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -528,7 +528,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -580,7 +580,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -881,7 +881,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -934,7 +934,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -174,7 +174,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -228,7 +228,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -530,7 +530,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -584,7 +584,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -885,7 +885,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -940,7 +940,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/post-release-prime.yml
+++ b/.github/workflows/post-release-prime.yml
@@ -167,7 +167,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -421,7 +421,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"

--- a/.github/workflows/prime-recurring-tests.yml
+++ b/.github/workflows/prime-recurring-tests.yml
@@ -164,7 +164,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -214,7 +214,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -466,7 +466,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -516,7 +516,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/proxy-cluster-provisioning.yml
+++ b/.github/workflows/proxy-cluster-provisioning.yml
@@ -174,7 +174,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -231,7 +231,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -554,7 +554,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -611,7 +611,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -934,7 +934,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -992,7 +992,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
@@ -158,7 +158,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -222,7 +222,7 @@ jobs:
             bastionUser: "${{ secrets.AWS_USER }}"
             bastionWindowsUser: "${{ secrets.AWS_WINDOWS_USER }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -472,7 +472,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -536,7 +536,7 @@ jobs:
             bastionUser: "${{ secrets.AWS_USER }}"
             bastionWindowsUser: "${{ secrets.AWS_WINDOWS_USER }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -786,7 +786,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -852,7 +852,7 @@ jobs:
             bastionUser: "${{ secrets.AWS_USER }}"
             bastionWindowsUser: "${{ secrets.AWS_WINDOWS_USER }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -182,7 +182,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -243,7 +243,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -563,7 +563,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -624,7 +624,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -944,7 +944,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -1006,7 +1006,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
@@ -176,7 +176,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -238,7 +238,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -561,7 +561,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -623,7 +623,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -946,7 +946,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -1009,7 +1009,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -175,7 +175,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -229,7 +229,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -538,7 +538,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -592,7 +592,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -900,7 +900,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -955,7 +955,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/recurring-ipv6-tests.yml
+++ b/.github/workflows/recurring-ipv6-tests.yml
@@ -175,7 +175,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -231,7 +231,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -539,7 +539,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -595,7 +595,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -902,7 +902,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -959,7 +959,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/recurring-proxy-tests.yml
+++ b/.github/workflows/recurring-proxy-tests.yml
@@ -175,7 +175,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -229,7 +229,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -550,7 +550,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -604,7 +604,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -925,7 +925,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -980,7 +980,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -175,7 +175,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -227,7 +227,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -542,7 +542,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -594,7 +594,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -909,7 +909,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -962,7 +962,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"

--- a/.github/workflows/registries-cluster-provisioning.yml
+++ b/.github/workflows/registries-cluster-provisioning.yml
@@ -157,7 +157,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -215,7 +215,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -480,7 +480,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -538,7 +538,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
@@ -803,7 +803,7 @@ jobs:
             insecure: true
             cleanup: true
           terraform:
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -862,7 +862,7 @@ jobs:
 
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ secrets.CNI }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"


### PR DESCRIPTION
This PR adds functionality to send a Slack notification when all release tests successfully pass. This ensures stakeholders are promptly informed about the release testing status via Slack.