### PR TITLE
bypass broken rancher2 provider signature via filesystem mirror

### DIFF
--- a/validation/Jenkinsfile.e2e
+++ b/validation/Jenkinsfile.e2e
@@ -541,10 +541,31 @@ insecure = true'''
 
         stage('Build Docker Images') {
             steps {
-                // rancher-infra-tools:latest — used by make.groovy / infra.* for all make targets
-                sh "docker build --no-cache --platform linux/amd64 -t rancher-infra-tools:latest -f ${env.TESTS_DIR}/validation/pipeline/Dockerfile.infra ."
-                // rancher-go-test:latest — used for qase binary build and admin-token playbook
-                sh "docker build --no-cache --platform linux/amd64 -t rancher-go-test:latest -f ${env.TESTS_DIR}/validation/pipeline/Dockerfile.airgap-go-tests ."
+                script {
+                    // rancher2 provider releases are signed with a key that does not match the
+                    // signing key published in the registry, so OpenTofu refuses them. Mirror the
+                    // exact version pinned by qa-infra-automation's lockfile into the image to
+                    // bypass signature verification (hash still checked in the Dockerfile).
+                    // Remove when upstream fixes provider signing.
+                    def rancher2Version = ''
+                    def lockfilePath = "${env.INFRA_DIR}/tofu/rancher/cluster/.terraform.lock.hcl"
+                    if (env.INFRA_DIR && fileExists(lockfilePath)) {
+                        rancher2Version = sh(
+                            script: "grep -A5 'rancher/rancher2' '${lockfilePath}' | grep -m1 version | sed -E 's/.*\"([^\"]+)\".*/\\1/'",
+                            returnStdout: true
+                        ).trim()
+                        if (rancher2Version) {
+                            echo "rancher2 provider ${rancher2Version} will be mirrored into rancher-go-test (signature bypass)"
+                        } else {
+                            echo 'WARNING: could not parse rancher2 version from lockfile; provider mirror will be empty'
+                        }
+                    }
+
+                    // rancher-infra-tools:latest — used by make.groovy / infra.* for all make targets
+                    sh "docker build --no-cache --platform linux/amd64 -t rancher-infra-tools:latest -f ${env.TESTS_DIR}/validation/pipeline/Dockerfile.infra ."
+                    // rancher-go-test:latest — used for qase binary build, admin-token playbook, and tofu
+                    sh "docker build --no-cache --platform linux/amd64 --build-arg RANCHER2_PROVIDER_VERSION='${rancher2Version}' -t rancher-go-test:latest -f ${env.TESTS_DIR}/validation/pipeline/Dockerfile.airgap-go-tests ."
+                }
             }
         }
 

--- a/validation/pipeline/Dockerfile.airgap-go-tests
+++ b/validation/pipeline/Dockerfile.airgap-go-tests
@@ -5,6 +5,11 @@ ARG TOFU_VERSION=1.10.7
 ARG GOTESTSUM_VERSION=v1.13.0
 ARG ANSIBLE_VERSION=12.3.0
 ARG AWSCLI_VERSION=1.44.44
+# Pinned version of rancher2 provider to mirror into the image. Required because
+# the provider's release artifacts are signed with a key that does not match the
+# signing key published in the registry, so OpenTofu refuses registry installs.
+# Passed from Jenkinsfile.e2e (read from qa-infra-automation's lockfile).
+ARG RANCHER2_PROVIDER_VERSION=
 
 FROM --platform=linux/amd64 golang:1.26-alpine3.22@sha256:457d8584db11412777c4196146b8060fdaabe0b0ba7b62c553d08e07d8c22bd3
 
@@ -12,6 +17,7 @@ ARG TOFU_VERSION
 ARG GOTESTSUM_VERSION
 ARG ANSIBLE_VERSION
 ARG AWSCLI_VERSION
+ARG RANCHER2_PROVIDER_VERSION
 
 # Install runtime dependencies
 RUN apk add --no-cache \
@@ -38,6 +44,30 @@ RUN curl -Lo /tmp/tofu_${TOFU_VERSION}_linux_amd64.tar.gz "https://github.com/op
     && tar -xzf /tmp/tofu_${TOFU_VERSION}_linux_amd64.tar.gz -C /usr/local/bin/ \
     && rm /tmp/tofu_${TOFU_VERSION}_linux_amd64.tar.gz /tmp/tofu_SHA256SUMS \
     && chmod +x /usr/local/bin/tofu
+
+# Temporary: mirror the rancher2 provider into the image to bypass its broken
+# release signature. The provider's artifacts are signed by a key that does not
+# match the signing key published in the registry ("authentication signature
+# from unknown issuer"), so OpenTofu refuses registry installs for it. Serving
+# the zip from a filesystem mirror skips signature verification entirely, while
+# the SHA-256 is still checked against the registry's published shasum below.
+# Remove this block when upstream fixes provider signing.
+# https://opentofu.org/docs/cli/plugins/signing/
+RUN if [ -n "${RANCHER2_PROVIDER_VERSION}" ]; then \
+      set -e; \
+      META=$(curl -fsSL "https://registry.opentofu.org/v1/providers/rancher/rancher2/${RANCHER2_PROVIDER_VERSION}/download/linux/amd64"); \
+      ZIP_URL=$(printf '%s' "$META" | python3 -c 'import sys,json;print(json.load(sys.stdin)["download_url"])'); \
+      SHA=$(printf '%s' "$META" | python3 -c 'import sys,json;print(json.load(sys.stdin)["shasum"])'); \
+      FNAME=$(printf '%s' "$META" | python3 -c 'import sys,json;print(json.load(sys.stdin)["filename"])'); \
+      MIRROR="/usr/local/share/terraform/mirror/registry.opentofu.org/rancher/rancher2/${RANCHER2_PROVIDER_VERSION}/linux_amd64"; \
+      mkdir -p "$MIRROR"; \
+      curl -fsSL "$ZIP_URL" -o "$MIRROR/$FNAME"; \
+      printf '%s  %s/%s\n' "$SHA" "$MIRROR" "$FNAME" | sha256sum -c -; \
+      printf 'provider_installation {\n  filesystem_mirror {\n    path = "/usr/local/share/terraform/mirror"\n  }\n  direct {\n    exclude = ["rancher/rancher2"]\n  }\n}\n' > /root/.terraformrc; \
+      echo "Mirrored rancher2 ${RANCHER2_PROVIDER_VERSION} ($SHA)"; \
+    else \
+      echo "RANCHER2_PROVIDER_VERSION not set; skipping provider mirror"; \
+    fi
 
 # Install gotestsum (pinned version for reproducible builds)
 ENV GOBIN=/usr/local/bin


### PR DESCRIPTION
The rancher2 provider's release artifacts are signed by a key that does not match the signing key published in the OpenTofu registry (e.g. v13.1.4 is signed by 4CCE5F287729F2DFDDE1045F2EEB0F9AD44A135C but the registry advertises 6D5B085066648C32), so `tofu init` fails with "authentication signature from unknown issuer" before any apply/destroy can run. This is an upstream release defect in rancher/terraform-provider-rancher2 and affects every checked version (7.0.0, 13.1.4, 13.5.0). Note OPENTOFU_ENFORCE_GPG_VALIDATION=false does NOT bypass this: when the registry returns a key, OpenTofu always enforces (len(Keys) > 0 short-circuit in package_authentication.go).

Serve the provider from a filesystem mirror instead. The mirror path skips signature verification entirely (NewSignatureAuthentication is only called from registry_client.go), while the zip's SHA-256 is still checked against the registry's published shasum at image build time, and .terraform.lock.hcl still pins h1:/zh: hashes at runtime.

- Dockerfile.airgap-go-tests: add RANCHER2_PROVIDER_VERSION ARG; when set, fetch registry metadata, download the zip, verify its sha256, drop it into /usr/local/share/terraform/mirror, and write /root/.terraformrc so tofu serves rancher2 from the mirror while everything else stays on `direct`.
- Jenkinsfile.e2e: read the rancher2 version pinned in qa-infra-automation/tofu/rancher/cluster/.terraform.lock.hcl (checked out in the prior stage) and pass it as --build-arg so the mirror stays version-correct rather than hard-pinned.

Only rancher2 is mirrored; hashicorp/random and others retain full signature verification. Remove both blocks when upstream fixes provider signing.