### PR TITLE
Add v2.15 Rancher release line support in Check Rancher Tag

### DIFF
--- a/.github/actions/check-rancher-tag-result/action.yaml
+++ b/.github/actions/check-rancher-tag-result/action.yaml
@@ -15,6 +15,9 @@ inputs:
     description: "GitHub token for API access"
     required: true
 outputs:
+  failed_workflows_v215:
+    description: "Comma-separated list of workflows that did not pass for the given Rancher tag for v2.15"
+    value: ${{ steps.check.outputs.failed_workflows_v215 }}
   failed_workflows_v214:
     description: "Comma-separated list of workflows that did not pass for the given Rancher tag for v2.14"
     value: ${{ steps.check.outputs.failed_workflows_v214 }}
@@ -66,6 +69,9 @@ runs:
               ;;
             v2.14*)
               release_line="v2.14"
+              ;;
+            v2.15*)
+              release_line="v2.15"
               ;;
             *)
               return 0
@@ -158,6 +164,7 @@ runs:
         done
 
         failed_workflows_str=$(IFS=,; echo "${cleaned_failed_workflows[*]}")
+        echo "failed_workflows_v215=$failed_workflows_str" >> $GITHUB_OUTPUT
         echo "failed_workflows_v214=$failed_workflows_str" >> $GITHUB_OUTPUT
         echo "failed_workflows_v213=$failed_workflows_str" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/compare-rancher-tag/action.yaml
+++ b/.github/actions/compare-rancher-tag/action.yaml
@@ -2,6 +2,8 @@
 name: Compare Rancher tag
 description: "Compares the latest Rancher tag for specified release lines with cached values"
 inputs:
+  cached-tag-v215:
+    required: true
   cached-tag-v214:
     required: true
   cached-tag-v213:
@@ -11,6 +13,8 @@ inputs:
   latest-tag-v213:
     required: true
 outputs:
+  is_tag_new_v215:
+    value: ${{ steps.compare.outputs.is_tag_new_v215 }}
   is_tag_new_v214:
     value: ${{ steps.compare.outputs.is_tag_new_v214 }}
   is_tag_new_v213:
@@ -20,8 +24,11 @@ runs:
   steps:
     - id: compare
       run: |
-        for RELEASE_LINE in v214 v213; do
-          if [[ "$RELEASE_LINE" = "v214" ]]; then
+        for RELEASE_LINE in v215 v214 v213; do
+          if [[ "$RELEASE_LINE" = "v215" ]]; then
+            TAG_INPUT="${{ inputs.latest-tag-v215 }}"
+            CACHED_TAG="${{ inputs.cached-tag-v215 }}"
+          elif [[ "$RELEASE_LINE" = "v214" ]]; then
             TAG_INPUT="${{ inputs.latest-tag-v214 }}"
             CACHED_TAG="${{ inputs.cached-tag-v214 }}"
           elif [[ "$RELEASE_LINE" = "v213" ]]; then
@@ -41,6 +48,7 @@ runs:
           fi
         done
 
+        echo "is_tag_new_v215=$IS_TAG_NEW_v215" >> $GITHUB_OUTPUT
         echo "is_tag_new_v214=$IS_TAG_NEW_v214" >> $GITHUB_OUTPUT
         echo "is_tag_new_v213=$IS_TAG_NEW_v213" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/get-latest-rancher-tag/action.yaml
+++ b/.github/actions/get-latest-rancher-tag/action.yaml
@@ -9,12 +9,18 @@ inputs:
     description: "Path to prime artifacts"
     required: true
 outputs:
+  latest_tag_v215:
+    description: "Latest tag for v2.15"
+    value: ${{ steps.set-outputs.outputs.latest_tag_v215 }}
   latest_tag_v214:
     description: "Latest tag for v2.14"
     value: ${{ steps.set-outputs.outputs.latest_tag_v214 }}
   latest_tag_v213:
     description: "Latest tag for v2.13"
     value: ${{ steps.set-outputs.outputs.latest_tag_v213 }}
