### PR TITLE
Add support for importing proxy RKE2/K3s standalone clusters

### DIFF
--- a/.github/workflows/proxy-cluster-provisioning.yml
+++ b/.github/workflows/proxy-cluster-provisioning.yml
@@ -37,6 +37,7 @@ permissions:
 
 env:
   CLOUD_PROVIDER_VERSION: "6.34.0"
+  LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
 
 jobs:
   v2-15:
@@ -48,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: head
     env:
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
       HOSTNAME_PREFIX: "ghap-prov-215"
       REPORTING_ENABLED: >-
         ${{
@@ -225,6 +227,7 @@ jobs:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
@@ -439,6 +442,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: head
     env:
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
       HOSTNAME_PREFIX: "ghap-prov-214"
       REPORTING_ENABLED: >-
         ${{
@@ -616,6 +620,7 @@ jobs:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
@@ -830,6 +835,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging-latest
     env:
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_13 }}"
       HOSTNAME_PREFIX: "ghap-prov-213"
       REPORTING_ENABLED: >-
         ${{
@@ -1007,6 +1013,7 @@ jobs:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"

--- a/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
@@ -48,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: upgrade-community-head
     env:
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
       HOSTNAME_PREFIX: "ghap-up-215"
       REPORTING_ENABLED: >-
         ${{
@@ -227,6 +228,7 @@ jobs:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -444,6 +446,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: upgrade-community-head
     env:
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
       HOSTNAME_PREFIX: "ghap-up-214"
       REPORTING_ENABLED: >-
         ${{
@@ -623,6 +626,7 @@ jobs:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
@@ -840,6 +844,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
     env:
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_13 }}"
       HOSTNAME_PREFIX: "ghap-up-213"
       REPORTING_ENABLED: >-
         ${{
@@ -1019,6 +1024,7 @@ jobs:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ secrets.OS_USER }}"
               osGroup: "${{ secrets.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"

--- a/actions/go.mod
+++ b/actions/go.mod
@@ -10,7 +10,7 @@ replace (
 
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20260527150105-ae26ccbc3fed
 	github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20260527150105-ae26ccbc3fed
-	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260701185620-64a4ef67d69a
+	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260708233546-2a5a480f8838
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
 	go.opentelemetry.io/otel => go.opentelemetry.io/otel v1.28.0
@@ -60,7 +60,7 @@ require (
 	github.com/qase-tms/qase-go/qase-api-client v1.2.1
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360
-	github.com/rancher/tfp-automation v0.0.0-20260701185620-64a4ef67d69a
+	github.com/rancher/tfp-automation v0.0.0-20260708233546-2a5a480f8838
 )
 
 require (

--- a/actions/go.sum
+++ b/actions/go.sum
@@ -217,8 +217,8 @@ github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360 h1:wYxVY/UlFhBX7c
 github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8/go.mod h1:xDDFkXVPcCf+S6wQoIDwgIijQHcIaVdN0eQRG2GcFd4=
-github.com/rancher/tfp-automation v0.0.0-20260701185620-64a4ef67d69a h1:T1dleEon60KO4H6JN3QSRp7q+QHFKlt3bnrko4pmmcA=
-github.com/rancher/tfp-automation v0.0.0-20260701185620-64a4ef67d69a/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
+github.com/rancher/tfp-automation v0.0.0-20260708233546-2a5a480f8838 h1:DtjH9Nz3B9LtHPZo0yeQlKpk+rjOqpD/88oxOsbMCmQ=
+github.com/rancher/tfp-automation v0.0.0-20260708233546-2a5a480f8838/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=
 github.com/rancher/wrangler v1.1.2/go.mod h1:2k9MyhlBdjcutcBGoOJSUAz0HgDAXnMjv81d3n/AaQc=
 github.com/rancher/wrangler/v3 v3.7.0 h1:rB6GJpnc4Kz8lWuAH3wZwQPgJqPGOu43Aih6147uZB8=

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ replace (
 
 	github.com/rancher/tests/actions => ./actions
 	github.com/rancher/tests/interoperability => ./interoperability
-	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260701185620-64a4ef67d69a
+	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260708233546-2a5a480f8838
 
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
@@ -73,7 +73,7 @@ require (
 	github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360
 	github.com/rancher/tests/actions v0.0.0-20260610140123-a36d05641397
 	github.com/rancher/tests/interoperability v0.0.0
-	github.com/rancher/tfp-automation v0.0.0-20260701185620-64a4ef67d69a
+	github.com/rancher/tfp-automation v0.0.0-20260708233546-2a5a480f8838
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -3701,8 +3701,8 @@ github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360 h1:wYxVY/UlFhBX7c
 github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8/go.mod h1:xDDFkXVPcCf+S6wQoIDwgIijQHcIaVdN0eQRG2GcFd4=
-github.com/rancher/tfp-automation v0.0.0-20260701185620-64a4ef67d69a h1:T1dleEon60KO4H6JN3QSRp7q+QHFKlt3bnrko4pmmcA=
-github.com/rancher/tfp-automation v0.0.0-20260701185620-64a4ef67d69a/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
+github.com/rancher/tfp-automation v0.0.0-20260708233546-2a5a480f8838 h1:DtjH9Nz3B9LtHPZo0yeQlKpk+rjOqpD/88oxOsbMCmQ=
+github.com/rancher/tfp-automation v0.0.0-20260708233546-2a5a480f8838/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/interoperability/go.mod
+++ b/interoperability/go.mod
@@ -13,7 +13,7 @@ replace (
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20260527150105-ae26ccbc3fed
 	github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20260527150105-ae26ccbc3fed
 	github.com/rancher/tests/actions => ./../actions
-	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260701185620-64a4ef67d69a
+	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260708233546-2a5a480f8838
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
 	go.opentelemetry.io/otel => go.opentelemetry.io/otel v1.28.0
@@ -69,7 +69,7 @@ require (
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360
 	github.com/rancher/tests/actions v0.0.0-20260610140123-a36d05641397
-	github.com/rancher/tfp-automation v0.0.0-20260701185620-64a4ef67d69a
+	github.com/rancher/tfp-automation v0.0.0-20260708233546-2a5a480f8838
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.51.0

--- a/interoperability/go.sum
+++ b/interoperability/go.sum
@@ -3655,8 +3655,8 @@ github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360 h1:wYxVY/UlFhBX7c
 github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8/go.mod h1:xDDFkXVPcCf+S6wQoIDwgIijQHcIaVdN0eQRG2GcFd4=
-github.com/rancher/tfp-automation v0.0.0-20260701185620-64a4ef67d69a h1:T1dleEon60KO4H6JN3QSRp7q+QHFKlt3bnrko4pmmcA=
-github.com/rancher/tfp-automation v0.0.0-20260701185620-64a4ef67d69a/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
+github.com/rancher/tfp-automation v0.0.0-20260708233546-2a5a480f8838 h1:DtjH9Nz3B9LtHPZo0yeQlKpk+rjOqpD/88oxOsbMCmQ=
+github.com/rancher/tfp-automation v0.0.0-20260708233546-2a5a480f8838/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/validation/provisioning/ipv6/README.md
+++ b/validation/provisioning/ipv6/README.md
@@ -55,8 +55,8 @@ Import test verfies that various imported cluster configurations provision prope
 8. `K3S_IPv6_Imported|3_etcd|2_cp|3_worker`
 
 #### Run Commands:
-1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/dualstack --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestImportK3SIPv6 -timeout=1h -v`
-2. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/dualstack --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestImportRKE2IPv6 -timeout=1h -v`
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/ipv6 --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestImportK3SIPv6 -timeout=1h -v`
+2. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/ipv6 --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestImportRKE2IPv6 -timeout=1h -v`
 
 ### Node Driver Test
 

--- a/validation/provisioning/ipv6/k3s_import_test.go
+++ b/validation/provisioning/ipv6/k3s_import_test.go
@@ -4,6 +4,7 @@ package ipv6
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/rancher/shepherd/clients/rancher"
@@ -53,9 +54,6 @@ func importK3SIPv6Setup(t *testing.T) importK3SIPv6Test {
 	err = logging.SetLogger(loggingConfig)
 	require.NoError(t, err)
 
-	k.cattleConfig, err = defaults.SetK8sDefault(k.client, defaults.K3S, k.cattleConfig)
-	require.NoError(t, err)
-
 	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
 	require.NoError(t, err)
 
@@ -96,6 +94,10 @@ func TestImportK3SIPv6(t *testing.T) {
 			rancherConfig, terraformConfig, terratestConfig, _ := tfpConfig.LoadTFPConfigs(k.cattleConfig)
 			terratestConfig.Nodepools = tt.nodePools
 
+			if containsIPv4(terraformConfig.AWSConfig.ClusterCIDR) || containsIPv4(terraformConfig.AWSConfig.ServiceCIDR) {
+				t.Skipf("Skipping test %s: cluster/service CIDR must be IPv6 only, found IPv4 CIDR.", tt.name)
+			}
+
 			logrus.Info("Provisioning imported cluster")
 			nestedRancherModuleDir, perTestTerraformOptions, _, cluster := tfpImported.CreateImportedCluster(t, tt.client, rancherConfig, terraformConfig, terratestConfig, defaults.K3S, "validation/provisioning/ipv6")
 			defer os.RemoveAll(nestedRancherModuleDir)
@@ -120,4 +122,8 @@ func TestImportK3SIPv6(t *testing.T) {
 			logrus.Warningf("Failed to upload schema parameters %s", err)
 		}
 	}
+}
+
+func containsIPv4(cidr string) bool {
+	return strings.Contains(cidr, ".")
 }

--- a/validation/provisioning/proxy/README.md
+++ b/validation/provisioning/proxy/README.md
@@ -31,6 +31,30 @@ Custom test verfies that various custom cluster configurations provision properl
 1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/proxy --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestCustomRKE2Proxy -timeout=1h -v`
 2. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/proxy --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestCustomK3SProxy -timeout=1h -v`
 
+### Import Test
+
+#### Description: 
+Import test verfies that various imported cluster configurations provision properly.
+
+#### Required Configurations: 
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Custom Cluster Config](#custom-cluster)
+
+#### Table Tests
+1. `RKE2_Proxy_Imported|etcd_cp_worker`
+2. `RKE2_Proxy_Imported|etcd_cp|worker`
+3. `RKE2_Proxy_Imported|etcd|cp|worker`
+4. `RKE2_Proxy_Imported|3_etcd|2_cp|3_worker`
+5. `K3S_Proxy_Imported|etcd_cp_worker`
+6. `K3S_Proxy_Imported|etcd_cp|worker`
+7. `K3S_Proxy_Imported|etcd|cp|worker`
+8. `K3S_Proxy_Imported|3_etcd|2_cp|3_worker`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/proxy --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestImportK3SProxy -timeout=1h -v`
+2. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/proxy --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestImportRKE2Proxy -timeout=1h -v`
+
 ### Node Driver Test
 
 #### Description: 
@@ -50,6 +74,47 @@ Node driver test verfies that various node driver cluster configurations provisi
 2. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/provisioning/proxy --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestNodeDriverK3SProxy -timeout=1h -v`
 
 ## Configurations
+
+### Terraform Config
+terraform config is needed when running the custom clusters and imported clusters as rancher/tfp-automation is utilized to create the clusters.
+
+```yaml
+terraform:
+  downstreamClusterProvider: "aws"
+  privateKeyPath: ""
+  resourcePrefix: ""
+  windowsPrivateKeyPath: ""
+  awsConfig:
+    ami: ""
+    awsKeyName: ""
+    awsInstanceType: "t"
+    awsVolumeType: ""
+    region: ""
+    awsSecurityGroups: ["sg-"]
+    awsSecurityGroupNames: [""]
+    awsSubnetID: ""
+    awsVpcID: ""
+    awsZoneLetter: "a"
+    awsRootSize: 100
+    awsUser: "ubuntu"
+    sshConnectionType: "ssh"
+    timeout: "5m"
+    windows2019AMI: ""
+    windows2022AMI: ""
+    windowsAWSUser: ""
+    windows2019Password: ""
+    windows2022Password: ""
+    windowsInstanceType: ""
+    windowsKeyName: ""
+```
+
+Also, be sure to export the following variables:
+
+```
+export RANCHER2_PROVIDER_VERSION=""                                     # Required
+export CLOUD_PROVIDER_VERSION=""                                        # Required for custom cluster / infrastructure building
+export LOCALS_PROVIDER_VERSION=""                                       # Required for custom cluster / infrastructure building
+```
 
 ### Cluster Config
 clusterConfig is needed to the run the all RKE2 tests. If no cluster config is provided all values have defaults.
@@ -153,10 +218,6 @@ awsMachineConfigs:                            #default
   awsMachineConfig:
   - roles: ["etcd","controlplane","worker"]
     ami: ""                                   #required
-    enablePrimaryIPv6: true
-    httpProtocolIpv6: "enabled"
-    ipv6AddressOnly: true
-    ipv6AddressCount: "1"
     instanceType: "t3a.medium"
     sshUser: "ubuntu"                         #required
     vpcId: ""                                 #required

--- a/validation/provisioning/proxy/k3s_import_test.go
+++ b/validation/provisioning/proxy/k3s_import_test.go
@@ -1,6 +1,6 @@
-//go:build validation || (recurring && ipv6) || ipv6
+//go:build validation || (recurring && proxy) || proxy
 
-package ipv6
+package proxy
 
 import (
 	"os"
@@ -24,44 +24,48 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type importRKE2IPv6Test struct {
+type importK3SProxyTest struct {
 	client             *rancher.Client
 	session            *session.Session
 	standardUserClient *rancher.Client
 	cattleConfig       map[string]any
+	terraformConfig    *tfpConfig.TerraformConfig
 }
 
-func importRKE2IPv6Setup(t *testing.T) importRKE2IPv6Test {
-	var r importRKE2IPv6Test
+func importK3SProxySetup(t *testing.T) importK3SProxyTest {
+	var k importK3SProxyTest
 
 	testSession := session.NewSession()
-	r.session = testSession
+	k.session = testSession
 
 	client, err := rancher.NewClient("", testSession)
 	require.NoError(t, err)
 
-	r.client = client
+	k.client = client
 
-	r.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
+	k.cattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
-	r.cattleConfig, err = defaults.LoadPackageDefaults(r.cattleConfig, "")
+	k.cattleConfig, err = defaults.LoadPackageDefaults(k.cattleConfig, "")
 	require.NoError(t, err)
 
 	loggingConfig := new(logging.Logging)
-	operations.LoadObjectFromMap(logging.LoggingKey, r.cattleConfig, loggingConfig)
+	operations.LoadObjectFromMap(logging.LoggingKey, k.cattleConfig, loggingConfig)
 
 	err = logging.SetLogger(loggingConfig)
 	require.NoError(t, err)
 
-	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
+	k.terraformConfig = new(tfpConfig.TerraformConfig)
+	operations.LoadObjectFromMap(tfpConfig.TerraformConfigurationFileKey, k.cattleConfig, k.terraformConfig)
+
+	k.standardUserClient, _, _, err = standard.CreateStandardUser(k.client)
 	require.NoError(t, err)
 
-	return r
+	return k
 }
 
-func TestImportRKE2IPv6(t *testing.T) {
+func TestImportK3SProxy(t *testing.T) {
 	t.Parallel()
-	r := importRKE2IPv6Setup(t)
+	k := importK3SProxySetup(t)
 
 	nodeRolesAll := []tfpConfig.Nodepool{{Quantity: 1, Etcd: true, Controlplane: true, Worker: true}}
 	nodeRolesShared := []tfpConfig.Nodepool{{Quantity: 1, Etcd: true, Controlplane: true}, {Quantity: 1, Worker: true}}
@@ -73,16 +77,16 @@ func TestImportRKE2IPv6(t *testing.T) {
 		client    *rancher.Client
 		nodePools []tfpConfig.Nodepool
 	}{
-		{"RKE2_IPv6_Imported|etcd_cp_worker", r.standardUserClient, nodeRolesAll},
-		{"RKE2_IPv6_Imported|etcd_cp|worker", r.standardUserClient, nodeRolesShared},
-		{"RKE2_IPv6_Imported|etcd|cp|worker", r.standardUserClient, nodeRolesDedicated},
-		{"RKE2_IPv6_Imported|3_etcd|2_cp|3_worker", r.standardUserClient, nodeRolesStandard},
+		{"K3S_Proxy_Imported|etcd_cp_worker", k.standardUserClient, nodeRolesAll},
+		{"K3S_Proxy_Imported|etcd_cp|worker", k.standardUserClient, nodeRolesShared},
+		{"K3S_Proxy_Imported|etcd|cp|worker", k.standardUserClient, nodeRolesDedicated},
+		{"K3S_Proxy_Imported|3_etcd|2_cp|3_worker", k.standardUserClient, nodeRolesStandard},
 	}
 
 	for _, tt := range tests {
 		t.Cleanup(func() {
 			logrus.Infof("Running cleanup (%s)", tt.name)
-			r.session.Cleanup()
+			k.session.Cleanup()
 		})
 
 		t.Run(tt.name, func(t *testing.T) {
@@ -90,32 +94,28 @@ func TestImportRKE2IPv6(t *testing.T) {
 
 			var err error
 
-			rancherConfig, terraformConfig, terratestConfig, _ := tfpConfig.LoadTFPConfigs(r.cattleConfig)
+			rancherConfig, terraformConfig, terratestConfig, _ := tfpConfig.LoadTFPConfigs(k.cattleConfig)
 			terratestConfig.Nodepools = tt.nodePools
 
-			if containsIPv4(terraformConfig.AWSConfig.ClusterCIDR) || containsIPv4(terraformConfig.AWSConfig.ServiceCIDR) {
-				t.Skipf("Skipping test %s: cluster/service CIDR must be IPv6 only, found IPv4 CIDR.", tt.name)
-			}
-
 			logrus.Info("Provisioning imported cluster")
-			nestedRancherModuleDir, perTestTerraformOptions, _, cluster := tfpImported.CreateImportedCluster(t, tt.client, rancherConfig, terraformConfig, terratestConfig, defaults.RKE2, "validation/provisioning/ipv6")
+			nestedRancherModuleDir, perTestTerraformOptions, _, cluster := tfpImported.CreateImportedCluster(t, tt.client, rancherConfig, terraformConfig, terratestConfig, defaults.K3S, "validation/provisioning/proxy")
 			defer os.RemoveAll(nestedRancherModuleDir)
 			defer cleanup.Cleanup(t, perTestTerraformOptions, nestedRancherModuleDir)
 
 			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
-			err = provisioning.VerifyClusterReadyV3(r.client, cluster.Name)
+			err = provisioning.VerifyClusterReadyV3(k.client, cluster.Name)
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
-			err = deployment.VerifyClusterDeployments(r.client, cluster)
+			err = deployment.VerifyClusterDeployments(k.client, cluster)
 			require.NoError(t, err)
 
 			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
-			err = pods.VerifyClusterPods(r.client, cluster)
+			err = pods.VerifyClusterPods(k.client, cluster)
 			require.NoError(t, err)
 		})
 
-		params := provisioning.GetCustomSchemaParams(tt.client, r.cattleConfig)
+		params := provisioning.GetCustomSchemaParams(tt.client, k.cattleConfig)
 		err := qase.UpdateSchemaParameters(tt.name, params)
 		if err != nil {
 			logrus.Warningf("Failed to upload schema parameters %s", err)

--- a/validation/provisioning/proxy/rke2_import_test.go
+++ b/validation/provisioning/proxy/rke2_import_test.go
@@ -1,6 +1,6 @@
-//go:build validation || (recurring && ipv6) || ipv6
+//go:build validation || (recurring && proxy) || proxy
 
-package ipv6
+package proxy
 
 import (
 	"os"
@@ -24,15 +24,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type importRKE2IPv6Test struct {
+type importRKE2ProxyTest struct {
 	client             *rancher.Client
 	session            *session.Session
 	standardUserClient *rancher.Client
 	cattleConfig       map[string]any
+	terraformConfig    *tfpConfig.TerraformConfig
 }
 
-func importRKE2IPv6Setup(t *testing.T) importRKE2IPv6Test {
-	var r importRKE2IPv6Test
+func importRKE2ProxySetup(t *testing.T) importRKE2ProxyTest {
+	var r importRKE2ProxyTest
 
 	testSession := session.NewSession()
 	r.session = testSession
@@ -53,15 +54,18 @@ func importRKE2IPv6Setup(t *testing.T) importRKE2IPv6Test {
 	err = logging.SetLogger(loggingConfig)
 	require.NoError(t, err)
 
+	r.terraformConfig = new(tfpConfig.TerraformConfig)
+	operations.LoadObjectFromMap(tfpConfig.TerraformConfigurationFileKey, r.cattleConfig, r.terraformConfig)
+
 	r.standardUserClient, _, _, err = standard.CreateStandardUser(r.client)
 	require.NoError(t, err)
 
 	return r
 }
 
-func TestImportRKE2IPv6(t *testing.T) {
+func TestImportRKE2Proxy(t *testing.T) {
 	t.Parallel()
-	r := importRKE2IPv6Setup(t)
+	r := importRKE2ProxySetup(t)
 
 	nodeRolesAll := []tfpConfig.Nodepool{{Quantity: 1, Etcd: true, Controlplane: true, Worker: true}}
 	nodeRolesShared := []tfpConfig.Nodepool{{Quantity: 1, Etcd: true, Controlplane: true}, {Quantity: 1, Worker: true}}
@@ -73,10 +77,10 @@ func TestImportRKE2IPv6(t *testing.T) {
 		client    *rancher.Client
 		nodePools []tfpConfig.Nodepool
 	}{
-		{"RKE2_IPv6_Imported|etcd_cp_worker", r.standardUserClient, nodeRolesAll},
-		{"RKE2_IPv6_Imported|etcd_cp|worker", r.standardUserClient, nodeRolesShared},
-		{"RKE2_IPv6_Imported|etcd|cp|worker", r.standardUserClient, nodeRolesDedicated},
-		{"RKE2_IPv6_Imported|3_etcd|2_cp|3_worker", r.standardUserClient, nodeRolesStandard},
+		{"RKE2_Proxy_Imported|etcd_cp_worker", r.standardUserClient, nodeRolesAll},
+		{"RKE2_Proxy_Imported|etcd_cp|worker", r.standardUserClient, nodeRolesShared},
+		{"RKE2_Proxy_Imported|etcd|cp|worker", r.standardUserClient, nodeRolesDedicated},
+		{"RKE2_Proxy_Imported|3_etcd|2_cp|3_worker", r.standardUserClient, nodeRolesStandard},
 	}
 
 	for _, tt := range tests {
@@ -93,12 +97,8 @@ func TestImportRKE2IPv6(t *testing.T) {
 			rancherConfig, terraformConfig, terratestConfig, _ := tfpConfig.LoadTFPConfigs(r.cattleConfig)
 			terratestConfig.Nodepools = tt.nodePools
 
-			if containsIPv4(terraformConfig.AWSConfig.ClusterCIDR) || containsIPv4(terraformConfig.AWSConfig.ServiceCIDR) {
-				t.Skipf("Skipping test %s: cluster/service CIDR must be IPv6 only, found IPv4 CIDR.", tt.name)
-			}
-
 			logrus.Info("Provisioning imported cluster")
-			nestedRancherModuleDir, perTestTerraformOptions, _, cluster := tfpImported.CreateImportedCluster(t, tt.client, rancherConfig, terraformConfig, terratestConfig, defaults.RKE2, "validation/provisioning/ipv6")
+			nestedRancherModuleDir, perTestTerraformOptions, _, cluster := tfpImported.CreateImportedCluster(t, tt.client, rancherConfig, terraformConfig, terratestConfig, defaults.RKE2, "validation/provisioning/proxy")
 			defer os.RemoveAll(nestedRancherModuleDir)
 			defer cleanup.Cleanup(t, perTestTerraformOptions, nestedRancherModuleDir)
 

--- a/validation/provisioning/proxy/schemas/hostbusters_schemas.yaml
+++ b/validation/provisioning/proxy/schemas/hostbusters_schemas.yaml
@@ -84,6 +84,260 @@
 - projects:
   - RRT
   - RM
+  suite: Go Automation/Provisioning/Proxy/Imported
+  cases:
+  - description: Provisions a 1 node all roles imported cluster
+    title: RKE2_Proxy_Imported|etcd_cp_worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a RKE2 imported cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 2 node stacked roles imported cluster
+    title: RKE2_Proxy_Imported|etcd_cp|worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a RKE2 imported cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 3 node split roles imported cluster
+    title: RKE2_Proxy_Imported|etcd|cp|worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a RKE2 imported cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 8 node 3etcd/2cp/3worker imported cluster
+    title: RKE2_Proxy_Imported|3_etcd|2_cp|3_worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a RKE2 imported cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 1 node all roles imported cluster
+    title: K3S_Proxy_Imported|etcd_cp_worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a K3S imported cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 2 node stacked roles imported cluster
+    title: K3S_Proxy_Imported|etcd_cp|worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a K3S imported cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 3 node split roles imported cluster
+    title: K3S_Proxy_Imported|etcd|cp|worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a K3S imported cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 8 node 3etcd/2cp/3worker imported cluster
+    title: K3S_Proxy_Imported|3_etcd|2_cp|3_worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a K3S imported cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+
+- projects:
+  - RRT
+  - RM
   suite: Go Automation/Provisioning/Proxy/NodeDriver
   cases:
   - description: Provisions an 8 node 3etcd/2cp/3worker node driver cluster with proxy environment variables defined


### PR DESCRIPTION
This pull request adds functionality to support importing proxy RKE2/K3s standalone clusters, enabling users to more easily integrate these clusters through a proxy configuration.