### PR TITLE
Removed JENKINS_RKE_VALIDATION variable

### DIFF
--- a/validation/Jenkinsfile
+++ b/validation/Jenkinsfile
@@ -110,11 +110,6 @@ node {
                 }
               }
 
-              dir("./validation/.ssh") {
-                def decodedRsa = new String(AWS_SSH_RSA_KEY.decodeBase64())
-                writeFile file: JENKINS_RKE_VALIDATION, text: decodedRsa
-              }
-
               dir("./validation") {
                 def filename = "config.yaml"
                 def configContents = env.CONFIG

--- a/validation/Jenkinsfile.rc
+++ b/validation/Jenkinsfile.rc
@@ -129,10 +129,6 @@ node {
                   def decoded = new String(AWS_SSH_PEM_KEY.decodeBase64())
                   writeFile file: AWS_SSH_KEY_NAME, text: decoded
                 }
-                dir("./validation/.ssh") {
-                  def decodedRsa = new String(AWS_SSH_RSA_KEY.decodeBase64())
-                  writeFile file: JENKINS_RKE_VALIDATION, text: decodedRsa
-                }
               }
               dir("./tests/validation") {
                 writeFile file: filename, text: config

--- a/validation/Jenkinsfile.vsphere
+++ b/validation/Jenkinsfile.vsphere
@@ -103,11 +103,6 @@ node("vsphere-vpn-1") {
                   }
                 }
 
-                dir("./validation/.ssh") {
-                  def decodedRsa = new String(AWS_SSH_RSA_KEY.decodeBase64())
-                  writeFile file: JENKINS_RKE_VALIDATION, text: decodedRsa
-                }
-
                 dir("./validation") {
                   def filename = "config.yaml"
                   def configContents = env.CONFIG

--- a/validation/pipeline/tfp/Jenkinsfile.tfp.setup
+++ b/validation/pipeline/tfp/Jenkinsfile.tfp.setup
@@ -61,9 +61,6 @@ node {
           dir(".ssh") {
               def decoded = new String(env.AWS_SSH_PEM_KEY.decodeBase64())
               writeFile file: AWS_SSH_KEY_NAME, text: decoded
-
-              def decodedRsa = new String(AWS_SSH_RSA_KEY.decodeBase64())
-              writeFile file: JENKINS_RKE_VALIDATION, text: decodedRsa
           }
 
           env.CATTLE_TEST_CONFIG=rootPath+'config.yml'


### PR DESCRIPTION
This PR removes the generation/writing of an RSA SSH key file previously written to JENKINS_RKE_VALIDATION across multiple Jenkins pipelines under validation/, aligning the jobs with the removal of that variable.

Changes:

- Removed base64 decode + writeFile steps that wrote the RSA key content into JENKINS_RKE_VALIDATION in several Jenkinsfiles.
- Kept PEM key handling and config setup unchanged while eliminating the extra RSA key artifact.