+  previous_tag_v215:
+    description: "Previous tag for v2.15"
+    value: ${{ steps.set-outputs.outputs.previous_tag_v215 }}
   previous_tag_v214:
     description: "Previous tag for v2.14"
     value: ${{ steps.set-outputs.outputs.previous_tag_v214 }}
@@ -49,7 +55,7 @@ runs:
           echo "Previous tag for $RELEASE_LINE: $PREVIOUS_VERSION"
 
           # (Optional) Keep the asset/prime artifact checks for the latest version only
-          if [[ "$RELEASE_LINE" == "v2.14" ]]; then
+          if [[ "$RELEASE_LINE" == "v2.14" || "$RELEASE_LINE" == "v2.15" ]]; then
             RELEASE_JSON=$(curl -s "https://api.github.com/repos/rancher/rancher/releases/tags/$LATEST_VERSION")
             ASSET_COUNT=$(echo "$RELEASE_JSON" | jq '.assets | length')
 
@@ -83,8 +89,10 @@ runs:
       shell: bash
     - id: set-outputs
       run: |
+        echo "latest_tag_v215=${LATEST_TAG_v215}" >> $GITHUB_OUTPUT
         echo "latest_tag_v214=${LATEST_TAG_v214}" >> $GITHUB_OUTPUT
         echo "latest_tag_v213=${LATEST_TAG_v213}" >> $GITHUB_OUTPUT
+        echo "previous_tag_v215=${PREVIOUS_TAG_v215}" >> $GITHUB_OUTPUT
         echo "previous_tag_v214=${PREVIOUS_TAG_v214}" >> $GITHUB_OUTPUT
         echo "previous_tag_v213=${PREVIOUS_TAG_v213}" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/config/dispatch-workflows.txt
+++ b/.github/config/dispatch-workflows.txt
@@ -1,10 +1,9 @@
 airgap-cluster-provisioning.yml
 day2-ops-rancher.yml
+day2-ops-rancher-prime.yml
 cluster-provisioning.yml
 post-release-prime.yml
 prime-recurring-tests.yml
-proxy-cluster-provisioning.yml
 rancher-upgrade-cluster-provisioning.yml
 rancher-upgrade-airgap-cluster-provisioning.yml
-rancher-upgrade-proxy-cluster-provisioning.yml
 registries-cluster-provisioning.yml

--- a/.github/workflows/airgap-cluster-provisioning.yml
+++ b/.github/workflows/airgap-cluster-provisioning.yml
@@ -34,7 +34,7 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
 
 jobs:
   v2-15:

--- a/.github/workflows/check-rancher-tag.yml
+++ b/.github/workflows/check-rancher-tag.yml
@@ -36,13 +36,16 @@ jobs:
     needs: get-dispatch-workflow-list
     runs-on: ubuntu-latest
     env:
-      RANCHER_RELEASE_LINES: "v2.14 v2.13"
-      SANITIZED_RELEASES: "v214 v213"
+      RANCHER_RELEASE_LINES: "v2.15 v2.14 v2.13"
+      SANITIZED_RELEASES: "v215 v214 v213"
     outputs:
+      latest_tag_v215: ${{ steps.get-latest-tag.outputs.latest_tag_v215 }}
       latest_tag_v214: ${{ steps.get-latest-tag.outputs.latest_tag_v214 }}
       latest_tag_v213: ${{ steps.get-latest-tag.outputs.latest_tag_v213 }}
+      previous_tag_v215: ${{ steps.get-latest-tag.outputs.previous_tag_v215 }}
       previous_tag_v214: ${{ steps.get-latest-tag.outputs.previous_tag_v214 }}
       previous_tag_v213: ${{ steps.get-latest-tag.outputs.previous_tag_v213 }}
+      is_tag_new_v215: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v215 }}
       is_tag_new_v214: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v214 }}
       is_tag_new_v213: ${{ steps.compare-rancher-tag.outputs.is_tag_new_v213 }}
       dispatch_workflow_list: ${{ needs.get-dispatch-workflow-list.outputs.workflow_list }}
