### PR TITLE
Fix incorrect CIDR definitions in IPv6 and dual-stack custom cluster tests

### DIFF
--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -200,6 +200,8 @@ jobs:
               awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
               clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
+              enablePrimaryIPv6: true
+              httpProtocolIPv6: "enabled"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -555,6 +557,8 @@ jobs:
               awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
               clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
+              enablePrimaryIPv6: true
+              httpProtocolIPv6: "enabled"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"

--- a/validation/provisioning/ipv6/k3s_custom_test.go
+++ b/validation/provisioning/ipv6/k3s_custom_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
@@ -65,9 +66,11 @@ func TestCustomK3SIPv6(t *testing.T) {
 
 	nodeRolesStandard := []tfpConfig.Nodepool{{Quantity: 3, Etcd: true}, {Quantity: 2, Controlplane: true}, {Quantity: 3, Worker: true}}
 
-	_, terraform, _, _ := tfpConfig.LoadTFPConfigs(r.cattleConfig)
-	cidrCluster := terraform.AWSConfig.ClusterCIDR
-	cidrService := terraform.AWSConfig.ServiceCIDR
+	clusterConfig := new(clusters.ClusterConfig)
+	operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
+
+	cidrCluster := clusterConfig.Networking.ClusterCIDR
+	cidrService := clusterConfig.Networking.ServiceCIDR
 
 	tests := []struct {
 		name            string

--- a/validation/provisioning/ipv6/rke2_custom_test.go
+++ b/validation/provisioning/ipv6/rke2_custom_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
@@ -65,9 +66,11 @@ func TestCustomRKE2IPv6(t *testing.T) {
 
 	nodeRolesStandard := []tfpConfig.Nodepool{{Quantity: 3, Etcd: true}, {Quantity: 2, Controlplane: true}, {Quantity: 3, Worker: true}}
 
-	_, terraform, _, _ := tfpConfig.LoadTFPConfigs(r.cattleConfig)
-	cidrCluster := terraform.AWSConfig.ClusterCIDR
-	cidrService := terraform.AWSConfig.ServiceCIDR
+	clusterConfig := new(clusters.ClusterConfig)
+	operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
+
+	cidrCluster := clusterConfig.Networking.ClusterCIDR
+	cidrService := clusterConfig.Networking.ServiceCIDR
 
 	tests := []struct {
 		name            string


### PR DESCRIPTION
This pull request corrects the CIDR definitions used in IPv6 and dual-stack custom cluster tests. The changes ensure that the test configurations use accurate network CIDRs, improving test reliability for these cluster scenarios.