### PR TITLE
Update tfp go.mod to get latest registry cluster provisioning changes

### DIFF
--- a/.github/workflows/registries-cluster-provisioning.yml
+++ b/.github/workflows/registries-cluster-provisioning.yml
@@ -229,7 +229,6 @@ jobs:
             standaloneRegistry:
               assetsPath: "${{ secrets.ASSETS_PATH }}"
               createAuthGlobalRegistry: true
-              createUnauthGlobalRegistry: true
               registryName: "${{ env.HOSTNAME_PREFIX }}"
               registryPassword: "${{ env.HOSTNAME_PREFIX }}-pass"
               registryUsername: "${{ env.HOSTNAME_PREFIX }}-user"
@@ -568,9 +567,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
             standaloneRegistry:
-              createAuthGlobalRegistry: true
-              createUnauthGlobalRegistry: true
               assetsPath: "${{ secrets.ASSETS_PATH }}"
+              createUnauthGlobalRegistry: true
               registryName: "${{ env.HOSTNAME_PREFIX }}"
               registryPassword: "${{ env.HOSTNAME_PREFIX }}-pass"
               registryUsername: "${{ env.HOSTNAME_PREFIX }}-user"
@@ -909,9 +907,8 @@ jobs:
               repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
             standaloneRegistry:
-              createAuthGlobalRegistry: true
-              createUnauthGlobalRegistry: true
               assetsPath: "${{ secrets.ASSETS_PATH }}"
+              createUnauthGlobalRegistry: true
               registryName: "${{ env.HOSTNAME_PREFIX }}"
               registryPassword: "${{ env.HOSTNAME_PREFIX }}-pass"
               registryUsername: "${{ env.HOSTNAME_PREFIX }}-user"

