### PR TITLE
Add encryption key rotation test suite for RKE2 and K3s

### DIFF
--- a/.github/actions/run-hostbusters-test-suites/action.yaml
+++ b/.github/actions/run-hostbusters-test-suites/action.yaml
@@ -88,6 +88,36 @@ runs:
             fi
 
             gotestsum --format standard-verbose \
+              --packages=github.com/rancher/tests/validation/encryptionkeyrotation/rke2 \
+              --junitfile results.xml \
+              --jsonfile results_rke2_encryption_key_rotation.json \
+              -- -timeout=5h -tags=${{ inputs.tags }} -v
+
+            rke2_encryption_key_rotation_exit=$?
+            echo "rke2_encryption_key_rotation_exit=$rke2_encryption_key_rotation_exit" >> "$GITHUB_ENV"
+            cp results_rke2_encryption_key_rotation.json results.json
+
+            if [[ "${{ inputs.reporting }}" == "true" ]]; then
+              ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
+              ./validation/reporter
+            fi
+
+            gotestsum --format standard-verbose \
+              --packages=github.com/rancher/tests/validation/encryptionkeyrotation/k3s \
+              --junitfile results.xml \
+              --jsonfile results_k3s_encryption_key_rotation.json \
+              -- -timeout=5h -tags=${{ inputs.tags }} -v
+
+            k3s_encryption_key_rotation_exit=$?
+            echo "k3s_encryption_key_rotation_exit=$k3s_encryption_key_rotation_exit" >> "$GITHUB_ENV"
+            cp results_k3s_encryption_key_rotation.json results.json
+
+            if [[ "${{ inputs.reporting }}" == "true" ]]; then
+              ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
+              ./validation/reporter
+            fi
+
+            gotestsum --format standard-verbose \
               --packages=github.com/rancher/tests/validation/nodescaling/rke2 \
               --junitfile results.xml \
               --jsonfile results_rke2_node_scale.json \
@@ -189,6 +219,8 @@ runs:
           [k3s_cert_exit]="K3S Cert Rotation:results_k3s_cert.json"
           [rke2_delete_exit]="Delete RKE2 Cluster:results_rke2_delete.json"
           [k3s_delete_exit]="Delete K3S Cluster:results_k3s_delete.json"
+          [rke2_encryption_key_rotation_exit]="RKE2 Encryption Key Rotation:results_rke2_encryption_key_rotation.json"
+          [k3s_encryption_key_rotation_exit]="K3S Encryption Key Rotation:results_k3s_encryption_key_rotation.json"
           [rke2_node_scale_exit]="RKE2 Node Scaling:results_rke2_node_scale.json"
           [k3s_node_scale_exit]="K3S Node Scaling:results_k3s_node_scale.json"
           [k3s_snapshot_exit]="K3S Snapshot Restore:results_k3s_snapshot.json"

