### PR TITLE
Do not skip running workflows for a new Rancher release line

### DIFF
--- a/.github/actions/check-rancher-tag-result/action.yaml
+++ b/.github/actions/check-rancher-tag-result/action.yaml
@@ -76,13 +76,7 @@ runs:
               run_conclusion=$(echo "$run_json" | jq -r '.conclusion // empty')
               jobs_json=$(echo "$run_json" | jq -c '.jobs // []')
 
-              # If the workflow run itself is skipped for this tag, count as skipped
-              if [[ "$run_conclusion" == "skipped" ]]; then
-                found_skipped=1
-                continue
-              fi
-
-              # If there are jobs, check them as before
+              # If there are jobs, check them for the current tag.
               if [[ "$jobs_json" != "[]" ]]; then
                 if echo "$jobs_json" | jq -e --arg tag "$prev_tag" '.[]? | select(.name == $tag and .conclusion == "success")' > /dev/null; then
                   most_recent_passed_tag="$prev_tag"
@@ -91,6 +85,9 @@ runs:
                 if echo "$jobs_json" | jq -e --arg tag "$prev_tag" '.[]? | select(.name == $tag and .conclusion == "skipped")' > /dev/null; then
                   found_skipped=1
                 fi
+              elif [[ "$run_conclusion" == "skipped" ]]; then
+                # Only count workflow-level skipped if there are no jobs and run itself is skipped.
+                found_skipped=1
               fi
             done
           done


### PR DESCRIPTION
This pull request ensures that workflows are not skipped for new Rancher release lines, allowing necessary CI/CD processes to run and validate changes as part of the release process.