--- a/actions/go.mod
+++ b/actions/go.mod
@@ -10,7 +10,7 @@ replace (
 
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20260527150105-ae26ccbc3fed
 	github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20260527150105-ae26ccbc3fed
-	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260714234229-7f371c35f112
+	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260715194347-e03e4ff5f114
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
 	go.opentelemetry.io/otel => go.opentelemetry.io/otel v1.28.0
@@ -60,7 +60,7 @@ require (
 	github.com/qase-tms/qase-go/qase-api-client v1.2.1
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360
-	github.com/rancher/tfp-automation v0.0.0-20260714234229-7f371c35f112
+	github.com/rancher/tfp-automation v0.0.0-20260715194347-e03e4ff5f114
 )
 
 require (

--- a/actions/go.sum
+++ b/actions/go.sum
@@ -217,8 +217,8 @@ github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360 h1:wYxVY/UlFhBX7c
 github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8/go.mod h1:xDDFkXVPcCf+S6wQoIDwgIijQHcIaVdN0eQRG2GcFd4=
-github.com/rancher/tfp-automation v0.0.0-20260714234229-7f371c35f112 h1:aSTq8EHP1aXO6ULnuqz8O323HCfNCSEF+W+YU/80gGc=
-github.com/rancher/tfp-automation v0.0.0-20260714234229-7f371c35f112/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
+github.com/rancher/tfp-automation v0.0.0-20260715194347-e03e4ff5f114 h1:hYrlk9n+HDT9NgcIFnxd/ftqiRCAED6Bfrc3f46gqz4=
+github.com/rancher/tfp-automation v0.0.0-20260715194347-e03e4ff5f114/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=
 github.com/rancher/wrangler v1.1.2/go.mod h1:2k9MyhlBdjcutcBGoOJSUAz0HgDAXnMjv81d3n/AaQc=
 github.com/rancher/wrangler/v3 v3.7.0 h1:rB6GJpnc4Kz8lWuAH3wZwQPgJqPGOu43Aih6147uZB8=

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ replace (
 
 	github.com/rancher/tests/actions => ./actions
 	github.com/rancher/tests/interoperability => ./interoperability
-	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260714234229-7f371c35f112
+	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260715194347-e03e4ff5f114
 
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
@@ -73,7 +73,7 @@ require (
 	github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360
 	github.com/rancher/tests/actions v0.0.0-20260610140123-a36d05641397
 	github.com/rancher/tests/interoperability v0.0.0
-	github.com/rancher/tfp-automation v0.0.0-20260714234229-7f371c35f112
+	github.com/rancher/tfp-automation v0.0.0-20260715194347-e03e4ff5f114
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -3701,8 +3701,8 @@ github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360 h1:wYxVY/UlFhBX7c
 github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8/go.mod h1:xDDFkXVPcCf+S6wQoIDwgIijQHcIaVdN0eQRG2GcFd4=
-github.com/rancher/tfp-automation v0.0.0-20260714234229-7f371c35f112 h1:aSTq8EHP1aXO6ULnuqz8O323HCfNCSEF+W+YU/80gGc=
-github.com/rancher/tfp-automation v0.0.0-20260714234229-7f371c35f112/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
+github.com/rancher/tfp-automation v0.0.0-20260715194347-e03e4ff5f114 h1:hYrlk9n+HDT9NgcIFnxd/ftqiRCAED6Bfrc3f46gqz4=
+github.com/rancher/tfp-automation v0.0.0-20260715194347-e03e4ff5f114/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/interoperability/go.mod
+++ b/interoperability/go.mod
@@ -13,7 +13,7 @@ replace (
 	github.com/rancher/rancher/pkg/apis => github.com/rancher/rancher/pkg/apis v0.0.0-20260527150105-ae26ccbc3fed
 	github.com/rancher/rancher/pkg/client => github.com/rancher/rancher/pkg/client v0.0.0-20260527150105-ae26ccbc3fed
 	github.com/rancher/tests/actions => ./../actions
-	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260714234229-7f371c35f112
+	github.com/rancher/tfp-automation => github.com/rancher/tfp-automation v0.0.0-20260715194347-e03e4ff5f114
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc => go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.53.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp => go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0
 	go.opentelemetry.io/otel => go.opentelemetry.io/otel v1.28.0
@@ -69,7 +69,7 @@ require (
 	github.com/rancher/rancher/pkg/apis v0.0.0
 	github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360
 	github.com/rancher/tests/actions v0.0.0-20260610140123-a36d05641397
-	github.com/rancher/tfp-automation v0.0.0-20260714234229-7f371c35f112
+	github.com/rancher/tfp-automation v0.0.0-20260715194347-e03e4ff5f114
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.51.0

--- a/interoperability/go.sum
+++ b/interoperability/go.sum
@@ -3655,8 +3655,8 @@ github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360 h1:wYxVY/UlFhBX7c
 github.com/rancher/shepherd v0.0.0-20260616224945-d2cbef93a360/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8/go.mod h1:xDDFkXVPcCf+S6wQoIDwgIijQHcIaVdN0eQRG2GcFd4=
-github.com/rancher/tfp-automation v0.0.0-20260714234229-7f371c35f112 h1:aSTq8EHP1aXO6ULnuqz8O323HCfNCSEF+W+YU/80gGc=
-github.com/rancher/tfp-automation v0.0.0-20260714234229-7f371c35f112/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
+github.com/rancher/tfp-automation v0.0.0-20260715194347-e03e4ff5f114 h1:hYrlk9n+HDT9NgcIFnxd/ftqiRCAED6Bfrc3f46gqz4=
+github.com/rancher/tfp-automation v0.0.0-20260715194347-e03e4ff5f114/go.mod h1:ojRA9GMeD9BxP4A7pytxHWMiDrTn4yZnkO0cKZ6Qud4=
 github.com/rancher/wrangler v0.6.2-0.20200515155908-1923f3f8ec3f/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v0.6.2-0.20200622171942-7224e49a2407/go.mod h1:NmtmlLkchboIksYJuBemwcP4RBfv8FpeyhVoWXB9Wdc=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=


### PR DESCRIPTION
This pull request updates the tfp go.mod file to fetch the latest changes related to registry cluster provisioning. By doing so, it ensures that tfp is using the most current version of the registry provisioning code, potentially including bug fixes, new features, and improvements relevant to cluster provisioning.