@@ -92,13 +95,16 @@ jobs:
         id: compare-rancher-tag
         uses: ./.github/actions/compare-rancher-tag
         with:
+          cached-tag-v215: ${{ env.CACHED_TAG_v215 }}
           cached-tag-v214: ${{ env.CACHED_TAG_v214 }}
           cached-tag-v213: ${{ env.CACHED_TAG_v213 }}
+          latest-tag-v215: ${{ steps.get-latest-tag.outputs.latest_tag_v215 }}
           latest-tag-v214: ${{ steps.get-latest-tag.outputs.latest_tag_v214 }}
           latest-tag-v213: ${{ steps.get-latest-tag.outputs.latest_tag_v213 }}
 
       - name: Write latest tags to files
         env:
+          LATEST_TAG_V215: ${{ steps.get-latest-tag.outputs.latest_tag_v215 }}
           LATEST_TAG_V214: ${{ steps.get-latest-tag.outputs.latest_tag_v214 }}
           LATEST_TAG_V213: ${{ steps.get-latest-tag.outputs.latest_tag_v213 }}
         run: |
@@ -118,6 +124,7 @@ jobs:
     needs: check-latest-rancher-tag
     runs-on: ubuntu-latest
     outputs:
+      chart_version_v215: ${{ steps.set-latest-chart-version.outputs.chart_version_v215 }}
       chart_version_v214: ${{ steps.set-latest-chart-version.outputs.chart_version_v214 }}
       chart_version_v213: ${{ steps.set-latest-chart-version.outputs.chart_version_v213 }}
 
@@ -125,12 +132,32 @@ jobs:
       - name: Chart versions
         id: set-latest-chart-version
         run: |
+          CHART_V215="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v215 }}"
           CHART_V214="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v214 }}"
           CHART_V213="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v213 }}"
 
+          echo "chart_version_v215=${CHART_V215#v}" >> $GITHUB_OUTPUT
           echo "chart_version_v214=${CHART_V214#v}" >> $GITHUB_OUTPUT
           echo "chart_version_v213=${CHART_V213#v}" >> $GITHUB_OUTPUT
 
