### PR TITLE
test: add airgap.daily build tag for daily airgap CI

### DIFF
--- a/validation/charts/alerting_test.go
+++ b/validation/charts/alerting_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !stress && !extended
+//go:build (validation || infra.any || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !stress && !extended && !airgap.daily
 
 package charts
 

--- a/validation/charts/appco/istio_test.go
+++ b/validation/charts/appco/istio_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || extended || pit.daily || pit.elemental || pit.harvester.daily) && !sanity && !stress
+//go:build (validation || infra.any || cluster.any || extended || pit.daily || pit.elemental || pit.harvester.daily) && !sanity && !stress && !airgap.daily
 
 package appco
 

--- a/validation/charts/cis_benchmark_test.go
+++ b/validation/charts/cis_benchmark_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !stress && !extended
+//go:build (validation || infra.any || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !stress && !extended && !airgap.daily
 
 package charts
 

--- a/validation/charts/istio_test.go
+++ b/validation/charts/istio_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.rke1 || cluster.any || stress || pit.daily || pit.elemental || pit.harvester.daily) && !infra.any && !infra.aks && !infra.eks && !infra.gke && !infra.rke2k3s && !sanity && !extended
+//go:build (validation || infra.rke1 || cluster.any || stress || pit.daily || pit.elemental || pit.harvester.daily) && !infra.any && !infra.aks && !infra.eks && !infra.gke && !infra.rke2k3s && !sanity && !extended && !airgap.daily
 
 package charts
 

--- a/validation/charts/logging_test.go
+++ b/validation/charts/logging_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !stress && !extended
+//go:build (validation || infra.any || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !stress && !extended && !airgap.daily
 
 package charts
 

--- a/validation/charts/monitoring_test.go
+++ b/validation/charts/monitoring_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.rke1 || cluster.any || stress || pit.daily || pit.elemental || pit.harvester.daily) && !infra.any && !infra.aks && !infra.eks && !infra.gke && !infra.rke2k3s && !sanity && !extended
+//go:build (validation || infra.rke1 || cluster.any || stress || pit.daily || pit.elemental || pit.harvester.daily) && !infra.any && !infra.aks && !infra.eks && !infra.gke && !infra.rke2k3s && !sanity && !extended && !airgap.daily
 
 package charts
 

--- a/validation/charts/neuvector_test.go
+++ b/validation/charts/neuvector_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !stress && !extended
+//go:build (validation || infra.any || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !stress && !extended && !airgap.daily
 
 package charts
 

--- a/validation/fleet/public_gitrepo_test.go
+++ b/validation/fleet/public_gitrepo_test.go
@@ -1,4 +1,4 @@
-//go:build validation || sanity || pit.daily || pit.elemental || pit.harvester.daily
+//go:build (validation || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !airgap.daily
 
 package fleet
 

--- a/validation/fleet/upgrade/upgrade_test.go
+++ b/validation/fleet/upgrade/upgrade_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || extended || pit.daily || pit.elemental || pit.harvester.daily) && !sanity && !stress
+//go:build (validation || infra.any || cluster.any || extended || pit.daily || pit.elemental || pit.harvester.daily) && !sanity && !stress && !airgap.daily
 
 package upgrade
 

--- a/validation/longhorn/chartinstall/installation_test.go
+++ b/validation/longhorn/chartinstall/installation_test.go
@@ -1,4 +1,4 @@
-//go:build validation || pit.daily || pit.elemental || pit.harvester.daily
+//go:build (validation || pit.daily || pit.elemental || pit.harvester.daily) && !airgap.daily
 
 package longhorn
 

--- a/validation/longhorn/longhorn_test.go
+++ b/validation/longhorn/longhorn_test.go
@@ -1,4 +1,4 @@
-//go:build validation || pit.daily || pit.elemental || pit.harvester.daily
+//go:build (validation || pit.daily || pit.elemental || pit.harvester.daily) && !airgap.daily
 
 package longhorn
 

--- a/validation/networking/connectivity/network_policy_test.go
+++ b/validation/networking/connectivity/network_policy_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.rke2k3s || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !stress && !extended
+//go:build (validation || infra.rke2k3s || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !stress && !extended && !airgap.daily
 
 package connectivity
 