--- a/actions/encryptionkeyrotation/creates.go
+++ b/actions/encryptionkeyrotation/creates.go
@@ -1,0 +1,82 @@
+package encryptionkeyrotation
+
+import (
+	"context"
+	"time"
+
+	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/shepherd/clients/rancher"
+	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/stevestates"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	"github.com/sirupsen/logrus"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+// EnableSecretsEncryption is a helper function to enable secrets encryption on an RKE2 or K3s cluster.
+func EnableSecretsEncryption(client *rancher.Client, clusterName string) error {
+	id, err := clusters.GetV1ProvisioningClusterByName(client, clusterName)
+	if err != nil {
+		return err
+	}
+
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(id)
+	if err != nil {
+		return err
+	}
+
+	clusterSpec := &apiv1.ClusterSpec{}
+	err = v1.ConvertToK8sType(cluster.Spec, clusterSpec)
+	if err != nil {
+		return err
+	}
+
+	updatedCluster := *cluster
+
+	secretEncryption := clusterSpec.RKEConfig.MachineGlobalConfig.Data["secrets-encryption"]
+	isEncryptionDisabled := secretEncryption == nil || secretEncryption == false
+
+	if isEncryptionDisabled {
+		clusterSpec.RKEConfig.MachineGlobalConfig.Data["secrets-encryption"] = true
+		updatedCluster.Spec = *clusterSpec
+
+		cluster, err = client.Steve.SteveType(clusters.ProvisioningSteveResourceType).Update(cluster, updatedCluster)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), defaults.FifteenMinuteTimeout)
+		defer cancel()
+
+		err = kwait.PollUntilContextTimeout(ctx, 10*time.Second, defaults.ThirtyMinuteTimeout, false, func(context.Context) (done bool, err error) {
+			cluster, err = client.Steve.SteveType(stevetypes.Provisioning).ByID(cluster.ID)
+			if err != nil {
+				return false, nil
+			}
+
+			clusterStatus := &provv1.ClusterStatus{}
+
+			err = steveV1.ConvertToK8sType(cluster.Status, clusterStatus)
+			if err != nil {
+				return false, nil
+			}
+
+			if !clusterStatus.Ready || cluster.State.Name != stevestates.Active || cluster.State.Error == true {
+				return false, nil
+			}
+
+			return true, nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	logrus.Infof("Secrets encryption enabled on cluster %s", clusterName)
+
+	return nil
+}

--- a/actions/encryptionkeyrotation/rotation.go
+++ b/actions/encryptionkeyrotation/rotation.go
@@ -1,0 +1,93 @@
+package encryptionkeyrotation
+
+import (
+	"context"
+	"time"
+
+	apisV1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	apiv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
+	"github.com/rancher/shepherd/clients/rancher"
+	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/stevestates"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+// RotateEncryptionKey is a helper function to rotate the encryption key on an RKE2 or K3s cluster.
+func RotateEncryptionKey(client *rancher.Client, clusterName string) error {
+	id, err := clusters.GetV1ProvisioningClusterByName(client, clusterName)
+	if err != nil {
+		return err
+	}
+
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(id)
+	if err != nil {
+		return err
+	}
+
+	clusterSpec := &apiv1.ClusterSpec{}
+	err = v1.ConvertToK8sType(cluster.Spec, clusterSpec)
+	if err != nil {
+		return err
+	}
+
+	updatedCluster := *cluster
+
+	if clusterSpec.RKEConfig != nil {
+		if clusterSpec.RKEConfig.RotateEncryptionKeys == nil {
+			clusterSpec.RKEConfig.RotateEncryptionKeys = &rkev1.RotateEncryptionKeys{
+				Generation: 1,
+			}
+		} else {
+			clusterSpec.RKEConfig.RotateEncryptionKeys = &rkev1.RotateEncryptionKeys{
+				Generation: clusterSpec.RKEConfig.RotateEncryptionKeys.Generation + 1,
+			}
+		}
+	} else {
+		clusterSpec.RKEConfig = &apisV1.RKEConfig{
+			RotateEncryptionKeys: &rkev1.RotateEncryptionKeys{
+				Generation: 1,
+			},
+		}
+	}
+
+	updatedCluster.Spec = *clusterSpec
+
+	_, err = client.Steve.SteveType(stevetypes.Provisioning).Update(cluster, updatedCluster)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaults.FifteenMinuteTimeout)
+	defer cancel()
+
+	err = kwait.PollUntilContextTimeout(ctx, 10*time.Second, defaults.ThirtyMinuteTimeout, false, func(context.Context) (done bool, err error) {
+		cluster, err = client.Steve.SteveType(stevetypes.Provisioning).ByID(cluster.ID)
+		if err != nil {
+			return false, nil
+		}
+
+		clusterStatus := &provv1.ClusterStatus{}
+
+		err = steveV1.ConvertToK8sType(cluster.Status, clusterStatus)
+		if err != nil {
+			return false, nil
+		}
+
+		if !clusterStatus.Ready || cluster.State.Name != stevestates.Active || cluster.State.Error == true {
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return err
+}

--- a/actions/encryptionkeyrotation/verify.go
+++ b/actions/encryptionkeyrotation/verify.go
@@ -1,0 +1,86 @@
+package encryptionkeyrotation
+
+import (
+	"fmt"
+	"strings"
+
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	"github.com/rancher/shepherd/extensions/sshkeys"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	controlPlane              = "control-plane"
+	nodeRoleControlPlaneLabel = "node-role.kubernetes.io/control-plane"
+)
+
+// VerifyEncryptionKeyRotation validates that encryption key rotation completed successfully on a cluster
+func VerifyEncryptionKeyRotation(client *rancher.Client, clusterStatus *provv1.ClusterStatus, clusterType string) error {
+	steveClient, err := client.Steve.ProxyDownstream(clusterStatus.ClusterName)
+	if err != nil {
+		return fmt.Errorf("failed to create downstream client for cluster %s: %w", clusterStatus.ClusterName, err)
+	}
+
+	nodeList, err := steveClient.SteveType(stevetypes.Node).List(nil)
+	if err != nil {
+		return fmt.Errorf("failed to list nodes for cluster %s: %w", clusterStatus.ClusterName, err)
+	}
+
+	if len(nodeList.Data) == 0 {
+		return fmt.Errorf("no nodes found in cluster %s", clusterStatus.ClusterName)
+	}
+
+	controlPlaneCount := 0
+
+	for _, machine := range nodeList.Data {
+		if !isControlPlaneMachine(machine.Labels) {
+			continue
+		}
+
+		controlPlaneCount++
+		logrus.Debugf("Selected control-plane node: %s", machine.Name)
+
+		sshNode, err := sshkeys.GetSSHNodeFromMachine(client, &machine)
+		if err != nil {
+			return fmt.Errorf("failed to get ssh node for machine %s: %w", machine.Name, err)
+		}
+
+		logrus.Debugf("Connecting to control plane node: %s", machine.Name)
+
+		output, err := sshNode.ExecuteCommand(fmt.Sprintf("sudo %s secrets-encrypt status", clusterType))
+		if err != nil {
+			return fmt.Errorf("failed to run secrets-encrypt status command on node %s: %w, output: %s", machine.Name, err, output)
+		}
+
+		statusOutput := output
+		logrus.Debugf("Encryption key rotation status output:\n%s", statusOutput)
+
+		if strings.Contains(statusOutput, "Current Rotation Stage") && strings.Contains(statusOutput, "rotate") && !strings.Contains(statusOutput, "reencrypt_finished") {
+			return fmt.Errorf("encryption key rotation is not finished yet: %s", statusOutput)
+		}
+
+		if !strings.Contains(statusOutput, "reencrypt_finished") {
+			return fmt.Errorf("expected 'reencrypt_finished' in output, but got: %s", statusOutput)
+		}
+
+		if !strings.Contains(statusOutput, "All hashes match") {
+			return fmt.Errorf("expected 'All hashes match' in output, but got: %s", statusOutput)
+		}
+	}
+
+	if controlPlaneCount == 0 {
+		return fmt.Errorf("no nodes found with control-plane role in cluster %s", clusterStatus.ClusterName)
+	}
+
+	return nil
+}
+
+func isControlPlaneMachine(labels map[string]string) bool {
+	if labels == nil {
+		return false
+	}
+
+	return strings.EqualFold(labels[nodeRoleControlPlaneLabel], "true")
+}

--- a/validation/encryptionkeyrotation/defaults/defaults.yaml
+++ b/validation/encryptionkeyrotation/defaults/defaults.yaml
@@ -1,0 +1,55 @@
+#Required for all tests
+rancher:
+  host: "<required>"
+  adminToken: "<required>"
+  insecure: true
+  cleanup: true
+
+#Required for all tests except template
+clusterConfig:
+  machinePools:
+  - machinePoolConfig:
+      etcd: true
+      controlplane: false
+      worker: false
+      quantity: 1
+  - machinePoolConfig:
+      etcd: false
+      controlplane: true
+      worker: false
+      quantity: 1
+  - machinePoolConfig:
+      etcd: false
+      controlplane: false
+      worker: true
+      quantity: 1
+  kubernetesVersion: ""
+  cni: "calico"
+  provider: "aws"
+  nodeProvider: "ec2"
+
+#Required for all tests
+awsCredentials:
+  secretKey: "<required>"
+  accessKey: "<required>"
+  defaultRegion: "us-east-2" 
+
+#Required for tests that utilize node driver clusters
+awsMachineConfigs:
+  region: "us-east-2"
+  awsMachineConfig:
+  - roles: ["etcd","controlplane","worker"]
+    ami: "<required>"
+    instanceType: "t3a.medium"
+    sshUser: "<required>"
+    vpcId: "<required>"
+    retries: "5"
+  - roles: ["windows"]
+    ami: "<required>"
+    instanceType: "t2.2xlarge"
+    sshUser: "<required>"
+    vpcId: "<required>"
+    volumeType: "<required>"
+    zone: "a"
+    retries: "5"
+    rootSize: "100"

--- a/validation/encryptionkeyrotation/k3s/README.md
+++ b/validation/encryptionkeyrotation/k3s/README.md
@@ -1,0 +1,65 @@
+# K3s Encryption Key Rotation
+
+## Table of Contents
+1. [Prerequisites](../README.md)
+2. [Tests Cases](#Test-Cases)
+3. [Configurations](#Configurations)
+4. [Configuration Defaults](#defaults)
+5. [Logging Levels](#Logging)
+6. [Back to general certificates](../README.md)
+
+## Test Cases
+All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
+
+### Encryption Key Rotation Tests
+
+#### Description:
+The encryption key rotation test verifies that a cluster can successfully perform encryption key rotation
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config) (with IPv6 settings)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `K3S_Encryption_Key_Rotation`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/encryptionkeyrotation/k3s --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestEncryptionKeyRotationTestSuite/TestEncryptionKeyRotation$ -timeout=2h -v`
+
+## Configurations
+
+### Existing cluster:
+```yaml
+rancher:
+  host: <rancher-fqdn>
+  adminToken: <rancher-token>
+  clusterName: "<existing cluster name>"
+  cleanup: true
+  insecure: true
+```
+
+NOTE: If you are providing an existing cluster, it is assumed that secrets encryption is enabled on the cluster; this is a K3s pre-requiste for encryption key rotation.
+
+### Provisioning cluster
+This test will create a cluster if one is not provided, see the needed cluster configuration [k3s provisioning](../../provisioning/k3s/README.md)
+
+## Defaults
+This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to: 
+1. Reduce the number of fields the user needs to provide in the cattle_config file. 
+2. Reduce the amount of yaml data that needs to be stored in our pipelines.
+3. Make it easier to run tests
+
+Any data the user provides will override these defaults which are stored here: [defaults](defaults/defaults.yaml). 
+
+## Logging
+This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 
+
+```yaml
+logging:
+   level: "trace" #trace debug, info, warning, error
+```
+
+## Additional
+1. If the tests passes immediately without warning, try adding the `-count=1` or run `go clean -cache`. This will avoid previous results from interfering with the new test run.
+2. All of the tests utilize parallelism when running for more finite control of how things are run in parallel use the -p and -parallel.

--- a/validation/encryptionkeyrotation/k3s/encryption_key_rotation_test.go
+++ b/validation/encryptionkeyrotation/k3s/encryption_key_rotation_test.go
@@ -1,0 +1,137 @@
+//go:build validation || recurring || proxy || ipv6 || dualstack
+
+package encryptionkeyrotation
+
+import (
+	"os"
+	"testing"
+
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/shepherd/clients/rancher"
+	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/encryptionkeyrotation"
+	"github.com/rancher/tests/actions/logging"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
+	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type EncryptionKeyRotationTestSuite struct {
+	suite.Suite
+	session      *session.Session
+	client       *rancher.Client
+	cattleConfig map[string]any
+	cluster      *v1.SteveAPIObject
+}
+
+func (e *EncryptionKeyRotationTestSuite) TearDownSuite() {
+	e.session.Cleanup()
+}
+
+func (e *EncryptionKeyRotationTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	e.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(e.T(), err)
+
+	e.client = client
+
+	standardUserClient, _, _, err := standard.CreateStandardUser(e.client)
+	require.NoError(e.T(), err)
+
+	e.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
+
+	e.cattleConfig, err = defaults.LoadPackageDefaults(e.cattleConfig, "")
+	require.NoError(e.T(), err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, e.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(e.T(), err)
+
+	clusterConfig := new(clusters.ClusterConfig)
+	operations.LoadObjectFromMap(defaults.ClusterConfigKey, e.cattleConfig, clusterConfig)
+
+	rancherConfig := new(rancher.Config)
+	operations.LoadObjectFromMap(defaults.RancherConfigKey, e.cattleConfig, rancherConfig)
+
+	if rancherConfig.ClusterName == "" {
+		provider := provisioning.CreateProvider(clusterConfig.Provider)
+		machineConfigSpec := provider.LoadMachineConfigFunc(e.cattleConfig)
+
+		logrus.Info("Provisioning K3S cluster")
+		e.cluster, err = resources.ProvisionRKE2K3SCluster(e.T(), standardUserClient, defaults.K3S, provider, *clusterConfig, machineConfigSpec, nil, true, false)
+		require.NoError(e.T(), err)
+	} else {
+		logrus.Infof("Using existing cluster %s", rancherConfig.ClusterName)
+		e.cluster, err = e.client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + e.client.RancherConfig.ClusterName)
+		require.NoError(e.T(), err)
+	}
+}
+
+func (e *EncryptionKeyRotationTestSuite) TestEncryptionKeyRotation() {
+	tests := []struct {
+		name    string
+		cluster *v1.SteveAPIObject
+	}{
+		{"K3S_Encryption_Key_Rotation", e.cluster},
+	}
+
+	for _, tt := range tests {
+		var err error
+		e.Run(tt.name, func() {
+			logrus.Infof("Enabling secrets encryption on cluster (%s)", tt.cluster.Name)
+			err = encryptionkeyrotation.EnableSecretsEncryption(e.client, tt.cluster.Name)
+			require.NoError(e.T(), err)
+
+			logrus.Infof("Performing encryption key rotation on cluster (%s)", tt.cluster.Name)
+			err = encryptionkeyrotation.RotateEncryptionKey(e.client, tt.cluster.Name)
+			require.NoError(e.T(), err)
+
+			clusterStatus := &provv1.ClusterStatus{}
+			err = steveV1.ConvertToK8sType(tt.cluster.Status, clusterStatus)
+			require.NoError(e.T(), err)
+
+			logrus.Infof("Verifying encryption key rotated on cluster (%s)", tt.cluster.Name)
+			err = encryptionkeyrotation.VerifyEncryptionKeyRotation(e.client, clusterStatus, defaults.K3S)
+			require.NoError(e.T(), err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(e.client, tt.cluster)
+			require.NoError(e.T(), err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(e.client, tt.cluster)
+			require.NoError(e.T(), err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(e.client, tt.cluster)
+			require.NoError(e.T(), err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(e.client, e.cattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}
+
+func TestEncryptionKeyRotationTestSuite(t *testing.T) {
+	suite.Run(t, new(EncryptionKeyRotationTestSuite))
+}

--- a/validation/encryptionkeyrotation/k3s/schemas/hostbusters_schemas.yaml
+++ b/validation/encryptionkeyrotation/k3s/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,23 @@
+- suite: Go Automation/EncryptionKeyRotation/k3s
+  projects: [RRT, RM]
+  cases:
+  - description: Rotates the clusters encryption keys
+    title: K3S_Encryption_Key_Rotation
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Rotate the clusters encryption keys
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/encryptionkeyrotation/rke2/README.md
+++ b/validation/encryptionkeyrotation/rke2/README.md
@@ -1,0 +1,63 @@
+# RKE2 Encryption Key Rotation
+
+## Table of Contents
+1. [Prerequisites](../README.md)
+2. [Tests Cases](#Test-Cases)
+3. [Configurations](#Configurations)
+4. [Configuration Defaults](#defaults)
+5. [Logging Levels](#Logging)
+6. [Back to general certificates](../README.md)
+
+## Test Cases
+All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
+
+### Encryption Key Rotation Tests
+
+#### Description:
+The encryption key rotation test verifies that a cluster can successfully perform encryption key rotation
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config) (with IPv6 settings)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `RKE2_Encryption_Key_Rotation`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/encryptionkeyrotation/rke2 --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestEncryptionKeyRotationTestSuite/TestEncryptionKeyRotation$ -timeout=2h -v`
+
+## Configurations
+
+### Existing cluster:
+```yaml
+rancher:
+  host: <rancher-fqdn>
+  adminToken: <rancher-token>
+  clusterName: "<existing cluster name>"
+  cleanup: true
+  insecure: true
+```
+
+### Provisioning cluster
+This test will create a cluster if one is not provided, see the needed cluster configuration [rke2 provisioning](../../provisioning/rke2/README.md)
+
+## Defaults
+This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to: 
+1. Reduce the number of fields the user needs to provide in the cattle_config file. 
+2. Reduce the amount of yaml data that needs to be stored in our pipelines.
+3. Make it easier to run tests
+
+Any data the user provides will override these defaults which are stored here: [defaults](defaults/defaults.yaml). 
+
+## Logging
+This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 
+
+```yaml
+logging:
+   level: "trace" #trace debug, info, warning, error
+```
+
+## Additional
+1. If the tests passes immediately without warning, try adding the `-count=1` or run `go clean -cache`. This will avoid previous results from interfering with the new test run.
+2. All of the tests utilize parallelism when running for more finite control of how things are run in parallel use the -p and -parallel.

--- a/validation/encryptionkeyrotation/rke2/encryption_key_rotation_test.go
+++ b/validation/encryptionkeyrotation/rke2/encryption_key_rotation_test.go
@@ -1,0 +1,133 @@
+//go:build validation || recurring || proxy || ipv6 || dualstack
+
+package encryptionkeyrotation
+
+import (
+	"os"
+	"testing"
+
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/shepherd/clients/rancher"
+	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/encryptionkeyrotation"
+	"github.com/rancher/tests/actions/logging"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
+	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type EncryptionKeyRotationTestSuite struct {
+	suite.Suite
+	session      *session.Session
+	client       *rancher.Client
+	cattleConfig map[string]any
+	cluster      *v1.SteveAPIObject
+}
+
+func (e *EncryptionKeyRotationTestSuite) TearDownSuite() {
+	e.session.Cleanup()
+}
+
+func (e *EncryptionKeyRotationTestSuite) SetupSuite() {
+	testSession := session.NewSession()
+	e.session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(e.T(), err)
+
+	e.client = client
+
+	standardUserClient, _, _, err := standard.CreateStandardUser(e.client)
+	require.NoError(e.T(), err)
+
+	e.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
+
+	e.cattleConfig, err = defaults.LoadPackageDefaults(e.cattleConfig, "")
+	require.NoError(e.T(), err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, e.cattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(e.T(), err)
+
+	clusterConfig := new(clusters.ClusterConfig)
+	operations.LoadObjectFromMap(defaults.ClusterConfigKey, e.cattleConfig, clusterConfig)
+
+	rancherConfig := new(rancher.Config)
+	operations.LoadObjectFromMap(defaults.RancherConfigKey, e.cattleConfig, rancherConfig)
+
+	if rancherConfig.ClusterName == "" {
+		provider := provisioning.CreateProvider(clusterConfig.Provider)
+		machineConfigSpec := provider.LoadMachineConfigFunc(e.cattleConfig)
+
+		logrus.Info("Provisioning RKE2 cluster")
+		e.cluster, err = resources.ProvisionRKE2K3SCluster(e.T(), standardUserClient, defaults.RKE2, provider, *clusterConfig, machineConfigSpec, nil, true, false)
+		require.NoError(e.T(), err)
+	} else {
+		logrus.Infof("Using existing cluster %s", rancherConfig.ClusterName)
+		e.cluster, err = e.client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + e.client.RancherConfig.ClusterName)
+		require.NoError(e.T(), err)
+	}
+}
+
+func (e *EncryptionKeyRotationTestSuite) TestEncryptionKeyRotation() {
+	tests := []struct {
+		name    string
+		cluster *v1.SteveAPIObject
+	}{
+		{"RKE2_Encryption_Key_Rotation", e.cluster},
+	}
+
+	for _, tt := range tests {
+		var err error
+		e.Run(tt.name, func() {
+			logrus.Infof("Performing encryption key rotation on cluster (%s)", tt.cluster.Name)
+			err = encryptionkeyrotation.RotateEncryptionKey(e.client, tt.cluster.Name)
+			require.NoError(e.T(), err)
+
+			clusterStatus := &provv1.ClusterStatus{}
+			err = steveV1.ConvertToK8sType(tt.cluster.Status, clusterStatus)
+			require.NoError(e.T(), err)
+
+			logrus.Infof("Verifying encryption key rotated on cluster (%s)", tt.cluster.Name)
+			err = encryptionkeyrotation.VerifyEncryptionKeyRotation(e.client, clusterStatus, defaults.RKE2)
+			require.NoError(e.T(), err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(e.client, tt.cluster)
+			require.NoError(e.T(), err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(e.client, tt.cluster)
+			require.NoError(e.T(), err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(e.client, tt.cluster)
+			require.NoError(e.T(), err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(e.client, e.cattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}
+
+func TestEncryptionKeyRotationTestSuite(t *testing.T) {
+	suite.Run(t, new(EncryptionKeyRotationTestSuite))
+}

--- a/validation/encryptionkeyrotation/rke2/schemas/hostbusters_schemas.yaml
+++ b/validation/encryptionkeyrotation/rke2/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,23 @@
+- suite: Go Automation/EncryptionKeyRotation/rke2
+  projects: [RRT, RM]
+  cases:
+  - description: Rotates the clusters encryption keys
+    title: RKE2_Encryption_Key_Rotation
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Rotate the clusters encryption keys
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters


### PR DESCRIPTION
This pull request introduces a new test suite to verify encryption key rotation functionality in both RKE2 and K3s clusters. The tests help ensure that key rotation is performed correctly and securely as part of cluster operations.