### PR TITLE
Update Jenkinsfile with improved shared library commands

### DIFF
--- a/validation/Jenkinsfile.e2e
+++ b/validation/Jenkinsfile.e2e
@@ -12,7 +12,7 @@
  *
  *
  * Consumes shared functions from qa-jenkins-library:
- *   infra.backendS3, infra.workspaceNew, infra.up, infra.cluster, infra.rancher, infra.down
+ *   make.runTarget (backend-s3, workspace-new, infra-up, cluster, rancher, infra-down)
  *   airgap.standardCheckout
  *   infrastructure.parseAndSubstituteVars, infrastructure.writeConfig,
  *   infrastructure.generateWorkspaceName, infrastructure.archiveWorkspaceName,
@@ -67,7 +67,8 @@ def destroyInfrastructure(String reason) {
                 path:    "${tofuDir}/terraform.tfvars",
                 content: terraformConfig
             )
-            infra.down(env.INFRA_DIR, wsName)
+            def mk = new make()
+            mk.runTarget(target: 'infra-down', dir: env.INFRA_DIR, makeArgs: "WORKSPACE=${wsName} AUTO_APPROVE=yes")
             env.INFRA_CLEANED = 'true'
         }
     } catch (cleanupErr) {
@@ -655,13 +656,18 @@ rancher_use_bundled_system_charts: true
                             )
                         }
 
+                        def mk = new make()
+
                         // ── Initialize S3 backend ──────────────────────────
                         stage('Initialize Tofu Backend') {
-                            infra.backendS3(
-                                env.INFRA_DIR,
-                                params.S3_BUCKET_NAME,
-                                params.S3_KEY_PREFIX,
-                                params.S3_BUCKET_REGION
+                            mk.runTarget(
+                                target:   'backend-s3',
+                                dir:      env.INFRA_DIR,
+                                makeArgs: [
+                                    "BUCKET=${params.S3_BUCKET_NAME}",
+                                    "KEY=${params.S3_KEY_PREFIX}",
+                                    "REGION=${params.S3_BUCKET_REGION}"
+                                ]
                             )
                         }
 
@@ -672,25 +678,39 @@ rancher_use_bundled_system_charts: true
                                 suffix:           params.HOSTNAME_PREFIX,
                                 includeTimestamp: false
                             )
-                            infra.workspaceNew(env.INFRA_DIR, workspaceName)
+                            mk.runTarget(
+                                target:   'workspace-new',
+                                dir:      env.INFRA_DIR,
+                                makeArgs: "WORKSPACE=${workspaceName}"
+                            )
                             infrastructure.archiveWorkspaceName(workspaceName: workspaceName)
                             env.WORKSPACE_NAME = workspaceName
                         }
 
                         // ── Provision infra + generate inventory ───────────
                         stage('Provision Infrastructure') {
-                            infra.up(env.INFRA_DIR, workspaceName)
+                            mk.runTarget(
+                                target:   'infra-up',
+                                dir:      env.INFRA_DIR,
+                                makeArgs: "WORKSPACE=${workspaceName}"
+                            )
                         }
 
                         // ── Deploy RKE2 cluster ────────────────────────────
                         stage('Deploy RKE2 Cluster') {
-                            infra.cluster(env.INFRA_DIR, workspaceName)
+                            mk.runTarget(
+                                target:   'cluster',
+                                dir:      env.INFRA_DIR
+                            )
                         }
 
                         // ── Deploy Rancher ─────────────────────────────────
                         stage('Deploy Rancher') {
                             if (params.DEPLOY_RANCHER) {
-                                infra.rancher(env.INFRA_DIR, workspaceName)
+                                mk.runTarget(
+                                    target: 'rancher',
+                                    dir:    env.INFRA_DIR
+                                )
                             } else {
                                 echo 'Skipping Rancher deployment (DEPLOY_RANCHER not checked)'
                             }

--- a/validation/Jenkinsfile.e2e
+++ b/validation/Jenkinsfile.e2e
@@ -67,8 +67,7 @@ def destroyInfrastructure(String reason) {
                 path:    "${tofuDir}/terraform.tfvars",
                 content: terraformConfig
             )
-            def mk = new make()
-            mk.runTarget(target: 'infra-down', dir: env.INFRA_DIR, makeArgs: "WORKSPACE=${wsName} AUTO_APPROVE=yes")
+            make.runTarget(target: 'infra-down', dir: env.INFRA_DIR, makeArgs: "WORKSPACE=${wsName} AUTO_APPROVE=yes")
             env.INFRA_CLEANED = 'true'
         }
     } catch (cleanupErr) {
@@ -656,11 +655,9 @@ rancher_use_bundled_system_charts: true
                             )
                         }
 