--- a/validation/networking/connectivity/port_test.go
+++ b/validation/networking/connectivity/port_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.rke2k3s || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !stress && !extended
+//go:build (validation || infra.rke2k3s || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !stress && !extended && !airgap.daily
 
 package connectivity
 

--- a/validation/upgrade/workload_test.go
+++ b/validation/upgrade/workload_test.go
@@ -1,4 +1,4 @@
-//go:build validation || pit.daily || pit.elemental || pit.harvester.daily
+//go:build (validation || pit.daily || pit.elemental || pit.harvester.daily) && !airgap.daily
 
 package upgrade
 

--- a/validation/workloads/workload_test.go
+++ b/validation/workloads/workload_test.go
@@ -1,4 +1,4 @@
-//go:build (validation || infra.any || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily) && !stress && !extended
+//go:build (validation || infra.any || cluster.any || sanity || pit.daily || pit.elemental || pit.harvester.daily || airgap.daily) && !stress && !extended
 
 package workloads
 


### PR DESCRIPTION
## Summary

Introduces a new \`airgap.daily\` build tag that defines a curated set of \`pit.daily\` suites to run daily against an airgap cluster. Each suite was validated against a live airgap RKE2 cluster (Rancher v2.14.2, custom ansible-provisioned nodes) — suites either passed and were tagged \`|| airgap.daily\`, or were verified unsuitable for airgap and excluded with \`&& !airgap.daily\`.

The tag doubles as both the CI gate and a visual audit trail of which suites work in which environment.

## Matrix (all 15 \`pit.daily\` suites)

| Suite | Verdict | Change |
|---|---|---|
| \`validation/workloads\` | ✅ 13/13 subtests pass | \`|| airgap.daily\` |
| \`networking/connectivity\` (×2) | ❌ requires node-driver SSH (custom airgap nodes carry none; no external IPs) | \`&& !airgap.daily\` |
| \`fleet/public_gitrepo\` | ❌ clones public GitHub (no egress) | \`&& !airgap.daily\` |
| \`fleet/upgrade\` | ❌ node SSH + public GitHub | \`&& !airgap.daily\` |
| \`upgrade/workload\` | ❌ upgrade-flow test (needs real cluster upgrade between pre/post phases) | \`&& !airgap.daily\` |
| \`charts/{alerting,cis,istio,logging,monitoring,neuvector}\`, \`charts/appco/istio\`, \`longhorn/{longhorn,chartinstall}\` | ❌ blocked by catalog-apps watch instability + external-node-IP deps (see follow-ups) | \`&& !airgap.daily\` |

## Verification

- \`-tags=airgap.daily\` → only \`TestWorkloadTestSuite\` compiles.
- \`-tags=pit.daily\` → all 15 target suites still compile/run (nothing lost).
- 15 files changed, one build-constraint line each.

## Run the daily airgap job

\`\`\`bash
CATTLE_TEST_CONFIG=$(pwd)/cattle-config.yaml go test -tags=airgap.daily ./validation/workloads/...
\`\`\`
(Scoped to the \`workloads\` package because two non-\`pit.daily\` files with negative-only build constraints also compile under \`airgap.daily\`.)

## Confirmed airgap-environment constraints on this cluster
- ✅ Image pulls work (docker.io mirror in front)
- ✅ Chart installs + ingress work
- ❌ No public-GitHub egress
- ❌ Custom ansible nodes carry no node-driver SSH credentials and no external IPs

## Follow-ups (to re-enable the chart/longhorn suites)
- **rancher/rancher:** catalog app watch (\`catalog.cattle.io.apps\`) intermittently resets with HTTP/2 \`INTERNAL_ERROR\` / returns a collection instead of a stream (reproduced on CI). Root cause of the chart-suite flakiness.
- **rancher/tests:** normalize watch-retry resilience across chart install helpers (monitoring retries, alerting does not); monitoring test's external-node-IP dependency (\`monitoring_test.go\` webhook NodePort); monitoring teardown bug (empty pod name in log streaming).

\`cattle-config.yaml\` is intentionally **not** committed (contains credentials).