### PR TITLE
Separate template tests to run after general provisioning and ACE tests

### DIFF
--- a/.github/actions/run-hostbusters-provisioning/action.yaml
+++ b/.github/actions/run-hostbusters-provisioning/action.yaml
@@ -15,6 +15,10 @@ inputs:
     description: "Whether to run ACE tests"
     required: false
     default: "true"
+  run_template:
+    description: "Whether to run template tests"
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -39,6 +43,38 @@ runs:
         if [[ "${{ inputs.reporting }}" == "true" ]]; then
           ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
           ./validation/reporter
+        fi
+
+        if [[ "${{ inputs.run_template }}" == "true" ]]; then
+          gotestsum --format standard-verbose \
+            --packages=github.com/rancher/tests/validation/provisioning/k3s \
+            --junitfile results.xml \
+            --jsonfile results_k3s_template.json \
+            -- -timeout=3h -tags=template -v
+
+          k3s_template_exit=$?
+          echo "k3s_template_exit=$k3s_template_exit" >> "$GITHUB_ENV"
+          cp results_k3s_template.json results.json
+    
+          if [[ "${{ inputs.reporting }}" == "true" ]]; then
+            ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
+            ./validation/reporter
+          fi
+
+          gotestsum --format standard-verbose \
+            --packages=github.com/rancher/tests/validation/provisioning/rke2 \
+            --junitfile results.xml \
+            --jsonfile results_rke2_template.json \
+            -- -timeout=3h -tags=template -v
+
+          rke2_template_exit=$?
+          echo "rke2_template_exit=$rke2_template_exit" >> "$GITHUB_ENV"
+          cp results_rke2_template.json results.json
+    
+          if [[ "${{ inputs.reporting }}" == "true" ]]; then
+            ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
+            ./validation/reporter
+          fi
         fi
 
         if [[ "${{ inputs.run_ace }}" == "true" ]]; then
@@ -82,6 +118,19 @@ runs:
           echo "Failed Provisioning tests:"
           jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' results_provisioning.json
           failed=1
+        fi
+
+        if [[ "${{ inputs.run_template }}" == "true" ]]; then
+          if [ "${k3s_template_exit:-}" != "" ] && [ "$k3s_template_exit" -ne 0 ]; then
+            echo "Failed K3S Template tests:"
+            jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' results_k3s_template.json
+            failed=1
+          fi
+          if [ "${rke2_template_exit:-}" != "" ] && [ "$rke2_template_exit" -ne 0 ]; then
+            echo "Failed RKE2 Template tests:"
+            jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' results_rke2_template.json
+            failed=1
+          fi
         fi
 
         if [[ "${{ inputs.run_ace }}" == "true" ]]; then

--- a/.github/workflows/airgap-cluster-provisioning.yml
+++ b/.github/workflows/airgap-cluster-provisioning.yml
@@ -290,6 +290,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: airgap
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -597,6 +598,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: airgap
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -905,6 +907,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: airgap
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -327,6 +327,8 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: dualstack
+          run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -681,6 +683,8 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: dualstack
+          run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1035,6 +1039,8 @@ jobs:
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: dualstack
+          run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -327,6 +327,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: ipv6
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -681,6 +682,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: ipv6
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1035,6 +1037,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: ipv6
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -329,6 +329,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: ipv6
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -685,6 +686,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: ipv6
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1041,6 +1043,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: ipv6
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/proxy-cluster-provisioning.yml
+++ b/.github/workflows/proxy-cluster-provisioning.yml
@@ -351,6 +351,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: proxy
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -731,6 +732,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: proxy
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1112,6 +1114,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: proxy
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
@@ -297,6 +297,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: airgap
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -611,6 +612,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: airgap
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -927,6 +929,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: airgap
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
@@ -356,6 +356,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: proxy
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -741,6 +742,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: proxy
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -1127,6 +1129,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: proxy
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()

--- a/.github/workflows/registries-cluster-provisioning.yml
+++ b/.github/workflows/registries-cluster-provisioning.yml
@@ -306,6 +306,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: registries
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -629,6 +630,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: registries
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -953,6 +955,7 @@ jobs:
           reporting: ${{ env.REPORTING_ENABLED }}
           tags: registries
           run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()

--- a/validation/provisioning/k3s/README.md
+++ b/validation/provisioning/k3s/README.md
@@ -207,9 +207,7 @@ Template Test verfies that an K3S template can be used to provision a cluster.
 All table tests listed above except the dynamic tests
 
 #### Run Commands:
-1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s --junitfile results.xml --jsonfile results.json -- -tags=recurring -timeout=3h -v`
-
-
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/k3s --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestTemplate -timeout=1h -v`
 
 ## Configurations
 

--- a/validation/provisioning/k3s/template_test.go
+++ b/validation/provisioning/k3s/template_test.go
@@ -1,4 +1,4 @@
-//go:build validation || recurring
+//go:build validation || template
 
 package k3s
 

--- a/validation/provisioning/rke2/template_test.go
+++ b/validation/provisioning/rke2/template_test.go
@@ -1,4 +1,4 @@
-//go:build validation || recurring
+//go:build validation || template
 
 package rke2
 


### PR DESCRIPTION
This pull request updates the test execution order, ensuring that template tests are run only after the completion of general provisioning and ACE tests. This segregation enhances test organization and reliability by preventing template tests from running prematurely.