### PR TITLE
Remove prime-recurring-tests.yml from dispatch-workflows.txt

### DIFF
--- a/.github/config/dispatch-workflows.txt
+++ b/.github/config/dispatch-workflows.txt
@@ -3,7 +3,6 @@ day2-ops-rancher.yml
 day2-ops-rancher-prime.yml
 cluster-provisioning.yml
 post-release-prime.yml
-prime-recurring-tests.yml
 rancher-upgrade-cluster-provisioning.yml
 rancher-upgrade-airgap-cluster-provisioning.yml
 registries-cluster-provisioning.yml


### PR DESCRIPTION
This pull request removes the entry for prime-recurring-tests.yml from the dispatch-workflows.txt file, eliminating the associated workflow from dispatch operations.