### PR TITLE
 Modified observedGenererationLocal/Remote value for CRTB Status field test

### DIFF
--- a/validation/rbac/crtb/crtb.go
+++ b/validation/rbac/crtb/crtb.go
@@ -94,8 +94,8 @@ func verifyClusterRoleTemplateBindingStatusField(crtb *v3.ClusterRoleTemplateBin
 		}
 	}
 
-	if status.ObservedGenerationRemote != 1 {
-		return fmt.Errorf("observedGenerationRemote is not 1, found: %d", status.ObservedGenerationRemote)
+	if status.ObservedGenerationRemote != 2 {
+		return fmt.Errorf("observedGenerationRemote is not 2, found: %d", status.ObservedGenerationRemote)
 	}
 
 	if status.SummaryRemote != completedSummary {

--- a/validation/rbac/crtb/crtb.go
+++ b/validation/rbac/crtb/crtb.go
@@ -58,8 +58,8 @@ func verifyClusterRoleTemplateBindingStatusField(crtb *v3.ClusterRoleTemplateBin
 		}
 	}
 
-	if status.ObservedGenerationLocal != 2 {
-		return fmt.Errorf("observedGenerationLocal is not 2, found: %d", status.ObservedGenerationLocal)
+	if status.ObservedGenerationLocal < 1 {
+		return fmt.Errorf("observedGenerationLocal has not been reconciled, found: %d", status.ObservedGenerationLocal)
 	}
 
 	if status.Summary != completedSummary || status.SummaryLocal != completedSummary {
@@ -94,8 +94,8 @@ func verifyClusterRoleTemplateBindingStatusField(crtb *v3.ClusterRoleTemplateBin
 		}
 	}
 
-	if status.ObservedGenerationRemote != 2 {
-		return fmt.Errorf("observedGenerationRemote is not 2, found: %d", status.ObservedGenerationRemote)
+	if status.ObservedGenerationRemote < 1 {
+		return fmt.Errorf("observedGenerationRemote has not been reconciled, found: %d", status.ObservedGenerationRemote)
 	}
 
 	if status.SummaryRemote != completedSummary {


### PR DESCRIPTION
Checks on the observedGenerationLocal/Remotehave value been modified to handle at least one reconciliation occurring to the CRTB status. This should eliminate flaky tests that were failing due to reconciliation timing. 