### PR TITLE
Temporarily exclude kubeconfigs suite from 2.15

### DIFF
--- a/validation/auth/kubeconfigs/kubeconfigs_test.go
+++ b/validation/auth/kubeconfigs/kubeconfigs_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !2.8 && !2.9 && !2.10 && !2.11
+//go:build (validation || infra.any || cluster.any || extended) && !sanity && !stress && !2.8 && !2.9 && !2.10 && !2.11 && !2.15
 
 package kubeconfigs
 


### PR DESCRIPTION
This PR is a temporary fix to stop the kubeconfigs suite from running on 2.15.
2.15 introduced changes that break the current suite. A new test suite for 2.15 will be added. Until then, excluding the test suite via !2.15 build tag instead of deprecating it. 