+  check-individual-tests-v215:
+    needs: [check-latest-rancher-tag, set-latest-chart-version, get-dispatch-workflow-list]
+    runs-on: ubuntu-latest
+    outputs:
+      failed_workflows_v215: ${{ steps.check.outputs.failed_workflows_v215 }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+
+      - name: Check test results for v2.15
+        id: check
+        uses: ./.github/actions/check-rancher-tag-result
+        with:
+          rancher_tag: ${{ needs.check-latest-rancher-tag.outputs.latest_tag_v215 }}
+          previous_rancher_tag: ${{ needs.check-latest-rancher-tag.outputs.previous_tag_v215 }}
+          dispatch_workflow_list: ${{ needs.get-dispatch-workflow-list.outputs.workflow_list }}
+          github_token: ${{ github.token }}
+  
   check-individual-tests-v214:
     needs: [check-latest-rancher-tag, set-latest-chart-version, get-dispatch-workflow-list]
     runs-on: ubuntu-latest
@@ -167,6 +194,15 @@ jobs:
           dispatch_workflow_list: ${{ needs.get-dispatch-workflow-list.outputs.workflow_list }}
           github_token: ${{ github.token }}
   
+  trigger-tests-v215:
+    needs: [check-latest-rancher-tag, set-latest-chart-version, check-individual-tests-v215, get-dispatch-workflow-list]
+    if: ${{ needs.check-latest-rancher-tag.outputs.is_tag_new_v215 == 'true' && (needs.check-individual-tests-v215.outputs.failed_workflows_v215 != '' || github.event.inputs.override == 'true') }}
+    uses: ./.github/workflows/dispatch-workflows.yml
+    with:
+      rancher_version: ${{ needs.check-latest-rancher-tag.outputs.latest_tag_v215 }}
+      rancher_chart_version: ${{ needs.set-latest-chart-version.outputs.chart_version_v215 }}
+      workflow_list: ${{ (github.event.inputs.override == 'true' && needs.get-dispatch-workflow-list.outputs.workflow_list) || needs.check-individual-tests-v215.outputs.failed_workflows_v215 }}
+  
   trigger-tests-v214:
     needs: [check-latest-rancher-tag, set-latest-chart-version, check-individual-tests-v214, get-dispatch-workflow-list]
     if: ${{ needs.check-latest-rancher-tag.outputs.is_tag_new_v214 == 'true' && (needs.check-individual-tests-v214.outputs.failed_workflows_v214 != '' || github.event.inputs.override == 'true') }}
@@ -185,6 +221,58 @@ jobs:
       rancher_chart_version: ${{ needs.set-latest-chart-version.outputs.chart_version_v213 }}
       workflow_list: ${{ (github.event.inputs.override == 'true' && needs.get-dispatch-workflow-list.outputs.workflow_list) || needs.check-individual-tests-v213.outputs.failed_workflows_v213 }}
 
+  notify-slack-v215:
+    needs: [check-individual-tests-v215, check-latest-rancher-tag]
+    runs-on: ubuntu-latest
+    if: ${{ needs.check-individual-tests-v215.outputs.failed_workflows_v215 == '' && needs.check-latest-rancher-tag.outputs.latest_tag_v215 != '' }}
+    steps:
+       - name: Configure AWS credentials
+         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+         with:
+           role-to-assume: ${{ secrets.IAM_ROLE }}
+           aws-region: ${{ secrets.AWS_REGION }}
+
+       - name: Check if Slack notification already sent
+         id: check_marker
+         run: |
+          TAG="${{ needs.check-latest-rancher-tag.outputs.latest_tag_v215 }}"
+          BASE_TAG=$(echo "$TAG" | grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+')
+          MARKER_FILE="slack_notified_${BASE_TAG}.txt"
+
+          echo "BASE_TAG=$BASE_TAG" >> $GITHUB_ENV
+
+          if aws s3 ls "s3://${{ secrets.RANCHER_TAG_BUCKET }}/$MARKER_FILE" > /dev/null 2>&1; then
+            echo "Notification already sent for $BASE_TAG. Skipping."
+            echo "skip_slack=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip_slack=false" >> $GITHUB_OUTPUT
+          fi
+      
+       - name: Send Slack notification for v2.15
+         if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
+         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 #v3
+         with:
+          webhook: ${{ secrets.HB_TEAM_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "*[rancher/tests]* :alert:\n`${{ env.BASE_TAG }}` Release Testing Completed :white_check_mark:"
+            }
+      
+       - name: Configure AWS credentials
+         if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
+         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+         with:
+           role-to-assume: ${{ secrets.IAM_ROLE }}
+           aws-region: ${{ secrets.AWS_REGION }}
+
+       - name: Write Slack notification marker to S3
+         if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
+         run: |
+          MARKER_FILE="slack_notified_${BASE_TAG}.txt"
+          echo "notified" > $MARKER_FILE
+          aws s3 cp "$MARKER_FILE" "s3://${{ secrets.RANCHER_TAG_BUCKET }}/$MARKER_FILE"
+  
   notify-slack-v214:
     needs: [check-individual-tests-v214, check-latest-rancher-tag]
     runs-on: ubuntu-latest

--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -36,15 +36,15 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
 
 jobs:
   v2-15:
     if: |
-      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: head

--- a/.github/workflows/day2-ops-dualstack-rancher.yml
+++ b/.github/workflows/day2-ops-dualstack-rancher.yml
@@ -36,7 +36,7 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
 
 jobs:
   v2-15:

--- a/.github/workflows/day2-ops-ipv6-rancher.yml
+++ b/.github/workflows/day2-ops-ipv6-rancher.yml
@@ -36,7 +36,7 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
 
 jobs:
   v2-15:

--- a/.github/workflows/day2-ops-proxy-rancher.yml
+++ b/.github/workflows/day2-ops-proxy-rancher.yml
@@ -36,7 +36,7 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
 
 jobs:
   v2-15:

--- a/.github/workflows/day2-ops-rancher-prime.yml
+++ b/.github/workflows/day2-ops-rancher-prime.yml
@@ -34,7 +34,7 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
 
 jobs:
   v2-14:

--- a/.github/workflows/day2-ops-rancher.yml
+++ b/.github/workflows/day2-ops-rancher.yml
@@ -36,14 +36,14 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
 
 jobs:
   v2-15:
     if: |
-      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: head

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -36,7 +36,7 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
 
 jobs:

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -36,7 +36,7 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
 
 jobs:

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -36,7 +36,7 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
 
 jobs:

--- a/.github/workflows/post-release-prime.yml
+++ b/.github/workflows/post-release-prime.yml
@@ -29,17 +29,17 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
 
 jobs:
   create-qase-run:
     if: |
-      ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
-      ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-head'))
+      ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
+      (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
+      (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
+      ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-alpha') &&
+      (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-rc') &&
+      (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-head'))
     runs-on: ubuntu-latest
     outputs:
       run_id: ${{ steps.create-qase-run.outputs.id }}
@@ -307,19 +307,6 @@ jobs:
           rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Save test result as artifact for weekly summary
-        if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"post-release-prime-test\", \"job\": \"v2-14\" }" > test-result-post-release-prime-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
-        with:
-          name: test-result-post-release-prime-test-v2-14-${{ github.run_id }}
-          path: test-result-post-release-prime-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
   
   v2-13:
     needs: [create-qase-run]
@@ -572,28 +559,15 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
-        if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"post-release-prime-test\", \"job\": \"v2-13\" }" > test-result-post-release-prime-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
-        with:
-          name: test-result-post-release-prime-test-v2-13-${{ github.run_id }}
-          path: test-result-post-release-prime-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-
   close-qase-run:
     needs: [create-qase-run, v2-14, v2-13]
     if: always() && (
-        ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
-        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
-        ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-alpha') &&
-        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-rc') &&
-        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-head'))
+        ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
+        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
+        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
+        ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-alpha') &&
+        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-rc') &&
+        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.1') || startsWith(inputs.rancher_version, 'v2.13'))) && !contains(inputs.rancher_version, '-head'))
       )
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/proxy-cluster-provisioning.yml
+++ b/.github/workflows/proxy-cluster-provisioning.yml
@@ -36,7 +36,7 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
 
 jobs:
@@ -436,8 +436,7 @@ jobs:
     if: |
       github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && contains(github.event.inputs.rancher_version, '-alpha') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && contains(inputs.rancher_version, '-alpha')
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: head
@@ -829,8 +828,7 @@ jobs:
     if: |
       github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && contains(github.event.inputs.rancher_version, '-alpha') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && contains(inputs.rancher_version, '-alpha')
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: staging-latest

--- a/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
@@ -34,7 +34,7 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
 
 jobs:
   v2-15:

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -36,15 +36,15 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
 
 jobs:
   v2-15:
     if: |
-      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: upgrade-community-head

--- a/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
@@ -36,7 +36,7 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
 
 jobs:
   v2-15:
@@ -440,8 +440,7 @@ jobs:
     if: |
       github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && contains(github.event.inputs.rancher_version, '-alpha') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && contains(inputs.rancher_version, '-alpha')
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: upgrade-community-head
@@ -838,8 +837,7 @@ jobs:
     if: |
       github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && contains(github.event.inputs.rancher_version, '-alpha') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && contains(inputs.rancher_version, '-alpha')
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging

--- a/.github/workflows/registries-cluster-provisioning.yml
+++ b/.github/workflows/registries-cluster-provisioning.yml
@@ -34,7 +34,7 @@ permissions:
   contents: read
 
 env:
-  CLOUD_PROVIDER_VERSION: "6.34.0"
+  CLOUD_PROVIDER_VERSION: "6.50.0"
 
 jobs:
   v2-15:


### PR DESCRIPTION
This PR updates the Check Rancher Tag functionality to include support for the v2.15 Rancher release line, ensuring compatibility and recognition of the latest Rancher version.