### PR TITLE
Add GetGlobalSettingsNamesForCluster action for RA replacement test

### DIFF
--- a/actions/kubeapi/settings/settings.go
+++ b/actions/kubeapi/settings/settings.go
@@ -1,0 +1,27 @@
+package settings
+
+import (
+	"github.com/rancher/shepherd/clients/rancher"
+	
+	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	extsettingsapi "github.com/rancher/shepherd/extensions/kubeapi/settings"
+)
+
+// GetGlobalSettingNamesForCluster lists global setting names using a cluster-scoped wrangler
+// context so non-admin users can read them via the downstream cluster proxy.
+func GetGlobalSettingNamesForCluster(client *rancher.Client, clusterID string) ([]string, error) {
+	settingsClient := client
+
+	if clusterID != extclusterapi.LocalCluster {
+		clusterContext, err := client.WranglerContext.DownStreamClusterWranglerContext(clusterID)
+		if err != nil {
+			return nil, err
+		}
+
+		scopedClient := *client
+		scopedClient.WranglerContext = clusterContext
+		settingsClient = &scopedClient
+	}
+
+	return extsettingsapi.GetGlobalSettingNames(settingsClient)
+}

--- a/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
+++ b/validation/rbac/globalroles/restrictedadmin_replacement_role_test.go
@@ -10,7 +10,6 @@ import (
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
 	extensionscluster "github.com/rancher/shepherd/extensions/clusters"
-	extsettingsapi "github.com/rancher/shepherd/extensions/kubeapi/settings"
 	extensionsettings "github.com/rancher/shepherd/extensions/settings"
 	password "github.com/rancher/shepherd/extensions/users/passwordgenerator"
 	"github.com/rancher/shepherd/pkg/config"
@@ -18,6 +17,7 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/kubeapi/settings"
 	"github.com/rancher/tests/actions/machinepools"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/provisioninginput"
@@ -122,9 +122,9 @@ func (ra *RestrictedAdminReplacementTestSuite) TestRestrictedAdminReplacementLis
 	createdRaReplacementRole, createdRaReplacementUser, createdRaReplacementUserClient := ra.createRestrictedAdminReplacementRoleAndUser(false)
 
 	log.Infof("Verifying user %s with role %s can list global settings", createdRaReplacementUser.Name, createdRaReplacementRole.Name)
-	raReplacementUserSettingsList, err := extsettingsapi.GetGlobalSettingNames(createdRaReplacementUserClient)
+	raReplacementUserSettingsList, err := settings.GetGlobalSettingNamesForCluster(createdRaReplacementUserClient, ra.cluster.ID)
 	require.NoError(ra.T(), err)
-	adminGlobalSettingsList, err := extsettingsapi.GetGlobalSettingNames(ra.client)
+	adminGlobalSettingsList, err := settings.GetGlobalSettingNamesForCluster(ra.client, ra.cluster.ID)
 	require.NoError(ra.T(), err)
 
 	require.Equal(ra.T(), adminGlobalSettingsList, raReplacementUserSettingsList)


### PR DESCRIPTION
The `TestRestrictedAdminReplacementListGlobalSettings` test was updated in https://github.com/rancher/tests/commit/71936e39782699f8bf1b8d08dac668e2c72e0ab4 to use Wrangler based shepherd extension to get the global settings. 

Previously the old helper listed settings through a cluster-scoped Wrangler context( the `/k8s/clusters/<id>` proxy), which the `restricted-admin-replacement` user can reach via it's inherited `cluster-owner` role.

The new Shepherd extension instead always uses the base Wrangler context (the Rancher management host `/apis/...)`, which the `restricted-admin-replacement` user isn't authorized against causing the test to fail with error: 
`failed to list settings:  (get settings.meta.k8s.io)`.

This PR adds an action that restores the cluster-scoped context and then delegates to the Shepherd extension.