### PR TITLE
Created pit.crew.style.agent agent and updated pit.crew.schema

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -92,10 +92,7 @@ Reviews and fixes Go validation test files to comply with the repository's code 
 **Example prompt:**
 ```
 copilot --agent=pit.crew.code.style -p "Review @validation/networking/connectivity/network_policy_test.go for code style issues"
-```
 
-**Github example:**
-```
 In an issue or PR comment:
 @github-copilot Use the pit.crew.code.style agent to review the changes in this PR
 ```

--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -102,6 +102,23 @@ In an issue or PR comment:
 
 ---
 
+### `pit.crew.jenkins` — Jenkinsfile Code Style Enforcer
+
+**File:** [`pit.crew.jenkins.agent.md`](./pit.crew.jenkins.agent.md)
+
+Reviews and fixes Jenkinsfiles to comply with the repository's pipeline standards, including `qa-jenkins-library` shared library usage, declarative pipeline structure, credential handling, and cleanup patterns.
+
+**When to use:** After writing or modifying a Jenkinsfile, run this agent to catch style and structural violations before opening a PR.
+
+**Example prompt:**
+```
+copilot --agent=pit.crew.jenkins -p "Review @validation/Jenkinsfile.e2e for pipeline code style issues"
+
+@github-copilot Use the pit.crew.jenkins agent to review the changes in this PR
+```
+
+---
+
 ## Additional Resources
 
 - [GitHub Copilot CLI documentation](https://docs.github.com/copilot/concepts/agents/about-copilot-cli)

--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -94,6 +94,12 @@ Reviews and fixes Go validation test files to comply with the repository's code 
 copilot --agent=pit.crew.code.style -p "Review @validation/networking/connectivity/network_policy_test.go for code style issues"
 ```
 
+**Github example:**
+```
+In an issue or PR comment:
+@github-copilot Use the pit.crew.code.style agent to review the changes in this PR
+```
+
 ---
 
 ## Additional Resources

--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -81,6 +81,21 @@ Generates or updates `schemas/pit_schemas.yaml` files for PIT (Platform Interope
 copilot --agent=pit.crew.schema --allow-tool write -p "Create the pit_schemas.yaml for @validation/networking/connectivity/"
 ```
 
+### `pit.crew.code.style` — Code Style Enforcer
+
+**File:** [`pit.crew.code.style.agent.md`](./pit.crew.code.style.agent.md)
+
+Reviews and fixes Go validation test files to comply with the repository's code style, naming conventions, error handling patterns, and linter rules.
+
+**When to use:** Reviewing, creating, or modifying test files to identify style violations and ensure consistency with project standards before opening a PR
+
+**Example prompt:**
+```
+copilot --agent=pit.crew.code.style -p "Review @validation/networking/connectivity/network_policy_test.go for code style issues"
+```
+
+---
+
 ## Additional Resources
 
 - [GitHub Copilot CLI documentation](https://docs.github.com/copilot/concepts/agents/about-copilot-cli)

--- a/.github/agents/pit.crew.code.style.agent.md
+++ b/.github/agents/pit.crew.code.style.agent.md
@@ -44,12 +44,11 @@ Workload upgrade test file:
 ## Checklist
 
 ### File and package structure
-* Helper functions specific to a test package must live in a separate file that does **not** end in `_test.go`.
+* Helper functions specific to a test package must live in a separate file in the same package directory that does **not** end in `_test.go` (e.g., `validation/charts/monitoring.go` alongside `validation/charts/monitoring_test.go`).
 * Helper functions that can be generalized across packages belong in the `actions/` directory.
 * Avoid unnecessary or multiple layers of abstraction.
 * Code must not be duplicated.
 
-### Naming conventions
 ### Naming conventions
 * Public functions must use `UpperCamelCase`.
 * Private functions must use `lowerCamelCase`.
@@ -66,7 +65,7 @@ Workload upgrade test file:
 * Automatic cleanup registration (via `session.Cleanup()`) is required.
 
 ### Helper functions
-* Default to returning an `error` instead of accepting a `*testing.T` parameter.
+* Default to returning an `error` instead of accepting a `*testing.T` parameter. Exception: a `*testing.T` parameter is acceptable when the function needs to emit structured test logs via `t.Log` or assertions that must surface in the test output as part of the function's own responsibility (e.g., a reusable validation helper that logs context on failure).
 * Return pointers to objects where possible.
 * All function parameters should use primitive types whenever possible.
 * Avoid adding new parameters to Create calls unless strictly necessary.

--- a/.github/agents/pit.crew.code.style.agent.md
+++ b/.github/agents/pit.crew.code.style.agent.md
@@ -1,0 +1,89 @@
+---
+name: pit.crew.code.style
+description: Review and fix Go validation test files to comply with repository code style and standards
+tools: ["view", "edit", "grep", "glob", "create"]
+---
+
+As a QA, ensure that test files follow the repository's code style. The reference test files below represent the expected quality and patterns — treat them as the standard.
+
+## Reference test files
+
+Chart test files:
+* [alerting_test.go](../../validation/charts/alerting_test.go)
+* [cis_benchmark_test.go](../../validation/charts/cis_benchmark_test.go)
+* [istio_test.go](../../validation/charts/istio_test.go)
+* [monitoring_test.go](../../validation/charts/monitoring_test.go)
+* [logging_test.go](../../validation/charts/logging_test.go)
+* [neuvector_test.go](../../validation/charts/neuvector_test.go)
+
+AppCo test file:
+* [istio_test.go](../../validation/charts/appco/istio_test.go)
+
+Fleet test file:
+* [public_gitrepo_test.go](../../validation/fleet/public_gitrepo_test.go)
+
+Fleet upgrade test file:
+* [upgrade_test.go](../../validation/fleet/upgrade/upgrade_test.go)
+
+Longhorn chart installation test file:
+* [installation_test.go](../../validation/longhorn/chartinstall/installation_test.go)
+
+Longhorn chart test file:
+* [longhorn_test.go](../../validation/longhorn/longhorn_test.go)
+
+Connectivity test files:
+* [network_policy_test.go](../../validation/networking/connectivity/network_policy_test.go)
+* [port_test.go](../../validation/networking/connectivity/port_test.go)
+
+Workload test file:
+* [workload_test.go](../../validation/workloads/workload_test.go)
+
+Workload upgrade test file:
+* [workload_test.go](../../validation/upgrade/workload_test.go)
+
+## Checklist
+
+### File and package structure
+* Helper functions specific to a test package must live in a separate file that does **not** end in `_test.go`.
+* Helper functions that can be generalized across packages belong in the `actions/` directory.
+* Avoid unnecessary or multiple layers of abstraction.
+* Code must not be duplicated.
+
+### Naming conventions
+* Public functions must use `UpperCamelCase`.
+* Private functions must use `lowerCamelCase`.
+* The receiver variable must use the initial letters of the test suite struct name (e.g., `func (m *MonitoringTestSuite)` not `func (i *MonitoringTestSuite)`).
+* Test names must not be redundant with the suite name (e.g., prefer `LoggingTestSuite.TestChartInstallation` over `LoggingTestSuite.TestLoggingInstallation`).
+* Test and suite names must not be ambiguous.
+
+### Test logic
+* Waits and validations must live in the test logic, not in helper or library functions.
+* Always validate in a separate function.
+* Arrays or slices must be validated as non-empty when applicable — `for` loops can silently hide errors if this is skipped.
+* Ensure CRDs are installed before deploying other charts.
+* Ensure CRDs are uninstalled only after other charts are removed.
+* Automatic cleanup registration (via `session.Cleanup()`) is required.
+
+### Helper functions
+* Default to returning an `error` instead of accepting a `*testing.T` parameter.
+* Return pointers to objects where possible.
+* All function parameters should use primitive types whenever possible.
+* Avoid adding new parameters to Create calls unless strictly necessary.
+* GoDoc comments are required for all exported functions.
+
+### Error handling
+* If an error is intentionally ignored, add a comment explaining why.
+
+### Logging and output
+* Use `logrus` for all logging — do not use `t.Log()` or `fmt.Print*`.
+* Logs must clearly describe test steps to improve traceability.
+
+### Constants and strings
+* Strings must be a `const` wherever possible, except in log messages and error strings.
+
+### API usage
+* Use SteveV1 or public APIs in preference to command-line interactions.
+
+### Linter compliance
+* No `time.Sleep` calls — use appropriate polls and watches instead.
+* No `fmt.Print*` calls — use `logrus` or the `testing` package.

--- a/.github/agents/pit.crew.code.style.agent.md
+++ b/.github/agents/pit.crew.code.style.agent.md
@@ -50,9 +50,10 @@ Workload upgrade test file:
 * Code must not be duplicated.
 
 ### Naming conventions
+### Naming conventions
 * Public functions must use `UpperCamelCase`.
 * Private functions must use `lowerCamelCase`.
-* The receiver variable must use the initial letters of the test suite struct name (e.g., `func (m *MonitoringTestSuite)` not `func (i *MonitoringTestSuite)`).
+* The receiver variable must use the first letter of the test suite struct name (e.g., `func (m *MonitoringTestSuite)` not `func (i *MonitoringTestSuite)`).
 * Test names must not be redundant with the suite name (e.g., prefer `LoggingTestSuite.TestChartInstallation` over `LoggingTestSuite.TestLoggingInstallation`).
 * Test and suite names must not be ambiguous.
 

--- a/.github/agents/pit.crew.jenkins.agent.md
+++ b/.github/agents/pit.crew.jenkins.agent.md
@@ -4,7 +4,7 @@ description: Review and fix Jenkinsfiles to comply with repository pipeline stan
 tools: ["view", "edit", "grep", "glob"]
 ---
 
-Ensure that Jenkinsfiles follow the repository's code style. The reference files below represent reviewed and merged pipelines — treat them as the standard.
+Ensure that Jenkinsfiles follow the repository's pipeline code style. The reference files below represent reviewed and merged pipelines — treat them as the standard.
 
 ## Reference Jenkinsfiles
 
@@ -82,3 +82,6 @@ QA infra / Elemental pipelines:
 ### Readability
 * Jenkinsfiles must include a top-level Groovy doc comment (`/** ... */`) describing the pipeline's purpose, what it does, and which shared library functions it consumes — following the pattern in `Jenkinsfile.e2e` and `Jenkinsfile.individual.e2e`.
 * Inline comments must explain non-obvious decisions (e.g., why a `TODO` exists).
+
+### Pinned versions
+* Docker image and libs references must use pinned digests or explicit version tags — never `latest`.

--- a/.github/agents/pit.crew.jenkins.agent.md
+++ b/.github/agents/pit.crew.jenkins.agent.md
@@ -1,0 +1,84 @@
+---
+name: pit.crew.jenkins
+description: Review and fix Jenkinsfiles to comply with repository pipeline standards and the qa-jenkins-library shared library patterns
+tools: ["view", "edit", "grep", "glob"]
+---
+
+Ensure that Jenkinsfiles follow the repository's code style. The reference files below represent reviewed and merged pipelines — treat them as the standard.
+
+## Reference Jenkinsfiles
+
+Modern declarative pipelines (preferred pattern):
+* [Jenkinsfile.e2e](../../validation/Jenkinsfile.e2e)
+* [Jenkinsfile.individual.e2e](../../validation/Jenkinsfile.individual.e2e)
+
+Legacy scripted pipelines (for compatibility reference only):
+* [Jenkinsfile](../../validation/Jenkinsfile)
+* [Jenkinsfile.harvester](../../validation/Jenkinsfile.harvester)
+
+Upgrade pipelines:
+* [Jenkinsfile.upgrade.e2e](../../validation/Jenkinsfile.upgrade.e2e)
+
+Airgap pipelines:
+* [Jenkinsfile.airgap.go-tests](../../validation/pipeline/Jenkinsfile.airgap.go-tests)
+* [Jenkinsfile.setup.airgap.rke2](../../validation/pipeline/Jenkinsfile.setup.airgap.rke2)
+* [Jenkinsfile.destroy.airgap.rke2](../../validation/pipeline/Jenkinsfile.destroy.airgap.rke2)
+
+Recurring pipelines:
+* [Jenkinsfile.recurring](../../validation/pipeline/Jenkinsfile.recurring)
+* [Jenkinsfile.multibranch.recurring](../../validation/pipeline/Jenkinsfile.multibranch.recurring)
+
+Rancher HA pipelines:
+* [Jenkinsfile.ha.deploy](../../validation/pipeline/rancherha/Jenkinsfile.ha.deploy)
+
+QA infra / Elemental pipelines:
+* [Jenkinsfile.elemental.e2e](../../validation/pipeline/qainfra/Jenkinsfile.elemental.e2e)
+* [Jenkinsfile.elemental.harvester.e2e](../../validation/pipeline/qainfra/Jenkinsfile.elemental.harvester.e2e)
+
+## Checklist
+
+### Shared library usage
+* All pipelines must load the `qa-jenkins-library` shared library using the pattern:
+  ```groovy
+  def libraryBranch = env.QA_JENKINS_LIBRARY_BRANCH ?: 'main'
+  library "qa-jenkins-library@${libraryBranch}"
+  ```
+* Infrastructure operations must use library abstractions (`make.runTarget`, `tofu.*`, `infrastructure.*`, `airgap.standardCheckout`) — never invoke raw `sh` commands for these directly in a Jenkinsfile.
+* Test execution must use library helpers (`property.useWithProperties`) rather than ad-hoc credential or environment wiring.
+* Common logic shared across multiple Jenkinsfiles must live in the shared library, not be duplicated inline.
+
+### Pipeline structure
+* New pipelines must use declarative `pipeline {}` syntax. Scripted `node {}` pipelines are legacy and should not be created.
+* Pipeline logic in Jenkinsfiles must be minimal — orchestration only. Business logic belongs in shared library functions.
+* Avoid unnecessary layers of abstraction within the Jenkinsfile itself.
+
+### Parameters and configuration
+* All configurable values (paths, images, timeouts, tags, credentials, regions, repo URLs) must be pipeline parameters or sourced from library helpers — never hardcoded.
+* Use `?:` (Elvis operator) to provide safe defaults for all environment variable reads (e.g., `env.TIMEOUT ?: '60m'`).
+* Input validation must be present for all public functions: required map keys must be checked and meaningful errors raised when missing.
+
+### Error handling and cleanup
+* Error handling must be explicit: use `error(message)` with clear messages.
+* Cleanup logic (containers, workspaces, artifacts, infrastructure teardown) must execute on failure as well as success — use `post { always { } }` or `try/catch/finally` blocks.
+* Infrastructure teardown must guard against double-cleanup using a flag (e.g., `env.INFRA_CLEANED == 'true'`).
+* Teardown failures must be caught and logged without masking the original build failure.
+
+### Credentials and secrets
+* Credentials and sensitive data must be handled exclusively through Jenkins credentials bindings or library helpers.
+* Secrets must never be logged, echoed, or hardcoded in any form.
+
+### Workspace hygiene
+* Workspace usage must be deterministic and isolated: clean checkout, predictable directory names, no cross-build contamination.
+* Container and volume names must include `${JOB_NAME}` and `${BUILD_NUMBER}` to ensure uniqueness.
+
+### Naming conventions
+* Use centralized naming utilities from the shared library rather than ad-hoc string concatenation for job names, container names, and workspace names.
+* Variable names must use `lowerCamelCase` in Groovy.
+
+### Artifacts and results
+* Test results and artifacts must always be archived in a standard way, even in partial-failure scenarios where results are available.
+* Use `junit` and `archiveArtifacts` steps consistently across all pipelines.
+
+### Readability
+* Jenkinsfiles must include a top-level Groovy doc comment (`/** ... */`) describing the pipeline's purpose, what it does, and which shared library functions it consumes — following the pattern in `Jenkinsfile.e2e` and `Jenkinsfile.individual.e2e`.
+* Inline comments must explain non-obvious decisions (e.g., why a `TODO` exists).

--- a/.github/agents/pit.crew.schema.agent.md
+++ b/.github/agents/pit.crew.schema.agent.md
@@ -1,10 +1,19 @@
 ---
 name: pit.crew.schema
-description: Create or update schema files based on test automation
-tools: ["read", "edit", "search", "write"]
+description: Create or update PIT schema YAML files
+tools: ["view", "edit", "grep", "glob", "create"]
 ---
 
 As a QA, ensure that a schemas folder exists for each test suite. If it does not exist, create it. Then create or update the corresponding pit_schemas.yaml file based on the associated test file. Use the YAML and test files below as references.
+
+## Rules
+
+- The value of `custom_field["15"]` must exactly match the Go test function name (e.g., `"TestCISBenchmarkInstallation"`). Read the test file to find all `Test*` functions and create one case per function.
+- Each high-level action in the test function body maps to one step entry. Steps must be sequential and numbered starting at 1.
+- Always use `[RANCHERINT]` (no spaces) as the projects value.
+- Use `automation: 2` for all cases.
+
+## Test files and schema files
 
 Chart test files and schema file:
 * [alerting_test.go](../../validation/charts/alerting_test.go)
@@ -12,6 +21,7 @@ Chart test files and schema file:
 * [istio_test.go](../../validation/charts/istio_test.go)
 * [monitoring_test.go](../../validation/charts/monitoring_test.go)
 * [logging_test.go](../../validation/charts/logging_test.go)
+* [neuvector_test.go](../../validation/charts/neuvector_test.go)
 * [pit_schemas.yaml](../../validation/charts/schemas/pit_schemas.yaml)
 
 AppCo test files and schema file:
@@ -21,6 +31,10 @@ AppCo test files and schema file:
 Fleet test files and schema file:
 * [public_gitrepo_test.go](../../validation/fleet/public_gitrepo_test.go)
 * [pit_schemas.yaml](../../validation/fleet/schemas/pit_schemas.yaml)
+
+Fleet airgap test files and schema file:
+* [fleet_airgap_test.go](../../validation/fleet/airgap/fleet_airgap_test.go)
+* [pit_schemas.yaml](../../validation/fleet/airgap/schemas/pit_schemas.yaml)
 
 Fleet upgrade test files and schema file:
 * [upgrade_test.go](../../validation/fleet/upgrade/upgrade_test.go)
@@ -39,6 +53,32 @@ Connectivity test files and schema file:
 * [port_test.go](../../validation/networking/connectivity/port_test.go)
 * [pit_schemas.yaml](../../validation/networking/connectivity/schemas/pit_schemas.yaml)
 
+NeuVector test files and schema file:
+* [neuvector_hardened_test.go](../../validation/neuvector/neuvector_hardened_test.go)
+* [pit_schemas.yaml](../../validation/neuvector/schemas/pit_schemas.yaml)
+
+Certificates RKE2 test files and schema file:
+* [cert_rotation_test.go](../../validation/certificates/rke2/cert_rotation_test.go)
+* [cert_rotation_wins_test.go](../../validation/certificates/rke2/cert_rotation_wins_test.go)
+* [pit_schemas.yaml](../../validation/certificates/rke2/schemas/pit_schemas.yaml)
+
+Snapshot RKE2 test files and schema file:
+* [snapshot_restore_test.go](../../validation/snapshot/rke2/snapshot_restore_test.go)
+* [snapshot_recurring_test.go](../../validation/snapshot/rke2/snapshot_recurring_test.go)
+* [snapshot_s3_restore_test.go](../../validation/snapshot/rke2/snapshot_s3_restore_test.go)
+* [snapshot_retention_test.go](../../validation/snapshot/rke2/snapshot_retention_test.go)
+* [snapshot_restore_wins_test.go](../../validation/snapshot/rke2/snapshot_restore_wins_test.go)
+* [pit_schemas.yaml](../../validation/snapshot/rke2/schemas/pit_schemas.yaml)
+
+Node scaling RKE2 test files and schema file:
+* [scaling_test.go](../../validation/nodescaling/rke2/scaling_test.go)
+* [pit_schemas.yaml](../../validation/nodescaling/rke2/schemas/pit_schemas.yaml)
+
+Provisioning RKE2 test files and schema file:
+* [node_driver_test.go](../../validation/provisioning/rke2/node_driver_test.go)
+* [custom_test.go](../../validation/provisioning/rke2/custom_test.go)
+* [pit_schemas.yaml](../../validation/provisioning/rke2/schemas/pit_schemas.yaml)
+
 Workload test file and schema file:
 * [workload_test.go](../../validation/workloads/workload_test.go)
 * [pit_schemas.yaml](../../validation/workloads/schemas/pit_schemas.yaml)
@@ -47,7 +87,9 @@ Workload upgrade test file and schema file:
 * [workload_test.go](../../validation/upgrade/workload_test.go)
 * [pit_schemas.yaml](../../validation/upgrade/schemas/pit_schemas.yaml)
 
-The yaml file should mirror the structure and style of the provided example below
+## Example YAML
+
+The yaml file should mirror the structure and style of the provided example below:
 ```yaml
 - projects: [RANCHERINT]
   suite: Charts


### PR DESCRIPTION
This PR updates the repository’s GitHub Copilot CLI custom agents documentation and agent definitions by adding a new code-style enforcement agent and expanding/refining the PIT schema generator agent guidance.

Changes:

- Added a new pit.crew.code.style agent definition for enforcing Go test code style conventions.
- Expanded pit.crew.schema agent instructions (rules + broader list of referenced test/schema locations).
- Updated .github/agents/README.md to document the new code-style agent and how to invoke it.