### PR TITLE
Set rancher_system_default_registry in airgap-rke2-tests group_vars

### DIFF
--- a/validation/pipeline/Jenkinsfile.airgap-rke2-tests
+++ b/validation/pipeline/Jenkinsfile.airgap-rke2-tests
@@ -286,7 +286,8 @@ install_helm: true
 rancher_hostname: "${HOSTNAME_PREFIX}.qa.rancher.space"
 rancher_bootstrap_password: "${RANCHER_BOOTSTRAP_PASSWORD}"
 rancher_image_tag: ${RANCHER_VERSION}
-rancher_use_bundled_system_charts: true'''
+rancher_use_bundled_system_charts: true
+rancher_system_default_registry: "${PRIVATE_REGISTRY_URL}"'''
         )
     }
 


### PR DESCRIPTION
## Problem
The `airgap-rke2-tests` pipeline renders `group_vars` with the Rancher deploy keys (`rancher_hostname`, `rancher_image_tag`, `rancher_use_bundled_system_charts`, …) but does **not** set `rancher_system_default_registry`. As a result Rancher is installed with an empty `system-default-registry` setting and `shell-image` stays as the public `rancher/shell:<tag>` reference, which is unpullable in airgap.

This broke `TestWorkloadTestSuite/TestDeployments/WorkloadUpgradeTest` (and any other path using `kubectl.Command`), surfacing as a misleading:
```
error streaming pod logs for pod kube-system/: resource name may not be empty
```

## Fix
Render one line in the group_vars block:
```yaml
rancher_system_default_registry: "\${PRIVATE_REGISTRY_URL}"
```
reusing the existing `PRIVATE_REGISTRY_URL` Jenkins parameter (no new param needed; `ENABLE_PRIVATE_REGISTRY` is already auto-derived from it).

## Verification
- Rendered `group_vars` parses as valid YAML after `\${...}` substitution; `rancher_system_default_registry` resolves to the registry value.
- Confirmed on a live cluster that `shell-image` is seeded at Rancher **startup** from `system-default-registry` (not rewritten post-install), so it must be set at deploy time — which this change does.

## Depends on
`rancher/qa-infra-automation#123` — the `airgap_rancher_helm_deploy` role currently defines `rancher_system_default_registry` but never passes it to the chart (`global.cattle.systemDefaultRegistry`). This PR sets the variable; that one makes it effective. Setting the variable is harmless on its own (no-op until the role wires it through).

## Prerequisite
`rancher/shell:<tag>` must be mirrored at `<registry>/rancher/shell:<tag>` (the containerd `proxycache`/`quaycache` mirrors do not cover this verbatim reference).