### PR TITLE
Fix dual-stack/IPv6 CIDR blocks from secrets to vars in workflows

### DIFF
--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -231,8 +231,8 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             networking:
-              clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             advanced:
               machineGlobalConfig:
@@ -586,8 +586,8 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             networking:
-              clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             advanced:
               machineGlobalConfig:
@@ -941,8 +941,8 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             networking:
-              clusterCIDR: "${{ secrets.IPV6_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.IPV6_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
             advanced:
               machineGlobalConfig:

--- a/.github/workflows/recurring-dualstack-tests.yml
+++ b/.github/workflows/recurring-dualstack-tests.yml
@@ -198,8 +198,8 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -234,8 +234,8 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             networking:
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
             advanced:
               machineGlobalConfig:
@@ -561,8 +561,8 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -597,8 +597,8 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             networking:
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
             advanced:
               machineGlobalConfig:
@@ -923,8 +923,8 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
               awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -960,8 +960,8 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             networking:
-              clusterCIDR: "${{ secrets.DUALSTACK_CLUSTER_CIDR }}"
-              serviceCIDR: "${{ secrets.DUALSTACK_SERVICE_CIDR }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
             advanced:
               machineGlobalConfig:


### PR DESCRIPTION
This PR updates the workflow configuration by moving the dual-stack/IPv6 CIDR blocks from GitHub secrets to workflow variables. This change improves the visibility and manageability of these values within the workflow files, making it easier to update and audit network configuration.