### PR TITLE
Revert IPv6 custom cluster provisioning to not use tfp-automation

### DIFF
--- a/validation/provisioning/ipv6/k3s_custom_test.go
+++ b/validation/provisioning/ipv6/k3s_custom_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/rancher/shepherd/clients/ec2"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
@@ -14,13 +15,11 @@ import (
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
-	tfpConfig "github.com/rancher/tfp-automation/config"
-	"github.com/rancher/tfp-automation/framework/cleanup"
-	tfpCustom "github.com/rancher/tfp-automation/tests/infrastructure/downstream/custom"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -54,6 +53,9 @@ func customK3SIPv6Setup(t *testing.T) customK3SIPv6Test {
 	err = logging.SetLogger(loggingConfig)
 	require.NoError(t, err)
 
+	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.K3S, r.cattleConfig)
+	require.NoError(t, err)
+
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	require.NoError(t, err)
 
@@ -64,23 +66,28 @@ func TestCustomK3SIPv6(t *testing.T) {
 	t.Parallel()
 	r := customK3SIPv6Setup(t)
 
-	nodeRolesStandard := []tfpConfig.Nodepool{{Quantity: 3, Etcd: true}, {Quantity: 2, Controlplane: true}, {Quantity: 3, Worker: true}}
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
 
 	clusterConfig := new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
 
-	cidrCluster := clusterConfig.Networking.ClusterCIDR
-	cidrService := clusterConfig.Networking.ServiceCIDR
+	cidrStackPreference := &provisioninginput.Networking{
+		ClusterCIDR:     clusterConfig.Networking.ClusterCIDR,
+		ServiceCIDR:     clusterConfig.Networking.ServiceCIDR,
+		StackPreference: "ipv6",
+	}
 
 	tests := []struct {
-		name            string
-		client          *rancher.Client
-		nodePools       []tfpConfig.Nodepool
-		clusterCIDR     string
-		serviceCIDR     string
-		stackPreference string
+		name         string
+		client       *rancher.Client
+		machinePools []provisioninginput.MachinePools
+		networking   *provisioninginput.Networking
 	}{
-		{"K3S_IPv6_Custom_CIDR_Stack_Preference", r.standardUserClient, nodeRolesStandard, cidrCluster, cidrService, "ipv6"},
+		{"K3S_IPv6_Custom_CIDR_Stack_Preference", r.standardUserClient, nodeRolesStandard, cidrStackPreference},
 	}
 
 	for _, tt := range tests {
@@ -89,24 +96,32 @@ func TestCustomK3SIPv6(t *testing.T) {
 			r.session.Cleanup()
 		})
 
+		clusterConfig := new(clusters.ClusterConfig)
+		operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
+
+		clusterConfig.IPv6Cluster = true
+		clusterConfig.MachinePools = tt.machinePools
+		clusterConfig.Networking = tt.networking
+
+		for i := range clusterConfig.MachinePools {
+			clusterConfig.MachinePools[i].SpecifyCustomPublicIP = true
+			clusterConfig.MachinePools[i].SpecifyCustomPrivateIP = true
+		}
+
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			rancherConfig, terraformConfig, terratestConfig, _ := tfpConfig.LoadTFPConfigs(r.cattleConfig)
-			terratestConfig.Nodepools = tt.nodePools
-			terraformConfig.AWSConfig.ClusterCIDR = tt.clusterCIDR
-			terraformConfig.AWSConfig.ServiceCIDR = tt.serviceCIDR
-			if terraformConfig.AWSConfig.Networking != nil {
-				terraformConfig.AWSConfig.Networking.StackPreference = tt.stackPreference
-			}
+			externalNodeProvider := provisioning.ExternalNodeProviderSetup(clusterConfig.NodeProvider)
 
-			logrus.Info("Provisioning custom cluster")
-			nestedRancherModuleDir, perTestTerraformOptions, _, cluster := tfpCustom.CreateCustomCluster(t, tt.client, rancherConfig, terraformConfig, terratestConfig, defaults.K3S, "validation/provisioning/ipv6", false)
-			defer os.RemoveAll(nestedRancherModuleDir)
-			defer cleanup.Cleanup(t, perTestTerraformOptions, nestedRancherModuleDir)
+			awsEC2Configs := new(ec2.AWSEC2Configs)
+			operations.LoadObjectFromMap(ec2.ConfigurationFileKey, r.cattleConfig, awsEC2Configs)
+
+			logrus.Info("Provisioning cluster")
+			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			err := provisioning.VerifyClusterReady(r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)

--- a/validation/provisioning/ipv6/rke2_custom_test.go
+++ b/validation/provisioning/ipv6/rke2_custom_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/rancher/shepherd/clients/ec2"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
@@ -14,13 +15,11 @@ import (
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/logging"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/qase"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
-	tfpConfig "github.com/rancher/tfp-automation/config"
-	"github.com/rancher/tfp-automation/framework/cleanup"
-	tfpCustom "github.com/rancher/tfp-automation/tests/infrastructure/downstream/custom"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -54,6 +53,9 @@ func customRKE2IPv6Setup(t *testing.T) customRKE2IPv6Test {
 	err = logging.SetLogger(loggingConfig)
 	require.NoError(t, err)
 
+	r.cattleConfig, err = defaults.SetK8sDefault(r.client, defaults.RKE2, r.cattleConfig)
+	require.NoError(t, err)
+
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	require.NoError(t, err)
 
@@ -64,23 +66,28 @@ func TestCustomRKE2IPv6(t *testing.T) {
 	t.Parallel()
 	r := customRKE2IPv6Setup(t)
 
-	nodeRolesStandard := []tfpConfig.Nodepool{{Quantity: 3, Etcd: true}, {Quantity: 2, Controlplane: true}, {Quantity: 3, Worker: true}}
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
 
 	clusterConfig := new(clusters.ClusterConfig)
 	operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
 
-	cidrCluster := clusterConfig.Networking.ClusterCIDR
-	cidrService := clusterConfig.Networking.ServiceCIDR
+	cidrStackPreference := &provisioninginput.Networking{
+		ClusterCIDR:     clusterConfig.Networking.ClusterCIDR,
+		ServiceCIDR:     clusterConfig.Networking.ServiceCIDR,
+		StackPreference: "ipv6",
+	}
 
 	tests := []struct {
-		name            string
-		client          *rancher.Client
-		nodePools       []tfpConfig.Nodepool
-		clusterCIDR     string
-		serviceCIDR     string
-		stackPreference string
+		name         string
+		client       *rancher.Client
+		machinePools []provisioninginput.MachinePools
+		networking   *provisioninginput.Networking
 	}{
-		{"RKE2_IPv6_Custom_CIDR_Stack_Preference", r.standardUserClient, nodeRolesStandard, cidrCluster, cidrService, "ipv6"},
+		{"RKE2_IPv6_Custom_CIDR_Stack_Preference", r.standardUserClient, nodeRolesStandard, cidrStackPreference},
 	}
 
 	for _, tt := range tests {
@@ -89,24 +96,32 @@ func TestCustomRKE2IPv6(t *testing.T) {
 			r.session.Cleanup()
 		})
 
+		clusterConfig := new(clusters.ClusterConfig)
+		operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
+
+		clusterConfig.IPv6Cluster = true
+		clusterConfig.MachinePools = tt.machinePools
+		clusterConfig.Networking = tt.networking
+
+		for i := range clusterConfig.MachinePools {
+			clusterConfig.MachinePools[i].SpecifyCustomPublicIP = true
+			clusterConfig.MachinePools[i].SpecifyCustomPrivateIP = true
+		}
+
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			rancherConfig, terraformConfig, terratestConfig, _ := tfpConfig.LoadTFPConfigs(r.cattleConfig)
-			terratestConfig.Nodepools = tt.nodePools
-			terraformConfig.AWSConfig.ClusterCIDR = tt.clusterCIDR
-			terraformConfig.AWSConfig.ServiceCIDR = tt.serviceCIDR
-			if terraformConfig.AWSConfig.Networking != nil {
-				terraformConfig.AWSConfig.Networking.StackPreference = tt.stackPreference
-			}
+			externalNodeProvider := provisioning.ExternalNodeProviderSetup(clusterConfig.NodeProvider)
 
-			logrus.Info("Provisioning custom cluster")
-			nestedRancherModuleDir, perTestTerraformOptions, _, cluster := tfpCustom.CreateCustomCluster(t, tt.client, rancherConfig, terraformConfig, terratestConfig, defaults.RKE2, "validation/provisioning/ipv6", false)
-			defer os.RemoveAll(nestedRancherModuleDir)
-			defer cleanup.Cleanup(t, perTestTerraformOptions, nestedRancherModuleDir)
+			awsEC2Configs := new(ec2.AWSEC2Configs)
+			operations.LoadObjectFromMap(ec2.ConfigurationFileKey, r.cattleConfig, awsEC2Configs)
+
+			logrus.Info("Provisioning cluster")
+			cluster, err := provisioning.CreateProvisioningCustomCluster(tt.client, &externalNodeProvider, clusterConfig, awsEC2Configs)
+			require.NoError(t, err)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			err := provisioning.VerifyClusterReady(r.client, cluster)
+			err = provisioning.VerifyClusterReady(r.client, cluster)
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)


### PR DESCRIPTION
This pull request reverts a previous change that modified the IPv6 custom cluster provisioning process to no longer use tfp-automation. By reverting, the provisioning workflow will once again utilize tfp-automation for IPv6 custom clusters as before.