### PR TITLE
Update airgap tests to enforce cluster level registry is being used

### DIFF
--- a/.github/workflows/airgap-cluster-provisioning.yml
+++ b/.github/workflows/airgap-cluster-provisioning.yml
@@ -231,9 +231,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            registries:
-              rke2Registries:
-                configs: {}
 
           logging:
             level: "${{ vars.LOGGING_LEVEL }}"
@@ -551,9 +548,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            registries:
-              rke2Registries:
-                configs: {}
 
           logging:
             level: "${{ vars.LOGGING_LEVEL }}"
@@ -872,9 +866,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            registries:
-              rke2Registries:
-                configs: {}
 
           logging:
             level: "${{ vars.LOGGING_LEVEL }}"

--- a/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
@@ -238,9 +238,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            registries:
-              rke2Registries:
-                 configs: {}
 
           logging:
             level: "${{ vars.LOGGING_LEVEL }}"
@@ -565,9 +562,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            registries:
-              rke2Registries:
-                 configs: {}
 
           logging:
             level: "${{ vars.LOGGING_LEVEL }}"
@@ -894,9 +888,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            registries:
-              rke2Registries:
-                 configs: {}
 
           logging:
             level: "${{ vars.LOGGING_LEVEL }}"

--- a/actions/go.mod
+++ b/actions/go.mod
@@ -10,7 +10,7 @@ replace (
 
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20260527150105-ae26ccbc3fed
 	github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20260527150105-ae26ccbc3fed
-	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260617190045-278b272fdd45
+	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260618220332-d6ad5005a462
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
 	go.opentelemetry.io/otel => go.opentelemetry.io/otel v1.28.0
@@ -60,7 +60,7 @@ require (
 	github.com/qase-tms/qase-go/qase-api-client v1.2.1
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/shepherd v0.0.0-20260610155525-6d926c75d49a
-	github.com/rancher/tfp-automation v0.0.0-20260617190045-278b272fdd45
+	github.com/rancher/tfp-automation v0.0.0-20260618220332-d6ad5005a462
 )
 
 require (

--- a/actions/go.sum
+++ b/actions/go.sum
@@ -217,8 +217,8 @@ github.com/rancher/shepherd v0.0.0-20260610155525-6d926c75d49a h1://lhZJ7E6znLtt
 github.com/rancher/shepherd v0.0.0-20260610155525-6d926c75d49a/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8/go.mod h1:xDDFkXVPcCf+S6wQoIDwgIijQHcIaVdN0eQRG2GcFd4=
-github.com/rancher/tfp-automation v0.0.0-20260617190045-278b272fdd45 h1:XFnNnsfb8jxWPseE7EWNiXArDRx21Z2qXzg6NfvTiNU=
-github.com/rancher/tfp-automation v0.0.0-20260617190045-278b272fdd45/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
+github.com/rancher/tfp-automation v0.0.0-20260618220332-d6ad5005a462 h1:3qA9omd6Y1o84J+AdPPz2P0i9OTbo74DPZlRapazFy4=
+github.com/rancher/tfp-automation v0.0.0-20260618220332-d6ad5005a462/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=
 github.com/rancher/wrangler v1.1.2/go.mod h1:2k9MyhlBdjcutcBGoOJSUAz0HgDAXnMjv81d3n/AaQc=
 github.com/rancher/wrangler/v3 v3.7.0 h1:rB6GJpnc4Kz8lWuAH3wZwQPgJqPGOu43Aih6147uZB8=

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ replace (
 
 	github.com/rancher/tests/actions => ./actions
 	github.com/rancher/tests/interoperability => ./interoperability
-	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260617190045-278b272fdd45
+	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260618220332-d6ad5005a462
 
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
@@ -73,7 +73,7 @@ require (
 	github.com/rancher/shepherd v0.0.0-20260610155525-6d926c75d49a
 	github.com/rancher/tests/actions v0.0.0-20260610140123-a36d05641397
 	github.com/rancher/tests/interoperability v0.0.0
-	github.com/rancher/tfp-automation v0.0.0-20260617190045-278b272fdd45
+	github.com/rancher/tfp-automation v0.0.0-20260618220332-d6ad5005a462
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -3701,8 +3701,8 @@ github.com/rancher/shepherd v0.0.0-20260610155525-6d926c75d49a h1://lhZJ7E6znLtt
 github.com/rancher/shepherd v0.0.0-20260610155525-6d926c75d49a/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8/go.mod h1:xDDFkXVPcCf+S6wQoIDwgIijQHcIaVdN0eQRG2GcFd4=
-github.com/rancher/tfp-automation v0.0.0-20260617190045-278b272fdd45 h1:XFnNnsfb8jxWPseE7EWNiXArDRx21Z2qXzg6NfvTiNU=
-github.com/rancher/tfp-automation v0.0.0-20260617190045-278b272fdd45/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
+github.com/rancher/tfp-automation v0.0.0-20260618220332-d6ad5005a462 h1:3qA9omd6Y1o84J+AdPPz2P0i9OTbo74DPZlRapazFy4=
+github.com/rancher/tfp-automation v0.0.0-20260618220332-d6ad5005a462/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/interoperability/go.mod
+++ b/interoperability/go.mod
@@ -13,7 +13,7 @@ replace (
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20260527150105-ae26ccbc3fed
 	github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20260527150105-ae26ccbc3fed
 	github.com/rancher/tests/actions => ./../actions
-	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260617190045-278b272fdd45
+	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260618220332-d6ad5005a462
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
 	go.opentelemetry.io/otel => go.opentelemetry.io/otel v1.28.0
@@ -69,7 +69,7 @@ require (
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/shepherd v0.0.0-20260610155525-6d926c75d49a
 	github.com/rancher/tests/actions v0.0.0-20260610140123-a36d05641397
-	github.com/rancher/tfp-automation v0.0.0-20260617190045-278b272fdd45
+	github.com/rancher/tfp-automation v0.0.0-20260618220332-d6ad5005a462
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.51.0

--- a/interoperability/go.sum
+++ b/interoperability/go.sum
@@ -3655,8 +3655,8 @@ github.com/rancher/shepherd v0.0.0-20260610155525-6d926c75d49a h1://lhZJ7E6znLtt
 github.com/rancher/shepherd v0.0.0-20260610155525-6d926c75d49a/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8/go.mod h1:xDDFkXVPcCf+S6wQoIDwgIijQHcIaVdN0eQRG2GcFd4=
-github.com/rancher/tfp-automation v0.0.0-20260617190045-278b272fdd45 h1:XFnNnsfb8jxWPseE7EWNiXArDRx21Z2qXzg6NfvTiNU=
-github.com/rancher/tfp-automation v0.0.0-20260617190045-278b272fdd45/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
+github.com/rancher/tfp-automation v0.0.0-20260618220332-d6ad5005a462 h1:3qA9omd6Y1o84J+AdPPz2P0i9OTbo74DPZlRapazFy4=
+github.com/rancher/tfp-automation v0.0.0-20260618220332-d6ad5005a462/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/validation/provisioning/airgap/airgap_setup.go
+++ b/validation/provisioning/airgap/airgap_setup.go
@@ -5,20 +5,22 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/pkg/config"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/logging"
+	"github.com/rancher/tests/actions/provisioninginput"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
 	tfpConfig "github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework"
 	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
 	"github.com/rancher/tfp-automation/tests/extensions/ssh"
-
 	ranchersetup "github.com/rancher/tfp-automation/tests/infrastructure/ranchers/setup"
 	"github.com/stretchr/testify/require"
 )
@@ -82,4 +84,22 @@ func airgapSetup(t *testing.T, clusterType string) airgapTest {
 	require.NoError(t, err)
 
 	return r
+}
+
+func initializeRegistryMachineSelectors(t *testing.T, clusterConfig *clusters.ClusterConfig) {
+	if clusterConfig.Advanced == nil {
+		clusterConfig.Advanced = &provisioninginput.Advanced{}
+	}
+
+	if clusterConfig.Advanced.MachineSelectors == nil {
+		clusterConfig.Advanced.MachineSelectors = &[]rkev1.RKESystemConfig{}
+	}
+
+	if len(*clusterConfig.Advanced.MachineSelectors) == 0 {
+		*clusterConfig.Advanced.MachineSelectors = append(*clusterConfig.Advanced.MachineSelectors, rkev1.RKESystemConfig{})
+	}
+
+	if (*clusterConfig.Advanced.MachineSelectors)[0].Config.Data == nil {
+		(*clusterConfig.Advanced.MachineSelectors)[0].Config.Data = map[string]interface{}{}
+	}
 }

--- a/validation/provisioning/airgap/defaults/defaults.yaml
+++ b/validation/provisioning/airgap/defaults/defaults.yaml
@@ -27,6 +27,10 @@ clusterConfig:
   cni: "calico"
   provider: "aws"
   nodeProvider: "ec2"
+  registries:
+    rke2Registries:
+      configs:
+        <required>:
 
 #Required for tests that utilize custom clusters
 awsEC2Configs:

--- a/validation/provisioning/airgap/k3s_ace_test.go
+++ b/validation/provisioning/airgap/k3s_ace_test.go
@@ -55,6 +55,16 @@ func TestAirgapK3SACE(t *testing.T) {
 		clusterConfig := new(clusters.ClusterConfig)
 		operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
 
+		clusterConfig.Registries.RKE2Registries.Configs[r.terraformConfig.PrivateRegistries.SystemDefaultRegistry] = clusterConfig.Registries.RKE2Registries.Configs["<required>"]
+		delete(clusterConfig.Registries.RKE2Registries.Configs, "<required>")
+
+		registryConfig := clusterConfig.Registries.RKE2Registries.Configs[r.terraformConfig.PrivateRegistries.SystemDefaultRegistry]
+		registryConfig.InsecureSkipVerify = true
+		clusterConfig.Registries.RKE2Registries.Configs[r.terraformConfig.PrivateRegistries.SystemDefaultRegistry] = registryConfig
+
+		initializeRegistryMachineSelectors(t, clusterConfig)
+
+		(*clusterConfig.Advanced.MachineSelectors)[0].Config.Data["system-default-registry"] = r.terraformConfig.PrivateRegistries.SystemDefaultRegistry
 		clusterConfig.MachinePools = tt.machinePools
 
 		t.Run(tt.name, func(t *testing.T) {

--- a/validation/provisioning/airgap/k3s_custom_test.go
+++ b/validation/provisioning/airgap/k3s_custom_test.go
@@ -55,6 +55,16 @@ func TestCustomK3SAirgap(t *testing.T) {
 		clusterConfig := new(clusters.ClusterConfig)
 		operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
 
+		clusterConfig.Registries.RKE2Registries.Configs[r.terraformConfig.PrivateRegistries.SystemDefaultRegistry] = clusterConfig.Registries.RKE2Registries.Configs["<required>"]
+		delete(clusterConfig.Registries.RKE2Registries.Configs, "<required>")
+
+		registryConfig := clusterConfig.Registries.RKE2Registries.Configs[r.terraformConfig.PrivateRegistries.SystemDefaultRegistry]
+		registryConfig.InsecureSkipVerify = true
+		clusterConfig.Registries.RKE2Registries.Configs[r.terraformConfig.PrivateRegistries.SystemDefaultRegistry] = registryConfig
+
+		initializeRegistryMachineSelectors(t, clusterConfig)
+
+		(*clusterConfig.Advanced.MachineSelectors)[0].Config.Data["system-default-registry"] = r.terraformConfig.PrivateRegistries.SystemDefaultRegistry
 		clusterConfig.MachinePools = tt.machinePools
 
 		t.Run(tt.name, func(t *testing.T) {

--- a/validation/provisioning/airgap/rke2_ace_test.go
+++ b/validation/provisioning/airgap/rke2_ace_test.go
@@ -59,6 +59,16 @@ func TestAirgapRKE2ACE(t *testing.T) {
 		clusterConfig := new(clusters.ClusterConfig)
 		operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
 
+		clusterConfig.Registries.RKE2Registries.Configs[r.terraformConfig.PrivateRegistries.SystemDefaultRegistry] = clusterConfig.Registries.RKE2Registries.Configs["<required>"]
+		delete(clusterConfig.Registries.RKE2Registries.Configs, "<required>")
+
+		registryConfig := clusterConfig.Registries.RKE2Registries.Configs[r.terraformConfig.PrivateRegistries.SystemDefaultRegistry]
+		registryConfig.InsecureSkipVerify = true
+		clusterConfig.Registries.RKE2Registries.Configs[r.terraformConfig.PrivateRegistries.SystemDefaultRegistry] = registryConfig
+
+		initializeRegistryMachineSelectors(t, clusterConfig)
+
+		(*clusterConfig.Advanced.MachineSelectors)[0].Config.Data["system-default-registry"] = r.terraformConfig.PrivateRegistries.SystemDefaultRegistry
 		clusterConfig.MachinePools = tt.machinePools
 
 		t.Run(tt.name, func(t *testing.T) {

--- a/validation/provisioning/airgap/rke2_custom_test.go
+++ b/validation/provisioning/airgap/rke2_custom_test.go
@@ -68,6 +68,16 @@ func TestCustomRKE2Airgap(t *testing.T) {
 		clusterConfig := new(clusters.ClusterConfig)
 		operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
 
+		clusterConfig.Registries.RKE2Registries.Configs[r.terraformConfig.PrivateRegistries.SystemDefaultRegistry] = clusterConfig.Registries.RKE2Registries.Configs["<required>"]
+		delete(clusterConfig.Registries.RKE2Registries.Configs, "<required>")
+
+		registryConfig := clusterConfig.Registries.RKE2Registries.Configs[r.terraformConfig.PrivateRegistries.SystemDefaultRegistry]
+		registryConfig.InsecureSkipVerify = true
+		clusterConfig.Registries.RKE2Registries.Configs[r.terraformConfig.PrivateRegistries.SystemDefaultRegistry] = registryConfig
+
+		initializeRegistryMachineSelectors(t, clusterConfig)
+
+		(*clusterConfig.Advanced.MachineSelectors)[0].Config.Data["system-default-registry"] = r.terraformConfig.PrivateRegistries.SystemDefaultRegistry
 		clusterConfig.MachinePools = tt.machinePools
 
 		t.Run(tt.name, func(t *testing.T) {

--- a/validation/provisioning/registries/global_registry_test.go
+++ b/validation/provisioning/registries/global_registry_test.go
@@ -33,14 +33,13 @@ func TestGlobalRegistry(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                  string
-		client                *rancher.Client
-		clusterType           string
-		machinePools          []provisioninginput.MachinePools
-		systemDefaultRegistry string
+		name         string
+		client       *rancher.Client
+		clusterType  string
+		machinePools []provisioninginput.MachinePools
 	}{
-		{"Global_Registry_RKE2", r.standardUserClient, defaults.RKE2, nodeRolesDedicated, r.terraformConfig.StandaloneRegistry.GlobalRegistryFQDN},
-		{"Global_Registry_K3S", r.standardUserClient, defaults.K3S, nodeRolesAll, r.terraformConfig.StandaloneRegistry.GlobalRegistryFQDN},
+		{"Global_Registry_RKE2", r.standardUserClient, defaults.RKE2, nodeRolesDedicated},
+		{"Global_Registry_K3S", r.standardUserClient, defaults.K3S, nodeRolesAll},
 	}
 
 	for _, tt := range tests {

--- a/validation/provisioning/registries/global_registry_wins_test.go
+++ b/validation/provisioning/registries/global_registry_wins_test.go
@@ -34,13 +34,12 @@ func TestGlobalRegistryWindows(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                  string
-		client                *rancher.Client
-		clusterType           string
-		machinePools          []provisioninginput.MachinePools
-		systemDefaultRegistry string
+		name         string
+		client       *rancher.Client
+		clusterType  string
+		machinePools []provisioninginput.MachinePools
 	}{
-		{"Global_Registry_RKE2_Windows", r.standardUserClient, defaults.RKE2, nodeRolesDedicatedWindows, r.terraformConfig.StandaloneRegistry.GlobalRegistryFQDN},
+		{"Global_Registry_RKE2_Windows", r.standardUserClient, defaults.RKE2, nodeRolesDedicatedWindows},
 	}
 
 	for _, tt := range tests {

--- a/validation/provisioning/registries/registries_setup.go
+++ b/validation/provisioning/registries/registries_setup.go
@@ -20,7 +20,6 @@ import (
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	"github.com/rancher/tfp-automation/framework"
 	"github.com/rancher/tfp-automation/framework/set/resources/rancher2"
-
 	ranchersetup "github.com/rancher/tfp-automation/tests/infrastructure/ranchers/setup"
 	"github.com/stretchr/testify/require"
 )

--- a/validation/recurring/infrastructure/config/replaceValues.go
+++ b/validation/recurring/infrastructure/config/replaceValues.go
@@ -26,36 +26,3 @@ func UpdateAgentEnvVar(config map[string]any, name, value string) {
 
 	}
 }
-
-// UpdateRegistryVars is a helper function to update the registry configs in the cattle config.
-func UpdateRegistryVars(config map[string]any, url string) {
-	clusterConfig, ok := config["clusterConfig"].(map[string]any)
-	if !ok {
-		logrus.Fatalf("clusterConfig not found or not a map")
-	}
-
-	registries, ok := clusterConfig["registries"].(map[string]any)
-	if !ok {
-		logrus.Fatalf("registries not found or not a map")
-	}
-
-	rke2Registries, ok := registries["rke2Registries"].(map[string]any)
-	if !ok {
-		logrus.Fatalf("rke2Registries not found or not a map")
-	}
-
-	configs, ok := rke2Registries["configs"].(map[string]any)
-	if !ok {
-		logrus.Fatalf("configs not found or not a map")
-	}
-
-	for k := range configs {
-		delete(configs, k)
-	}
-
-	rke2Registries["configs"] = map[string]any{
-		url: map[string]any{
-			"insecureSkipVerify": true,
-		},
-	}
-}

--- a/validation/recurring/infrastructure/setuprancher/airgap/main.go
+++ b/validation/recurring/infrastructure/setuprancher/airgap/main.go
@@ -47,8 +47,6 @@ func main() {
 		logrus.Fatalf("Failed to replace system default registry: %v", err)
 	}
 
-	infraConfig.UpdateRegistryVars(cattleConfig, registry)
-
 	cattleConfig, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, client.RancherConfig.AdminToken, cattleConfig)
 	if err != nil {
 		logrus.Fatalf("Failed to replace admin token: %v", err)

--- a/validation/recurring/infrastructure/upgraderancher/airgap/main.go
+++ b/validation/recurring/infrastructure/upgraderancher/airgap/main.go
@@ -64,8 +64,6 @@ func main() {
 		logrus.Fatalf("Failed to restore rancher host: %v", err)
 	}
 
-	infraConfig.UpdateRegistryVars(cattleConfig, registry)
-
 	cattleConfig, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, client.RancherConfig.AdminToken, cattleConfig)
 	if err != nil {
 		logrus.Fatalf("Failed to replace admin token: %v", err)


### PR DESCRIPTION
This PR updates the airgap test suite to ensure all tests verify and enforce the usage of the cluster-level registry, improving consistency and compliance with deployment expectations.