### PR TITLE
Remove pod and deployment checks from autoscaler pause test

### DIFF
--- a/.github/actions/run-hostbusters-prime-test-suites/action.yaml
+++ b/.github/actions/run-hostbusters-prime-test-suites/action.yaml
@@ -22,7 +22,7 @@ runs:
           --packages=github.com/rancher/tests/validation/prime/autoscaling \
           --junitfile results_autoscaling.xml \
           --jsonfile results_autoscaling.json \
-          -- -timeout=1h -tags=prime -v
+          -- -timeout=3h -tags=prime -v
 
         autoscaling_exit=$?
         echo "autoscaling_exit=$autoscaling_exit" >> "$GITHUB_ENV"

--- a/validation/prime/autoscaling/auto_scaling_test.go
+++ b/validation/prime/autoscaling/auto_scaling_test.go
@@ -305,14 +305,6 @@ func TestAutoScalingPause(t *testing.T) {
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
 			err = provisioning.VerifyClusterReady(s.client, cluster)
 			require.NoError(t, err)
-
-			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
-			err = deployment.VerifyClusterDeployments(s.client, cluster)
-			require.NoError(t, err)
-
-			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
-			err = pods.VerifyClusterPods(s.client, cluster)
-			require.NoError(t, err)
 		})
 
 		params := provisioning.GetProvisioningSchemaParams(tt.client, s.cattleConfig)


### PR DESCRIPTION
This PR removes the checks for pods and deployments from the autoscaler pause test, simplifying the test logic to focus solely on autoscaler behavior.