-                        def mk = new make()
-
                         // ── Initialize S3 backend ──────────────────────────
                         stage('Initialize Tofu Backend') {
-                            mk.runTarget(
+                            make.runTarget(
                                 target:   'backend-s3',
                                 dir:      env.INFRA_DIR,
                                 makeArgs: [
@@ -678,7 +675,7 @@ rancher_use_bundled_system_charts: true
                                 suffix:           params.HOSTNAME_PREFIX,
                                 includeTimestamp: false
                             )
-                            mk.runTarget(
+                            make.runTarget(
                                 target:   'workspace-new',
                                 dir:      env.INFRA_DIR,
                                 makeArgs: "WORKSPACE=${workspaceName}"
@@ -689,7 +686,7 @@ rancher_use_bundled_system_charts: true
 
                         // ── Provision infra + generate inventory ───────────
                         stage('Provision Infrastructure') {
-                            mk.runTarget(
+                            make.runTarget(
                                 target:   'infra-up',
                                 dir:      env.INFRA_DIR,
                                 makeArgs: "WORKSPACE=${workspaceName}"
@@ -698,7 +695,7 @@ rancher_use_bundled_system_charts: true
 
                         // ── Deploy RKE2 cluster ────────────────────────────
                         stage('Deploy RKE2 Cluster') {
-                            mk.runTarget(
+                            make.runTarget(
                                 target:   'cluster',
                                 dir:      env.INFRA_DIR
                             )
@@ -707,7 +704,7 @@ rancher_use_bundled_system_charts: true
                         // ── Deploy Rancher ─────────────────────────────────
                         stage('Deploy Rancher') {
                             if (params.DEPLOY_RANCHER) {
-                                mk.runTarget(
+                                make.runTarget(
                                     target: 'rancher',
                                     dir:    env.INFRA_DIR
                                 )


### PR DESCRIPTION
This pull request refactors the `validation/Jenkinsfile.e2e` pipeline to replace direct calls to the `infra.*` shared library functions with a unified `make.runTarget` interface for infrastructure operations. This change streamlines how infrastructure actions are invoked, making the pipeline more maintainable and consistent.

**Refactoring of infrastructure operations:**

* Replaced all usages of `infra.backendS3`, `infra.workspaceNew`, `infra.up`, `infra.cluster`, `infra.rancher`, and `infra.down` with corresponding `make.runTarget` calls, passing the appropriate target and arguments for each infrastructure step. [[1]](diffhunk://#diff-79767a56cdef16bf95fce0f20b80574fa07b30b264ce4dabca15438dcd2268b9L15-R15) [[2]](diffhunk://#diff-79767a56cdef16bf95fce0f20b80574fa07b30b264ce4dabca15438dcd2268b9L660-R667) [[3]](diffhunk://#diff-79767a56cdef16bf95fce0f20b80574fa07b30b264ce4dabca15438dcd2268b9L675-R710) [[4]](diffhunk://#diff-79767a56cdef16bf95fce0f20b80574fa07b30b264ce4dabca15438dcd2268b9L70-R70)

**Documentation update:**

* Updated the comment at the top of the file to reflect the new usage of `make.runTarget` instead of the old `infra.*` functions.