### PR TITLE
Align tests and schemas

### DIFF
--- a/actions/networking/verify.go
+++ b/actions/networking/verify.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -88,6 +87,66 @@ func VerifyNetworkPolicy(client *rancher.Client, clusterID string, namespaceName
 	return nil
 }
 
+// verifyConnectivityFromWorkerNodes verifies if any worker node in the cluster is able to access the provided ip:port
+// and retrieve the expected content from name.html.
+func verifyConnectivityFromWorkerNodes(client *rancher.Client, clusterID string, ip string, port int, workloadName string) error {
+	query, err := url.ParseQuery(clusters.LabelWorker)
+	if err != nil {
+		return err
+	}
+
+	steveClient, err := client.Steve.ProxyDownstream(clusterID)
+	if err != nil {
+		return err
+	}
+
+	nodeList, err := steveClient.SteveType(stevetypes.Node).List(query)
+	if err != nil {
+		return err
+	}
+
+	if len(nodeList.Data) == 0 {
+		return errors.New("no worker nodes found")
+	}
+
+	for _, machine := range nodeList.Data {
+		sshNode, err := sshkeys.GetSSHNodeFromMachine(client, &machine)
+		if err != nil {
+			logrus.Debugf("Could not SSH into worker node %s: %s", machine.Name, err.Error())
+			continue
+		}
+
+		logrus.Debugf("Curling '%s:%d/name.html' from node %s", ip, port, machine.Name)
+		log, err := sshNode.ExecuteCommand(fmt.Sprintf("curl -s %s:%d/name.html", ip, port))
+		if err != nil && !errors.Is(err, &ssh.ExitMissingError{}) {
+			logrus.Debugf("Curl failed on node %s: %v", machine.Name, err)
+			continue
+		}
+
+		if strings.Contains(log, workloadName) { // This should be one of the pod's names.
+			return nil
+		} else {
+			logrus.Debugf("Curl result %s doesn't contain expected content '%s'", log, workloadName)
+		}
+	}
+
+	return fmt.Errorf("Unable to connect to %s:%d/name.html from any worker node", ip, port)
+}
+
+func verifyConnectivityFromPod(client *rancher.Client, clusterID string, ip string, port int, workloadName string) error {
+	execCmd := []string{"curl", "-s", fmt.Sprintf("%s:%d/name.html", ip, port)}
+	log, err := kubectl.Command(client, nil, clusterID, execCmd, "")
+	if err != nil {
+		return err
+	}
+
+	if !strings.Contains(log, workloadName) { // This should be one of the pod's names.
+		return fmt.Errorf("Curl result %s doesn't include the workload name %s", log, workloadName)
+	}
+
+	return nil
+}
+
 // VerifyNodePortConnectivity verifies that the node port is accessible by curling the worker node external IP
 func VerifyNodePortConnectivity(client *rancher.Client, clusterID string, nodePort int, workloadName string) error {
 	steveClient, err := client.Steve.ProxyDownstream(clusterID)
@@ -122,21 +181,14 @@ func VerifyNodePortConnectivity(client *rancher.Client, clusterID string, nodePo
 		}
 
 		logrus.Debugf("Curling node port %d on node %s (%s)", nodePort, machine.Name, nodeIP)
-		execCmd := []string{"curl", fmt.Sprintf("%s:%s/name.html", nodeIP, strconv.Itoa(nodePort))}
-		log, err := kubectl.Command(client, nil, clusterID, execCmd, "")
-		if err != nil {
-			return fmt.Errorf("curl command failed on node %s: %w", machine.Name, err)
-		}
-
-		if strings.Contains(log, workloadName) {
-			return nil
-		}
+		verifyConnectivityFromPod(client, clusterID, nodeIP, nodePort, workloadName)
 	}
 
 	return fmt.Errorf("unable to access node port %d for workload %s", nodePort, workloadName)
 }
 
 // VerifyLoadBalancerConnectivity verifies that the Load Balancer service is accessible by curling its IP:port.
+// This includes
 func VerifyLoadBalancerConnectivity(t *testing.T, client *rancher.Client, clusterID string, serviceID string, workloadName string) {
 	steveClient, err := client.Steve.ProxyDownstream(clusterID)
 	require.NoError(t, err)
@@ -155,57 +207,17 @@ func VerifyLoadBalancerConnectivity(t *testing.T, client *rancher.Client, cluste
 	ip := k8sService.Status.LoadBalancer.Ingress[0].IP
 	t.Logf("Testing connectivity with load balancer %s by curling %s:%d/name.html", k8sService.Name, ip, port)
 
-	execCmd := []string{"curl", "-s", fmt.Sprintf("%s:%d/name.html", ip, port)}
-	log, err := kubectl.Command(client, nil, clusterID, execCmd, "")
+	err = verifyConnectivityFromPod(client, clusterID, ip, int(port), workloadName)
 	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(log), 7)
-	require.Equal(t, workloadName, log[:len(log)-7]) // This should be one of the pod's names.
 }
 
 // VerifyHostPortConnectivity verifies that the host port is accessible on worker nodes by SSHing directly into each node
 func VerifyHostPortConnectivity(client *rancher.Client, clusterID string, hostPort int, workloadName string) error {
-	steveClient, err := client.Steve.ProxyDownstream(clusterID)
-	if err != nil {
-		return err
-	}
-
-	query, err := url.ParseQuery(clusters.LabelWorker)
-	if err != nil {
-		return fmt.Errorf("failed to build worker node query: %w", err)
-	}
-
-	nodeList, err := steveClient.SteveType(stevetypes.Node).List(query)
-	if err != nil {
-		return fmt.Errorf("failed to list worker nodes: %w", err)
-	}
-
-	if len(nodeList.Data) == 0 {
-		return errors.New("no worker nodes found")
-	}
-
-	for _, machine := range nodeList.Data {
-		sshNode, err := sshkeys.GetSSHNodeFromMachine(client, &machine)
-		if err != nil {
-			logrus.Debugf("Could not SSH into worker node %s, skipping: %v", machine.Name, err)
-			continue
-		}
-
-		logrus.Debugf("Curling host port %d on worker node %s", hostPort, machine.Name)
-		output, err := sshNode.ExecuteCommand(fmt.Sprintf("curl localhost:%d/name.html", hostPort))
-		if err != nil {
-			continue
-		}
-
-		if strings.Contains(output, workloadName) {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("unable to access host port %d for workload %s on any worker node", hostPort, workloadName)
+	return verifyConnectivityFromWorkerNodes(client, clusterID, "localhost", hostPort, workloadName)
 }
 
 // VerifyClusterConnectivity verifies that the ClusterIP service is accessible via SSH from a worker node
-func VerifyClusterConnectivity(client *rancher.Client, clusterID string, serviceID string, path string, content string) error {
+func VerifyClusterConnectivity(client *rancher.Client, clusterID string, serviceID string, port int, content string) error {
 	steveClient, err := client.Steve.ProxyDownstream(clusterID)
 	if err != nil {
 		return err
@@ -222,40 +234,5 @@ func VerifyClusterConnectivity(client *rancher.Client, clusterID string, service
 		return err
 	}
 
-	clusterIP := newService.Spec.ClusterIP
-
-	query, err := url.ParseQuery(clusters.LabelWorker)
-	if err != nil {
-		return err
-	}
-
-	nodeList, err := steveClient.SteveType(stevetypes.Node).List(query)
-	if err != nil {
-		return err
-	}
-
-	if len(nodeList.Data) == 0 {
-		return errors.New("no worker nodes found")
-	}
-
-	for _, machine := range nodeList.Data {
-		sshNode, err := sshkeys.GetSSHNodeFromMachine(client, &machine)
-		if err != nil {
-			logrus.Debugf("Could not SSH into worker node %s, trying next node: %v", machine.Name, err)
-			continue
-		}
-
-		logrus.Debugf("Curling cluster IP %s:%s from node %s", clusterIP, path, machine.Name)
-		log, err := sshNode.ExecuteCommand(fmt.Sprintf("curl %s:%s", clusterIP, path))
-		if err != nil && !errors.Is(err, &ssh.ExitMissingError{}) {
-			logrus.Debugf("Curl failed on node %s: %v, trying next node", machine.Name, err)
-			continue
-		}
-
-		if strings.Contains(log, content) {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("unable to connect to the cluster IP %s:%s from any worker node", clusterIP, path)
+	return verifyConnectivityFromWorkerNodes(client, clusterID, newService.Spec.ClusterIP, port, content)
 }

--- a/actions/networking/verify.go
+++ b/actions/networking/verify.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"testing"
 
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
@@ -15,6 +16,7 @@ import (
 	"github.com/rancher/shepherd/extensions/sshkeys"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -132,6 +134,32 @@ func VerifyNodePortConnectivity(client *rancher.Client, clusterID string, nodePo
 	}
 
 	return fmt.Errorf("unable to access node port %d for workload %s", nodePort, workloadName)
+}
+
+// VerifyLoadBalancerConnectivity verifies that the Load Balancer service is accessible by curling its IP:port.
+func VerifyLoadBalancerConnectivity(t *testing.T, client *rancher.Client, clusterID string, serviceID string, workloadName string) {
+	steveClient, err := client.Steve.ProxyDownstream(clusterID)
+	require.NoError(t, err)
+
+	service, err := steveClient.SteveType(stevetypes.Service).ByID(serviceID)
+	require.NoError(t, err)
+
+	k8sService := &corev1.Service{}
+	err = v1.ConvertToK8sType(service, k8sService)
+	require.NoError(t, err)
+	require.Equal(t, corev1.ServiceTypeLoadBalancer, k8sService.Spec.Type)
+	require.NotEmpty(t, k8sService.Spec.Ports)
+	require.NotEmpty(t, k8sService.Status.LoadBalancer.Ingress)
+
+	port := k8sService.Spec.Ports[0].Port
+	ip := k8sService.Status.LoadBalancer.Ingress[0].IP
+	t.Logf("Testing connectivity with load balancer %s by curling %s:%d/name.html", k8sService.Name, ip, port)
+
+	execCmd := []string{"curl", "-s", fmt.Sprintf("%s:%d/name.html", ip, port)}
+	log, err := kubectl.Command(client, nil, clusterID, execCmd, "")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(log), 7)
+	require.Equal(t, workloadName, log[:len(log)-7]) // This should be one of the pod's names.
 }
 
 // VerifyHostPortConnectivity verifies that the host port is accessible on worker nodes by SSHing directly into each node

--- a/actions/networking/verify.go
+++ b/actions/networking/verify.go
@@ -110,38 +110,39 @@ func VerifyConnectivityFromWorkerNodes(client *rancher.Client, clusterID string,
 	for _, machine := range nodeList.Data {
 		sshNode, err := sshkeys.GetSSHNodeFromMachine(client, &machine)
 		if err != nil {
-			logrus.Debugf("Could not SSH into worker node %s: %s", machine.Name, err.Error())
+			logrus.Infof("Could not SSH into worker node %s: %s", machine.Name, err.Error())
 			continue
 		}
 
-		if ip == "" {
+		nodeIP := ip
+		if nodeIP == "" {
 			newNode := &corev1.Node{}
 			err = v1.ConvertToK8sType(machine.JSONResp, newNode)
 			if err != nil {
 				return fmt.Errorf("failed to convert node %s: %w", machine.Name, err)
 			}
 
-			ip = kubeapinodes.GetNodeIP(newNode, corev1.NodeExternalIP)
-			if ip == "" {
-				ip = kubeapinodes.GetNodeIP(newNode, corev1.NodeInternalIP)
+			nodeIP = kubeapinodes.GetNodeIP(newNode, corev1.NodeExternalIP)
+			if nodeIP == "" {
+				nodeIP = kubeapinodes.GetNodeIP(newNode, corev1.NodeInternalIP)
 			}
 		}
 
-		logrus.Debugf("Curling '%s:%d/name.html' from node %s", ip, port, machine.Name)
-		log, err := sshNode.ExecuteCommand(fmt.Sprintf("curl -s %s:%d/name.html", ip, port))
+		logrus.Infof("Curling '%s:%d/name.html' from node %s", nodeIP, port, machine.Name)
+		log, err := sshNode.ExecuteCommand(fmt.Sprintf("curl -s %s:%d/name.html", nodeIP, port))
 		if err != nil && !errors.Is(err, &ssh.ExitMissingError{}) {
-			logrus.Debugf("Curl failed on node %s: %v", machine.Name, err)
+			logrus.Infof("Curl failed on node %s: %v", machine.Name, err)
 			continue
 		}
 
 		if strings.Contains(log, workloadName) { // This should be one of the pod's names.
 			return nil
 		} else {
-			logrus.Debugf("Curl result %s doesn't contain expected content '%s'", log, workloadName)
+			logrus.Infof("Curl result %s doesn't contain expected content '%s'", log, workloadName)
 		}
 	}
 
-	return fmt.Errorf("Unable to connect to %s:%d/name.html from any worker node", ip, port)
+	return fmt.Errorf("Unable to connect to %s:%d/name.html from any worker node using SSH", ip, port)
 }
 
 func verifyConnectivityFromPod(client *rancher.Client, clusterID string, ip string, port int, workloadName string) error {
@@ -159,7 +160,6 @@ func verifyConnectivityFromPod(client *rancher.Client, clusterID string, ip stri
 }
 
 // VerifyLoadBalancerConnectivity verifies that the Load Balancer service is accessible by curling its IP:port.
-// This includes
 func VerifyLoadBalancerConnectivity(client *rancher.Client, clusterID string, serviceID string, workloadName string) error {
 	steveClient, err := client.Steve.ProxyDownstream(clusterID)
 	if err != nil {
@@ -186,7 +186,12 @@ func VerifyLoadBalancerConnectivity(client *rancher.Client, clusterID string, se
 	}
 
 	port := k8sService.Spec.Ports[0].Port
-	ip := k8sService.Status.LoadBalancer.Ingress[0].IP
+	ingress := k8sService.Status.LoadBalancer.Ingress[0]
+	ip := ingress.IP
+	if ip == "" {
+		ip = ingress.Hostname
+	}
+
 	logrus.Infof("Testing connectivity with load balancer %s by curling %s:%d/name.html", k8sService.Name, ip, port)
 
 	return verifyConnectivityFromPod(client, clusterID, ip, int(port), workloadName)

--- a/actions/networking/verify.go
+++ b/actions/networking/verify.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-	"testing"
 
 	"github.com/rancher/shepherd/clients/rancher"
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
@@ -15,7 +14,6 @@ import (
 	"github.com/rancher/shepherd/extensions/sshkeys"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -87,9 +85,9 @@ func VerifyNetworkPolicy(client *rancher.Client, clusterID string, namespaceName
 	return nil
 }
 
-// verifyConnectivityFromWorkerNodes verifies if any worker node in the cluster is able to access the provided ip:port
-// and retrieve the expected content from name.html.
-func verifyConnectivityFromWorkerNodes(client *rancher.Client, clusterID string, ip string, port int, workloadName string) error {
+// VerifyConnectivityFromWorkerNodes verifies if any worker node in the cluster is able to access the provided ip:port
+// and retrieve the expected content from name.html. Each node's own ip is used as default if no address is provided.
+func VerifyConnectivityFromWorkerNodes(client *rancher.Client, clusterID string, ip string, port int, workloadName string) error {
 	query, err := url.ParseQuery(clusters.LabelWorker)
 	if err != nil {
 		return err
@@ -114,6 +112,19 @@ func verifyConnectivityFromWorkerNodes(client *rancher.Client, clusterID string,
 		if err != nil {
 			logrus.Debugf("Could not SSH into worker node %s: %s", machine.Name, err.Error())
 			continue
+		}
+
+		if ip == "" {
+			newNode := &corev1.Node{}
+			err = v1.ConvertToK8sType(machine.JSONResp, newNode)
+			if err != nil {
+				return fmt.Errorf("failed to convert node %s: %w", machine.Name, err)
+			}
+
+			ip = kubeapinodes.GetNodeIP(newNode, corev1.NodeExternalIP)
+			if ip == "" {
+				ip = kubeapinodes.GetNodeIP(newNode, corev1.NodeInternalIP)
+			}
 		}
 
 		logrus.Debugf("Curling '%s:%d/name.html' from node %s", ip, port, machine.Name)
@@ -147,73 +158,38 @@ func verifyConnectivityFromPod(client *rancher.Client, clusterID string, ip stri
 	return nil
 }
 
-// VerifyNodePortConnectivity verifies that the node port is accessible by curling the worker node external IP
-func VerifyNodePortConnectivity(client *rancher.Client, clusterID string, nodePort int, workloadName string) error {
+// VerifyLoadBalancerConnectivity verifies that the Load Balancer service is accessible by curling its IP:port.
+// This includes
+func VerifyLoadBalancerConnectivity(client *rancher.Client, clusterID string, serviceID string, workloadName string) error {
 	steveClient, err := client.Steve.ProxyDownstream(clusterID)
 	if err != nil {
 		return err
 	}
 
-	query, err := url.ParseQuery(clusters.LabelWorker)
-	if err != nil {
-		return fmt.Errorf("failed to build worker node query: %w", err)
-	}
-
-	nodeList, err := steveClient.SteveType(stevetypes.Node).List(query)
-	if err != nil {
-		return fmt.Errorf("failed to list worker nodes: %w", err)
-	}
-
-	if len(nodeList.Data) == 0 {
-		return errors.New("no worker nodes found")
-	}
-
-	for _, machine := range nodeList.Data {
-		newNode := &corev1.Node{}
-		err = v1.ConvertToK8sType(machine.JSONResp, newNode)
-		if err != nil {
-			return fmt.Errorf("failed to convert node %s: %w", machine.Name, err)
-		}
-
-		nodeIP := kubeapinodes.GetNodeIP(newNode, corev1.NodeExternalIP)
-		if nodeIP == "" {
-			nodeIP = kubeapinodes.GetNodeIP(newNode, corev1.NodeInternalIP)
-		}
-
-		logrus.Debugf("Curling node port %d on node %s (%s)", nodePort, machine.Name, nodeIP)
-		verifyConnectivityFromPod(client, clusterID, nodeIP, nodePort, workloadName)
-	}
-
-	return fmt.Errorf("unable to access node port %d for workload %s", nodePort, workloadName)
-}
-
-// VerifyLoadBalancerConnectivity verifies that the Load Balancer service is accessible by curling its IP:port.
-// This includes
-func VerifyLoadBalancerConnectivity(t *testing.T, client *rancher.Client, clusterID string, serviceID string, workloadName string) {
-	steveClient, err := client.Steve.ProxyDownstream(clusterID)
-	require.NoError(t, err)
-
 	service, err := steveClient.SteveType(stevetypes.Service).ByID(serviceID)
-	require.NoError(t, err)
+	if err != nil {
+		return err
+	}
 
 	k8sService := &corev1.Service{}
-	err = v1.ConvertToK8sType(service, k8sService)
-	require.NoError(t, err)
-	require.Equal(t, corev1.ServiceTypeLoadBalancer, k8sService.Spec.Type)
-	require.NotEmpty(t, k8sService.Spec.Ports)
-	require.NotEmpty(t, k8sService.Status.LoadBalancer.Ingress)
+	err = v1.ConvertToK8sType(service.JSONResp, k8sService)
+	if err != nil {
+		return err
+	}
+
+	if len(k8sService.Spec.Ports) == 0 {
+		return fmt.Errorf("No ports (Spec.Ports) specified in service %s", k8sService.Name)
+	}
+
+	if len(k8sService.Status.LoadBalancer.Ingress) == 0 {
+		return fmt.Errorf("No ingress (Status.LoadBalancer.Ingress) specified in service %s", k8sService.Name)
+	}
 
 	port := k8sService.Spec.Ports[0].Port
 	ip := k8sService.Status.LoadBalancer.Ingress[0].IP
-	t.Logf("Testing connectivity with load balancer %s by curling %s:%d/name.html", k8sService.Name, ip, port)
+	logrus.Infof("Testing connectivity with load balancer %s by curling %s:%d/name.html", k8sService.Name, ip, port)
 
-	err = verifyConnectivityFromPod(client, clusterID, ip, int(port), workloadName)
-	require.NoError(t, err)
-}
-
-// VerifyHostPortConnectivity verifies that the host port is accessible on worker nodes by SSHing directly into each node
-func VerifyHostPortConnectivity(client *rancher.Client, clusterID string, hostPort int, workloadName string) error {
-	return verifyConnectivityFromWorkerNodes(client, clusterID, "localhost", hostPort, workloadName)
+	return verifyConnectivityFromPod(client, clusterID, ip, int(port), workloadName)
 }
 
 // VerifyClusterConnectivity verifies that the ClusterIP service is accessible via SSH from a worker node
@@ -234,5 +210,5 @@ func VerifyClusterConnectivity(client *rancher.Client, clusterID string, service
 		return err
 	}
 
-	return verifyConnectivityFromWorkerNodes(client, clusterID, newService.Spec.ClusterIP, port, content)
+	return VerifyConnectivityFromWorkerNodes(client, clusterID, newService.Spec.ClusterIP, port, content)
 }

--- a/actions/workloads/deployment/verify.go
+++ b/actions/workloads/deployment/verify.go
@@ -384,11 +384,12 @@ func VerifyDeploymentPodScaleDown(client *rancher.Client, clusterID, namespace, 
 		return err
 	}
 
-	logrus.Debugf("Updating deployment (%s) replicas from %v to %v", deployment.Name, *deployment.Spec.Replicas, *deployment.Spec.Replicas-1)
 	replicas := int32(*deployment.Spec.Replicas - 1)
 	if replicas < 0 {
 		return errors.New("Can't scale down a deployment with 0 replicas")
 	}
+
+	logrus.Debugf("Updating deployment (%s) replicas from %v to %v", deployment.Name, *deployment.Spec.Replicas, replicas)
 	deployment.Spec.Replicas = &replicas
 
 	deployment, err = extdeploymentsapi.UpdateDeployment(client, clusterID, deployment, true)

--- a/validation/charts/appco/schemas/pit_schemas.yaml
+++ b/validation/charts/appco/schemas/pit_schemas.yaml
@@ -1,4 +1,4 @@
-- projects: [RANCHERINT]
+- projects: [ RANCHERINT ]
   suite: AppCo
   cases:
   - title: "Install in SideCar Mode"

--- a/validation/charts/schemas/pit_schemas.yaml
+++ b/validation/charts/schemas/pit_schemas.yaml
@@ -1,4 +1,4 @@
-- projects: [RANCHERINT]
+- projects: [ RANCHERINT ]
   suite: Charts
   cases:
   - title: "CIS Benchmark Chart Installation and Scan"
@@ -36,7 +36,7 @@
       expectedresult: "The 'System' project is successfully created"
       position: 2
     - action: "Install Rancher Alerting chart"
-      data: "helm install rancher-alerting-drivers --namespace=default"
+      data: "helm install rancher-alerting-drivers --namespace=cattle-monitoring-system"
       expectedresult: "Alerting chart installation starts successfully"
       position: 3
     - action: "Wait for Alerting deployments"
@@ -107,10 +107,10 @@
       expectedresult: "Install payload prepared successfully"
       position: 5
     - action: "Install NeuVector charts"
-      data: "Install neuvector, neuvector-monitor, and neuvector-crd charts"
+      data: "Install neuvector and neuvector-crd charts"
       expectedresult: "All NeuVector charts installed successfully"
       position: 6
-    - action: "Wait for neuvector, neuvector-monitor, and neuvector-crd charts installations to complete"
+    - action: "Wait for neuvector and neuvector-crd charts installations to complete"
       expectedresult: "Charts reports successful installations"
       position: 7
     - action: "Verify NeuVector deployments readiness"

--- a/validation/fleet/schemas/pit_schemas.yaml
+++ b/validation/fleet/schemas/pit_schemas.yaml
@@ -15,7 +15,7 @@
       position: 2
     - action: "Deploy a GitRepo object targetting the specified downstream cluster"
       data: "/validation/fleet/schemas/gitrepo.yaml"
-      expectedresult: "the gitRepo itself comes to an active state and the resources defined in the spec are created on the downstream cluster in the fleet-testns namespace"
+      expectedresult: "the gitRepo itself comes to an active state and the resources defined in the spec are created on the downstream cluster in the test namespace"
       position: 3
     custom_field:
       "15": "TestGitRepoDeployment"

--- a/validation/longhorn/schemas/pit_schemas.yaml
+++ b/validation/longhorn/schemas/pit_schemas.yaml
@@ -147,27 +147,27 @@
       data: ""
       expectedresult: "Manifest prepared with Longhorn PVC template"
       position: 1
-    - action: "Deploy StatefulSet with 3 replicas via Rancher or kubectl"
+    - action: "Deploy StatefulSet with 1 replica via Rancher"
       data: ""
       expectedresult: "StatefulSet deployment begins"
       position: 2
     - action: "Verify each pod gets dedicated persistent volume"
       data: ""
-      expectedresult: "3 volumes created, each attached to respective pod"
+      expectedresult: "1 volume created, attached to respective pod"
       position: 3
     - action: "Write unique test data to each pod's volume"
       data: ""
       expectedresult: "Data successfully written to all volumes"
       position: 4
-    - action: "Scale StatefulSet up to 5 replicas"
+    - action: "Scale StatefulSet up to number of nodes + 1"
       data: ""
       expectedresult: "Scaling operation succeeds"
       position: 5
     - action: "Verify new pods get new dedicated volumes"
       data: ""
-      expectedresult: "2 additional volumes created and attached"
+      expectedresult: "additional volumes equal to the number of nodes created and attached"
       position: 6
-    - action: "Scale StatefulSet down to 2 replicas"
+    - action: "Scale StatefulSet down to 1 replica"
       data: ""
       expectedresult: "Scaling down completes"
       position: 7
@@ -801,7 +801,7 @@
       data: ""
       expectedresult: "Workload uses encrypted volume"
       position: 3
-    - action: "Verify volume shows as encrypted in Longhorn UI"
+    - action: "Verify volume shows as encrypted in Longhorn API"
       data: ""
       expectedresult: "Volume displays encryption status"
       position: 4

--- a/validation/networking/connectivity/port_test.go
+++ b/validation/networking/connectivity/port_test.go
@@ -3,7 +3,6 @@
 package connectivity
 
 import (
-	"fmt"
 	"math/rand"
 	"os"
 	"strings"
@@ -215,7 +214,7 @@ func (p *PortTestSuite) TestClusterIP() {
 			require.NoError(p.T(), err)
 
 			logrus.Infof("Verifying Cluster connectivity for daemonset %s on port %d", testDaemonset.Name, port)
-			err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, fmt.Sprintf("%d/name.html", port), testDaemonset.Name)
+			err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, port, testDaemonset.Name)
 			require.NoError(p.T(), err)
 		})
 	}
@@ -320,7 +319,7 @@ func (p *PortTestSuite) TestClusterIPScaleAndUpgrade() {
 			require.NoError(p.T(), err)
 
 			logrus.Infof("Verifying cluster IP connectivity after scale up for deployment %s", testDeployment.Name)
-			err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, fmt.Sprintf("%d/name.html", port), testDeployment.Name)
+			err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, port, testDeployment.Name)
 			require.NoError(p.T(), err)
 
 			logrus.Infof("Scaling down deployment %s to 2 replicas", testDeployment.Name)
@@ -330,7 +329,7 @@ func (p *PortTestSuite) TestClusterIPScaleAndUpgrade() {
 			require.NoError(p.T(), err)
 
 			logrus.Infof("Verifying cluster IP connectivity after scale down for deployment %s", testDeployment.Name)
-			err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, fmt.Sprintf("%d/name.html", port), testDeployment.Name)
+			err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, port, testDeployment.Name)
 			require.NoError(p.T(), err)
 
 			logrus.Infof("Upgrading deployment %s container", testDeployment.Name)
@@ -339,7 +338,7 @@ func (p *PortTestSuite) TestClusterIPScaleAndUpgrade() {
 			require.NoError(p.T(), err)
 
 			logrus.Infof("Verifying cluster IP connectivity after upgrade for deployment %s", testDeployment.Name)
-			err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, fmt.Sprintf("%d/name.html", port), testDeployment.Name)
+			err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, port, testDeployment.Name)
 			require.NoError(p.T(), err)
 		})
 	}

--- a/validation/networking/connectivity/port_test.go
+++ b/validation/networking/connectivity/port_test.go
@@ -222,61 +222,49 @@ func (p *PortTestSuite) TestClusterIP() {
 }
 
 func (p *PortTestSuite) TestLoadBalancer() {
-	loadBalancerTests := []struct {
-		name string
-	}{
-		{"Load_Balancer_Connectivity"},
+	isEnabled, err := cloudprovider.IsCloudProviderEnabled(p.client, p.cluster.ID)
+	require.NoError(p.T(), err)
+
+	if !isEnabled {
+		p.T().Skip("Load Balance test requires access to cloud provider.")
 	}
 
-	for _, loadBalancerTest := range loadBalancerTests {
-		p.Suite.Run(loadBalancerTest.name, func() {
-			isEnabled, err := cloudprovider.IsCloudProviderEnabled(p.client, p.cluster.ID)
-			require.NoError(p.T(), err)
+	workloadConfigs := new(workloads.Workloads)
+	operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
 
-			if !isEnabled {
-				p.T().Skip("Load Balance test requires access to cloud provider.")
-			}
+	port := rand.Intn(55283) + 10251
+	nodePort := rand.Intn(2767) + 30000
 
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
+	workloadConfigs.DaemonSet.ObjectMeta.Namespace = p.namespace.Name
+	workloadConfigs.DaemonSet.ObjectMeta.GenerateName = "load-balancer-connectivity-"
 
-			port := rand.Intn(55283) + 10251
-			nodePort := rand.Intn(2767) + 30000
+	logrus.Infof("Creating daemonset with name prefix: %s", workloadConfigs.DaemonSet.ObjectMeta.GenerateName)
+	testDaemonset, err := daemonset.CreateDaemonSetFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.DaemonSet)
+	require.NoError(p.T(), err)
 
-			workloadConfigs.DaemonSet.ObjectMeta.Namespace = p.namespace.Name
-			workloadConfigs.DaemonSet.ObjectMeta.GenerateName = "load-balancer-connectivity-"
+	logrus.Infof("Verifying daemonset %s is running", testDaemonset.Name)
+	err = extdaemonsetapi.WaitForDaemonSetReady(p.client, p.cluster.ID, p.namespace.Name, testDaemonset.Name)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Creating daemonset with name prefix: %s", workloadConfigs.DaemonSet.ObjectMeta.GenerateName)
-			testDaemonset, err := daemonset.CreateDaemonSetFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.DaemonSet)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying daemonset %s is running", testDaemonset.Name)
-			err = extdaemonsetapi.WaitForDaemonSetReady(p.client, p.cluster.ID, p.namespace.Name, testDaemonset.Name)
-			require.NoError(p.T(), err)
-
-			serviceName := namegen.AppendRandomString("test-service")
-			logrus.Infof("Creating LoadBalancer service %s on ports %d/%d", serviceName, port, nodePort)
-			ports := []corev1.ServicePort{
-				{
-					Protocol:   corev1.ProtocolTCP,
-					Port:       int32(port),
-					TargetPort: intstr.FromInt(defaultPort),
-					NodePort:   int32(nodePort),
-				},
-			}
-			lbService := servicesapi.NewServiceTemplate(serviceName, p.namespace.Name, corev1.ServiceTypeLoadBalancer, ports, workloadConfigs.DaemonSet.Spec.Template.Labels)
-			serviceResp, err := services.CreateService(p.downstreamClient, lbService)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying service %s is ready", serviceResp.Name)
-			err = services.VerifyService(p.downstreamClient, serviceResp)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying load balancer connectivity for daemonset %s on node port %d", testDaemonset.Name, nodePort)
-			err = networking.VerifyNodePortConnectivity(p.client, p.cluster.ID, nodePort, testDaemonset.Name)
-			require.NoError(p.T(), err)
-		})
+	serviceName := namegen.AppendRandomString("test-service")
+	logrus.Infof("Creating LoadBalancer service %s on ports %d/%d", serviceName, port, nodePort)
+	ports := []corev1.ServicePort{
+		{
+			Protocol:   corev1.ProtocolTCP,
+			Port:       int32(port),
+			TargetPort: intstr.FromInt(defaultPort),
+			NodePort:   int32(nodePort),
+		},
 	}
+	lbService := servicesapi.NewServiceTemplate(serviceName, p.namespace.Name, corev1.ServiceTypeLoadBalancer, ports, workloadConfigs.DaemonSet.Spec.Template.Labels)
+	serviceResp, err := services.CreateService(p.downstreamClient, lbService)
+	require.NoError(p.T(), err)
+
+	logrus.Infof("Verifying service %s is ready", serviceResp.Name)
+	err = services.VerifyService(p.downstreamClient, serviceResp)
+	require.NoError(p.T(), err)
+
+	networking.VerifyLoadBalancerConnectivity(p.T(), p.client, p.cluster.ID, serviceResp.ID, testDaemonset.Name)
 }
 
 func (p *PortTestSuite) TestClusterIPScaleAndUpgrade() {
@@ -508,90 +496,77 @@ func (p *PortTestSuite) TestNodePortScaleAndUpgrade() {
 }
 
 func (p *PortTestSuite) TestLoadBalanceScaleAndUpgrade() {
-	lbScaleTests := []struct {
-		name string
-	}{
-		{"Load_Balance_Scale_And_Upgrade"},
+	isEnabled, err := cloudprovider.IsCloudProviderEnabled(p.client, p.cluster.ID)
+	require.NoError(p.T(), err)
+
+	if !isEnabled {
+		p.T().Skip("Load Balance test requires access to cloud provider.")
 	}
 
-	for _, tt := range lbScaleTests {
-		p.Suite.Run(tt.name, func() {
-			isEnabled, err := cloudprovider.IsCloudProviderEnabled(p.client, p.cluster.ID)
-			require.NoError(p.T(), err)
+	_, namespace, err := projectsapi.CreateProjectAndNamespace(p.client, p.cluster.ID)
+	require.NoError(p.T(), err)
 
-			if !isEnabled {
-				p.T().Skip("Load Balance test requires access to cloud provider.")
-			}
+	workloadConfigs := new(workloads.Workloads)
+	operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
 
-			_, namespace, err := projectsapi.CreateProjectAndNamespace(p.client, p.cluster.ID)
-			require.NoError(p.T(), err)
+	port := rand.Intn(55283) + 10251
+	nodePort := rand.Intn(2767) + 30000
+	replicas := int32(2)
+	workloadConfigs.Deployment.ObjectMeta.Namespace = namespace.Name
+	workloadConfigs.Deployment.ObjectMeta.GenerateName = "load-balance-scale-"
+	workloadConfigs.Deployment.Spec.Replicas = &replicas
 
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
+	logrus.Infof("Creating deployment with prefix: %s", workloadConfigs.Deployment.ObjectMeta.GenerateName)
+	testDeployment, err := deployment.CreateDeploymentFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.Deployment)
+	require.NoError(p.T(), err)
 
-			port := rand.Intn(55283) + 10251
-			nodePort := rand.Intn(2767) + 30000
-			replicas := int32(2)
-			workloadConfigs.Deployment.ObjectMeta.Namespace = namespace.Name
-			workloadConfigs.Deployment.ObjectMeta.GenerateName = "load-balance-scale-"
-			workloadConfigs.Deployment.Spec.Replicas = &replicas
+	logrus.Infof("Verifying deployment %s is running", testDeployment.Name)
+	err = deployment.VerifyDeployment(p.client, p.cluster.ID, testDeployment.Namespace, testDeployment.Name)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Creating deployment with prefix: %s", workloadConfigs.Deployment.ObjectMeta.GenerateName)
-			testDeployment, err := deployment.CreateDeploymentFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.Deployment)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying deployment %s is running", testDeployment.Name)
-			err = deployment.VerifyDeployment(p.client, p.cluster.ID, testDeployment.Namespace, testDeployment.Name)
-			require.NoError(p.T(), err)
-
-			serviceName := namegen.AppendRandomString("test-service")
-			logrus.Infof("Creating LoadBalancer service %s on ports %d/%d", serviceName, port, nodePort)
-			ports := []corev1.ServicePort{
-				{
-					Protocol:   corev1.ProtocolTCP,
-					Port:       int32(port),
-					TargetPort: intstr.FromInt(defaultPort),
-					NodePort:   int32(nodePort),
-				},
-			}
-			lbService := servicesapi.NewServiceTemplate(serviceName, namespace.Name, corev1.ServiceTypeLoadBalancer, ports, testDeployment.Spec.Template.Labels)
-			serviceResp, err := services.CreateService(p.downstreamClient, lbService)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying service %s is ready", serviceResp.Name)
-			err = services.VerifyService(p.downstreamClient, serviceResp)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Scaling up deployment %s to 3 replicas", testDeployment.Name)
-			replicas = 3
-			testDeployment.Spec.Replicas = &replicas
-			testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying load balancer connectivity after scale up for deployment %s", testDeployment.Name)
-			err = networking.VerifyNodePortConnectivity(p.client, p.cluster.ID, nodePort, testDeployment.Name)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Scaling down deployment %s to 2 replicas", testDeployment.Name)
-			replicas = 2
-			testDeployment.Spec.Replicas = &replicas
-			testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying load balancer connectivity after scale down for deployment %s", testDeployment.Name)
-			err = networking.VerifyNodePortConnectivity(p.client, p.cluster.ID, nodePort, testDeployment.Name)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Upgrading deployment %s container", testDeployment.Name)
-			testDeployment.Spec.Template.Spec.Containers[0].Name = namegen.AppendRandomString("test-upgrade")
-			testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying load balancer connectivity after upgrade for deployment %s", testDeployment.Name)
-			err = networking.VerifyNodePortConnectivity(p.client, p.cluster.ID, nodePort, testDeployment.Name)
-			require.NoError(p.T(), err)
-		})
+	serviceName := namegen.AppendRandomString("test-service")
+	logrus.Infof("Creating LoadBalancer service %s on ports %d/%d", serviceName, port, nodePort)
+	ports := []corev1.ServicePort{
+		{
+			Protocol:   corev1.ProtocolTCP,
+			Port:       int32(port),
+			TargetPort: intstr.FromInt(defaultPort),
+			NodePort:   int32(nodePort),
+		},
 	}
+	lbService := servicesapi.NewServiceTemplate(serviceName, namespace.Name, corev1.ServiceTypeLoadBalancer, ports, testDeployment.Spec.Template.Labels)
+	serviceResp, err := services.CreateService(p.downstreamClient, lbService)
+	require.NoError(p.T(), err)
+
+	logrus.Infof("Verifying service %s is ready", serviceResp.Name)
+	err = services.VerifyService(p.downstreamClient, serviceResp)
+	require.NoError(p.T(), err)
+
+	logrus.Infof("Scaling up deployment %s to 3 replicas", testDeployment.Name)
+	replicas = 3
+	testDeployment.Spec.Replicas = &replicas
+	testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
+	require.NoError(p.T(), err)
+
+	logrus.Infof("Verifying load balancer connectivity after scale up for deployment %s", testDeployment.Name)
+	networking.VerifyLoadBalancerConnectivity(p.T(), p.client, p.cluster.ID, serviceResp.ID, testDeployment.Name)
+
+	logrus.Infof("Scaling down deployment %s to 2 replicas", testDeployment.Name)
+	replicas = 2
+	testDeployment.Spec.Replicas = &replicas
+	testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
+	require.NoError(p.T(), err)
+
+	logrus.Infof("Verifying load balancer connectivity after scale down for deployment %s", testDeployment.Name)
+	networking.VerifyLoadBalancerConnectivity(p.T(), p.client, p.cluster.ID, serviceResp.ID, testDeployment.Name)
+
+	logrus.Infof("Upgrading deployment %s container", testDeployment.Name)
+	testDeployment.Spec.Template.Spec.Containers[0].Name = namegen.AppendRandomString("test-upgrade")
+	testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
+	require.NoError(p.T(), err)
+
+	logrus.Infof("Verifying load balancer connectivity after upgrade for deployment %s", testDeployment.Name)
+	networking.VerifyLoadBalancerConnectivity(p.T(), p.client, p.cluster.ID, serviceResp.ID, testDeployment.Name)
 }
 
 func TestPortTestSuite(t *testing.T) {

--- a/validation/networking/connectivity/port_test.go
+++ b/validation/networking/connectivity/port_test.go
@@ -89,135 +89,105 @@ func (p *PortTestSuite) SetupSuite() {
 }
 
 func (p *PortTestSuite) TestHostPort() {
-	networkPolicyTests := []struct {
-		name string
-	}{
-		{"Host_Port_Connectivity"},
-	}
+	workloadConfigs := new(workloads.Workloads)
+	operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
+	hostPort := rand.Intn(55283) + 10251
 
-	for _, networkPolicyTest := range networkPolicyTests {
-		p.Suite.Run(networkPolicyTest.name, func() {
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
-			hostPort := rand.Intn(55283) + 10251
+	workloadConfigs.DaemonSet.ObjectMeta.Namespace = p.namespace.Name
+	workloadConfigs.DaemonSet.ObjectMeta.GenerateName = "host-port-connectivity-"
+	workloadConfigs.DaemonSet.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{{
+		HostPort:      int32(hostPort),
+		ContainerPort: defaultPort,
+		Protocol:      corev1.ProtocolTCP,
+	}}
 
-			workloadConfigs.DaemonSet.ObjectMeta.Namespace = p.namespace.Name
-			workloadConfigs.DaemonSet.ObjectMeta.GenerateName = "host-port-connectivity-"
-			workloadConfigs.DaemonSet.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{{
-				HostPort:      int32(hostPort),
-				ContainerPort: defaultPort,
-				Protocol:      corev1.ProtocolTCP,
-			}}
+	logrus.Infof("Creating daemonset with name prefix: %s", workloadConfigs.DaemonSet.ObjectMeta.GenerateName)
+	testDaemonset, err := daemonset.CreateDaemonSetFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.DaemonSet)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Creating daemonset with name prefix: %s", workloadConfigs.DaemonSet.ObjectMeta.GenerateName)
-			testDaemonset, err := daemonset.CreateDaemonSetFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.DaemonSet)
-			require.NoError(p.T(), err)
+	logrus.Infof("Verifying daemonset %s is running", testDaemonset.Name)
+	err = extdaemonsetapi.WaitForDaemonSetReady(p.client, p.cluster.ID, p.namespace.Name, testDaemonset.Name)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Verifying daemonset %s is running", testDaemonset.Name)
-			err = extdaemonsetapi.WaitForDaemonSetReady(p.client, p.cluster.ID, p.namespace.Name, testDaemonset.Name)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying host port %d for daemonset %s", hostPort, testDaemonset.Name)
-			err = networking.VerifyHostPortConnectivity(p.client, p.cluster.ID, hostPort, testDaemonset.Name)
-			require.NoError(p.T(), err)
-		})
-	}
+	logrus.Infof("Verifying host port %d for daemonset %s", hostPort, testDaemonset.Name)
+	err = networking.VerifyConnectivityFromWorkerNodes(p.client, p.cluster.ID, "localhost", hostPort, testDaemonset.Name)
+	require.NoError(p.T(), err)
 }
 
 func (p *PortTestSuite) TestNodePort() {
-	nodePortTests := []struct {
-		name string
-	}{
-		{"Node_Port_Connectivity"},
+	workloadConfigs := new(workloads.Workloads)
+	operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
+	nodePort := rand.Intn(2767) + 30000
+
+	workloadConfigs.DaemonSet.ObjectMeta.Namespace = p.namespace.Name
+	workloadConfigs.DaemonSet.ObjectMeta.GenerateName = "node-port-connectivity-"
+
+	logrus.Infof("Creating daemonset with name prefix: %s", workloadConfigs.DaemonSet.ObjectMeta.GenerateName)
+	testDaemonset, err := daemonset.CreateDaemonSetFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.DaemonSet)
+	require.NoError(p.T(), err)
+
+	logrus.Infof("Verifying daemonset %s is running", testDaemonset.Name)
+	err = extdaemonsetapi.WaitForDaemonSetReady(p.client, p.cluster.ID, p.namespace.Name, testDaemonset.Name)
+	require.NoError(p.T(), err)
+
+	serviceName := namegen.AppendRandomString("test-service")
+	logrus.Infof("Creating NodePort service %s on port %d", serviceName, nodePort)
+	ports := []corev1.ServicePort{
+		{
+			Protocol: corev1.ProtocolTCP,
+			Port:     defaultPort,
+			NodePort: int32(nodePort),
+		},
 	}
+	nodePortService := servicesapi.NewServiceTemplate(serviceName, p.namespace.Name, corev1.ServiceTypeNodePort, ports, workloadConfigs.DaemonSet.Spec.Template.Labels)
+	serviceResp, err := services.CreateService(p.downstreamClient, nodePortService)
+	require.NoError(p.T(), err)
 
-	for _, nodePortTest := range nodePortTests {
-		p.Suite.Run(nodePortTest.name, func() {
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
-			nodePort := rand.Intn(2767) + 30000
+	logrus.Infof("Verifying service %s is ready", serviceResp.Name)
+	err = services.VerifyService(p.downstreamClient, serviceResp)
+	require.NoError(p.T(), err)
 
-			workloadConfigs.DaemonSet.ObjectMeta.Namespace = p.namespace.Name
-			workloadConfigs.DaemonSet.ObjectMeta.GenerateName = "node-port-connectivity-"
-
-			logrus.Infof("Creating daemonset with name prefix: %s", workloadConfigs.DaemonSet.ObjectMeta.GenerateName)
-			testDaemonset, err := daemonset.CreateDaemonSetFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.DaemonSet)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying daemonset %s is running", testDaemonset.Name)
-			err = extdaemonsetapi.WaitForDaemonSetReady(p.client, p.cluster.ID, p.namespace.Name, testDaemonset.Name)
-			require.NoError(p.T(), err)
-
-			serviceName := namegen.AppendRandomString("test-service")
-			logrus.Infof("Creating NodePort service %s on port %d", serviceName, nodePort)
-			ports := []corev1.ServicePort{
-				{
-					Protocol: corev1.ProtocolTCP,
-					Port:     defaultPort,
-					NodePort: int32(nodePort),
-				},
-			}
-			nodePortService := servicesapi.NewServiceTemplate(serviceName, p.namespace.Name, corev1.ServiceTypeNodePort, ports, workloadConfigs.DaemonSet.Spec.Template.Labels)
-			serviceResp, err := services.CreateService(p.downstreamClient, nodePortService)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying service %s is ready", serviceResp.Name)
-			err = services.VerifyService(p.downstreamClient, serviceResp)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying node port %d for daemonset %s", nodePort, testDaemonset.Name)
-			err = networking.VerifyNodePortConnectivity(p.client, p.cluster.ID, nodePort, testDaemonset.Name)
-			require.NoError(p.T(), err)
-		})
-	}
+	logrus.Infof("Verifying node port %d for daemonset %s", nodePort, testDaemonset.Name)
+	err = networking.VerifyConnectivityFromWorkerNodes(p.client, p.cluster.ID, "", nodePort, testDaemonset.Name)
+	require.NoError(p.T(), err)
 }
 
 func (p *PortTestSuite) TestClusterIP() {
-	clusterIPTests := []struct {
-		name string
-	}{
-		{"Cluster_IP_Connectivity"},
+	workloadConfigs := new(workloads.Workloads)
+	operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
+	port := rand.Intn(55283) + 10251
+
+	workloadConfigs.DaemonSet.ObjectMeta.Namespace = p.namespace.Name
+	workloadConfigs.DaemonSet.ObjectMeta.GenerateName = "cluster-ip-connectivity-"
+
+	logrus.Infof("Creating daemonset with name prefix: %s", workloadConfigs.DaemonSet.ObjectMeta.GenerateName)
+	testDaemonset, err := daemonset.CreateDaemonSetFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.DaemonSet)
+	require.NoError(p.T(), err)
+
+	logrus.Infof("Verifying daemonset %s is running", testDaemonset.Name)
+	err = extdaemonsetapi.WaitForDaemonSetReady(p.client, p.cluster.ID, p.namespace.Name, testDaemonset.Name)
+	require.NoError(p.T(), err)
+
+	serviceName := namegen.AppendRandomString("test-service")
+	logrus.Infof("Creating ClusterIP service %s on port %d", serviceName, port)
+	ports := []corev1.ServicePort{
+		{
+			Protocol:   corev1.ProtocolTCP,
+			Port:       int32(port),
+			TargetPort: intstr.FromInt(defaultPort),
+		},
 	}
+	clusterIPService := servicesapi.NewServiceTemplate(serviceName, p.namespace.Name, corev1.ServiceTypeClusterIP, ports, workloadConfigs.DaemonSet.Spec.Template.Labels)
+	serviceResp, err := services.CreateService(p.downstreamClient, clusterIPService)
+	require.NoError(p.T(), err)
 
-	for _, clusterIPTest := range clusterIPTests {
-		p.Suite.Run(clusterIPTest.name, func() {
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
-			port := rand.Intn(55283) + 10251
+	logrus.Infof("Verifying service %s is ready", serviceResp.Name)
+	err = services.VerifyService(p.downstreamClient, serviceResp)
+	require.NoError(p.T(), err)
 
-			workloadConfigs.DaemonSet.ObjectMeta.Namespace = p.namespace.Name
-			workloadConfigs.DaemonSet.ObjectMeta.GenerateName = "cluster-ip-connectivity-"
-
-			logrus.Infof("Creating daemonset with name prefix: %s", workloadConfigs.DaemonSet.ObjectMeta.GenerateName)
-			testDaemonset, err := daemonset.CreateDaemonSetFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.DaemonSet)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying daemonset %s is running", testDaemonset.Name)
-			err = extdaemonsetapi.WaitForDaemonSetReady(p.client, p.cluster.ID, p.namespace.Name, testDaemonset.Name)
-			require.NoError(p.T(), err)
-
-			serviceName := namegen.AppendRandomString("test-service")
-			logrus.Infof("Creating ClusterIP service %s on port %d", serviceName, port)
-			ports := []corev1.ServicePort{
-				{
-					Protocol:   corev1.ProtocolTCP,
-					Port:       int32(port),
-					TargetPort: intstr.FromInt(defaultPort),
-				},
-			}
-			clusterIPService := servicesapi.NewServiceTemplate(serviceName, p.namespace.Name, corev1.ServiceTypeClusterIP, ports, workloadConfigs.DaemonSet.Spec.Template.Labels)
-			serviceResp, err := services.CreateService(p.downstreamClient, clusterIPService)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying service %s is ready", serviceResp.Name)
-			err = services.VerifyService(p.downstreamClient, serviceResp)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying Cluster connectivity for daemonset %s on port %d", testDaemonset.Name, port)
-			err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, port, testDaemonset.Name)
-			require.NoError(p.T(), err)
-		})
-	}
+	logrus.Infof("Verifying Cluster connectivity for daemonset %s on port %d", testDaemonset.Name, port)
+	err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, port, testDaemonset.Name)
+	require.NoError(p.T(), err)
 }
 
 func (p *PortTestSuite) TestLoadBalancer() {
@@ -263,235 +233,206 @@ func (p *PortTestSuite) TestLoadBalancer() {
 	err = services.VerifyService(p.downstreamClient, serviceResp)
 	require.NoError(p.T(), err)
 
-	networking.VerifyLoadBalancerConnectivity(p.T(), p.client, p.cluster.ID, serviceResp.ID, testDaemonset.Name)
+	err = networking.VerifyLoadBalancerConnectivity(p.client, p.cluster.ID, serviceResp.ID, testDaemonset.Name)
+	require.NoError(p.T(), err)
 }
 
 func (p *PortTestSuite) TestClusterIPScaleAndUpgrade() {
-	clusterIPScaleTests := []struct {
-		name string
-	}{
-		{"Cluster_IP_Scale_And_Upgrade"},
+	_, namespace, err := projectsapi.CreateProjectAndNamespace(p.client, p.cluster.ID)
+	require.NoError(p.T(), err)
+
+	workloadConfigs := new(workloads.Workloads)
+	operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
+
+	replicas := int32(2)
+	port := rand.Intn(55283) + 10251
+	workloadConfigs.Deployment.ObjectMeta.Namespace = namespace.Name
+	workloadConfigs.Deployment.ObjectMeta.GenerateName = "cluster-ip-scale-"
+	workloadConfigs.Deployment.Spec.Replicas = &replicas
+
+	logrus.Infof("Creating deployment with prefix: %s", workloadConfigs.Deployment.ObjectMeta.GenerateName)
+	testDeployment, err := deployment.CreateDeploymentFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.Deployment)
+	require.NoError(p.T(), err)
+
+	logrus.Infof("Verifying deployment %s is running", testDeployment.Name)
+	err = deployment.VerifyDeployment(p.client, p.cluster.ID, testDeployment.Namespace, testDeployment.Name)
+	require.NoError(p.T(), err)
+
+	serviceName := namegen.AppendRandomString("test-service")
+	logrus.Infof("Creating ClusterIP service %s on port %d", serviceName, port)
+	ports := []corev1.ServicePort{
+		{
+			Protocol:   corev1.ProtocolTCP,
+			Port:       int32(port),
+			TargetPort: intstr.FromInt(defaultPort),
+		},
 	}
+	clusterIPService := servicesapi.NewServiceTemplate(serviceName, namespace.Name, corev1.ServiceTypeClusterIP, ports, testDeployment.Spec.Template.Labels)
+	serviceResp, err := services.CreateService(p.downstreamClient, clusterIPService)
+	require.NoError(p.T(), err)
 
-	for _, tt := range clusterIPScaleTests {
-		p.Suite.Run(tt.name, func() {
-			_, namespace, err := projectsapi.CreateProjectAndNamespace(p.client, p.cluster.ID)
-			require.NoError(p.T(), err)
+	logrus.Infof("Verifying service %s is ready", serviceResp.Name)
+	err = services.VerifyService(p.downstreamClient, serviceResp)
+	require.NoError(p.T(), err)
 
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
+	logrus.Infof("Scaling up deployment %s to 3 replicas", testDeployment.Name)
+	replicas = 3
+	testDeployment.Spec.Replicas = &replicas
+	testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
+	require.NoError(p.T(), err)
 
-			replicas := int32(2)
-			port := rand.Intn(55283) + 10251
-			workloadConfigs.Deployment.ObjectMeta.Namespace = namespace.Name
-			workloadConfigs.Deployment.ObjectMeta.GenerateName = "cluster-ip-scale-"
-			workloadConfigs.Deployment.Spec.Replicas = &replicas
+	logrus.Infof("Verifying cluster IP connectivity after scale up for deployment %s", testDeployment.Name)
+	err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, port, testDeployment.Name)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Creating deployment with prefix: %s", workloadConfigs.Deployment.ObjectMeta.GenerateName)
-			testDeployment, err := deployment.CreateDeploymentFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.Deployment)
-			require.NoError(p.T(), err)
+	logrus.Infof("Scaling down deployment %s to 2 replicas", testDeployment.Name)
+	replicas = 2
+	testDeployment.Spec.Replicas = &replicas
+	testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Verifying deployment %s is running", testDeployment.Name)
-			err = deployment.VerifyDeployment(p.client, p.cluster.ID, testDeployment.Namespace, testDeployment.Name)
-			require.NoError(p.T(), err)
+	logrus.Infof("Verifying cluster IP connectivity after scale down for deployment %s", testDeployment.Name)
+	err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, port, testDeployment.Name)
+	require.NoError(p.T(), err)
 
-			serviceName := namegen.AppendRandomString("test-service")
-			logrus.Infof("Creating ClusterIP service %s on port %d", serviceName, port)
-			ports := []corev1.ServicePort{
-				{
-					Protocol:   corev1.ProtocolTCP,
-					Port:       int32(port),
-					TargetPort: intstr.FromInt(defaultPort),
-				},
-			}
-			clusterIPService := servicesapi.NewServiceTemplate(serviceName, namespace.Name, corev1.ServiceTypeClusterIP, ports, testDeployment.Spec.Template.Labels)
-			serviceResp, err := services.CreateService(p.downstreamClient, clusterIPService)
-			require.NoError(p.T(), err)
+	logrus.Infof("Upgrading deployment %s container", testDeployment.Name)
+	testDeployment.Spec.Template.Spec.Containers[0].Name = namegen.AppendRandomString("test-upgrade")
+	testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Verifying service %s is ready", serviceResp.Name)
-			err = services.VerifyService(p.downstreamClient, serviceResp)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Scaling up deployment %s to 3 replicas", testDeployment.Name)
-			replicas = 3
-			testDeployment.Spec.Replicas = &replicas
-			testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying cluster IP connectivity after scale up for deployment %s", testDeployment.Name)
-			err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, port, testDeployment.Name)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Scaling down deployment %s to 2 replicas", testDeployment.Name)
-			replicas = 2
-			testDeployment.Spec.Replicas = &replicas
-			testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying cluster IP connectivity after scale down for deployment %s", testDeployment.Name)
-			err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, port, testDeployment.Name)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Upgrading deployment %s container", testDeployment.Name)
-			testDeployment.Spec.Template.Spec.Containers[0].Name = namegen.AppendRandomString("test-upgrade")
-			testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying cluster IP connectivity after upgrade for deployment %s", testDeployment.Name)
-			err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, port, testDeployment.Name)
-			require.NoError(p.T(), err)
-		})
-	}
+	logrus.Infof("Verifying cluster IP connectivity after upgrade for deployment %s", testDeployment.Name)
+	err = networking.VerifyClusterConnectivity(p.client, p.cluster.ID, serviceResp.ID, port, testDeployment.Name)
+	require.NoError(p.T(), err)
 }
 
 func (p *PortTestSuite) TestHostPortScaleAndUpgrade() {
-	hostPortScaleTests := []struct {
-		name string
-	}{
-		{"Host_Port_Scale_And_Upgrade"},
+	err := clusters.VerifyNodePoolSize(p.downstreamClient, clusters.LabelWorker, nodePoolsize)
+	if err != nil && strings.Contains(err.Error(), clusters.SmallerPoolMessageError) {
+		p.T().Skip("The Host Port scale up/down test requires at least 3 worker nodes")
 	}
+	require.NoError(p.T(), err)
 
-	for _, tt := range hostPortScaleTests {
-		p.Suite.Run(tt.name, func() {
-			err := clusters.VerifyNodePoolSize(p.downstreamClient, clusters.LabelWorker, nodePoolsize)
-			if err != nil && strings.Contains(err.Error(), clusters.SmallerPoolMessageError) {
-				p.T().Skip("The Host Port scale up/down test requires at least 3 worker nodes")
-			}
-			require.NoError(p.T(), err)
+	_, namespace, err := projectsapi.CreateProjectAndNamespace(p.client, p.cluster.ID)
+	require.NoError(p.T(), err)
 
-			_, namespace, err := projectsapi.CreateProjectAndNamespace(p.client, p.cluster.ID)
-			require.NoError(p.T(), err)
+	workloadConfigs := new(workloads.Workloads)
+	operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
 
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
+	hostPort := rand.Intn(55283) + 10251
+	replicas := int32(2)
+	workloadConfigs.Deployment.ObjectMeta.Namespace = namespace.Name
+	workloadConfigs.Deployment.ObjectMeta.GenerateName = "host-port-scale-"
+	workloadConfigs.Deployment.Spec.Replicas = &replicas
+	workloadConfigs.Deployment.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{{
+		HostPort:      int32(hostPort),
+		ContainerPort: defaultPort,
+		Protocol:      corev1.ProtocolTCP,
+	}}
 
-			hostPort := rand.Intn(55283) + 10251
-			replicas := int32(2)
-			workloadConfigs.Deployment.ObjectMeta.Namespace = namespace.Name
-			workloadConfigs.Deployment.ObjectMeta.GenerateName = "host-port-scale-"
-			workloadConfigs.Deployment.Spec.Replicas = &replicas
-			workloadConfigs.Deployment.Spec.Template.Spec.Containers[0].Ports = []corev1.ContainerPort{{
-				HostPort:      int32(hostPort),
-				ContainerPort: defaultPort,
-				Protocol:      corev1.ProtocolTCP,
-			}}
+	logrus.Infof("Creating deployment with prefix: %s", workloadConfigs.Deployment.ObjectMeta.GenerateName)
+	testDeployment, err := deployment.CreateDeploymentFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.Deployment)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Creating deployment with prefix: %s", workloadConfigs.Deployment.ObjectMeta.GenerateName)
-			testDeployment, err := deployment.CreateDeploymentFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.Deployment)
-			require.NoError(p.T(), err)
+	logrus.Infof("Verifying deployment %s is running", testDeployment.Name)
+	err = deployment.VerifyDeployment(p.client, p.cluster.ID, testDeployment.Namespace, testDeployment.Name)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Verifying deployment %s is running", testDeployment.Name)
-			err = deployment.VerifyDeployment(p.client, p.cluster.ID, testDeployment.Namespace, testDeployment.Name)
-			require.NoError(p.T(), err)
+	logrus.Infof("Scaling up deployment %s to 3 replicas", testDeployment.Name)
+	replicas = 3
+	testDeployment.Spec.Replicas = &replicas
+	testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Scaling up deployment %s to 3 replicas", testDeployment.Name)
-			replicas = 3
-			testDeployment.Spec.Replicas = &replicas
-			testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
-			require.NoError(p.T(), err)
+	logrus.Infof("Verifying host port connectivity after scale up for deployment %s", testDeployment.Name)
+	err = networking.VerifyConnectivityFromWorkerNodes(p.client, p.cluster.ID, "localhost", hostPort, testDeployment.Name)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Verifying host port connectivity after scale up for deployment %s", testDeployment.Name)
-			err = networking.VerifyHostPortConnectivity(p.client, p.cluster.ID, hostPort, testDeployment.Name)
-			require.NoError(p.T(), err)
+	logrus.Infof("Scaling down deployment %s to 2 replicas", testDeployment.Name)
+	replicas = 2
+	testDeployment.Spec.Replicas = &replicas
+	testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Scaling down deployment %s to 2 replicas", testDeployment.Name)
-			replicas = 2
-			testDeployment.Spec.Replicas = &replicas
-			testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
-			require.NoError(p.T(), err)
+	logrus.Infof("Verifying host port connectivity after scale down for deployment %s", testDeployment.Name)
+	err = networking.VerifyConnectivityFromWorkerNodes(p.client, p.cluster.ID, "localhost", hostPort, testDeployment.Name)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Verifying host port connectivity after scale down for deployment %s", testDeployment.Name)
-			err = networking.VerifyHostPortConnectivity(p.client, p.cluster.ID, hostPort, testDeployment.Name)
-			require.NoError(p.T(), err)
+	logrus.Infof("Upgrading deployment %s container", testDeployment.Name)
+	testDeployment.Spec.Template.Spec.Containers[0].Name = namegen.AppendRandomString("test-upgrade")
+	testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Upgrading deployment %s container", testDeployment.Name)
-			testDeployment.Spec.Template.Spec.Containers[0].Name = namegen.AppendRandomString("test-upgrade")
-			testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying host port connectivity after upgrade for deployment %s", testDeployment.Name)
-			err = networking.VerifyHostPortConnectivity(p.client, p.cluster.ID, hostPort, testDeployment.Name)
-			require.NoError(p.T(), err)
-		})
-	}
+	logrus.Infof("Verifying host port connectivity after upgrade for deployment %s", testDeployment.Name)
+	err = networking.VerifyConnectivityFromWorkerNodes(p.client, p.cluster.ID, "localhost", hostPort, testDeployment.Name)
+	require.NoError(p.T(), err)
 }
 
 func (p *PortTestSuite) TestNodePortScaleAndUpgrade() {
-	nodePortScaleTests := []struct {
-		name string
-	}{
-		{"Node_Port_Scale_And_Upgrade"},
+	_, namespace, err := projectsapi.CreateProjectAndNamespace(p.client, p.cluster.ID)
+	require.NoError(p.T(), err)
+
+	workloadConfigs := new(workloads.Workloads)
+	operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
+
+	nodePort := rand.Intn(2767) + 30000
+	replicas := int32(2)
+	workloadConfigs.Deployment.ObjectMeta.Namespace = namespace.Name
+	workloadConfigs.Deployment.ObjectMeta.GenerateName = "node-port-scale-"
+	workloadConfigs.Deployment.Spec.Replicas = &replicas
+
+	logrus.Infof("Creating deployment with prefix: %s", workloadConfigs.Deployment.ObjectMeta.GenerateName)
+	testDeployment, err := deployment.CreateDeploymentFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.Deployment)
+	require.NoError(p.T(), err)
+
+	logrus.Infof("Verifying deployment %s is running", testDeployment.Name)
+	err = deployment.VerifyDeployment(p.client, p.cluster.ID, testDeployment.Namespace, testDeployment.Name)
+	require.NoError(p.T(), err)
+
+	serviceName := namegen.AppendRandomString("test-service")
+	logrus.Infof("Creating NodePort service %s on port %d", serviceName, nodePort)
+	ports := []corev1.ServicePort{
+		{
+			Protocol: corev1.ProtocolTCP,
+			Port:     defaultPort,
+			NodePort: int32(nodePort),
+		},
 	}
+	nodePortService := servicesapi.NewServiceTemplate(serviceName, namespace.Name, corev1.ServiceTypeNodePort, ports, testDeployment.Spec.Template.Labels)
+	serviceResp, err := services.CreateService(p.downstreamClient, nodePortService)
+	require.NoError(p.T(), err)
 
-	for _, tt := range nodePortScaleTests {
-		p.Suite.Run(tt.name, func() {
-			_, namespace, err := projectsapi.CreateProjectAndNamespace(p.client, p.cluster.ID)
-			require.NoError(p.T(), err)
+	logrus.Infof("Verifying service %s is ready", serviceResp.Name)
+	err = services.VerifyService(p.downstreamClient, serviceResp)
+	require.NoError(p.T(), err)
 
-			workloadConfigs := new(workloads.Workloads)
-			operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, p.cattleConfig, workloadConfigs)
+	logrus.Infof("Scaling up deployment %s to 3 replicas", testDeployment.Name)
+	replicas = 3
+	testDeployment.Spec.Replicas = &replicas
+	testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
+	require.NoError(p.T(), err)
 
-			nodePort := rand.Intn(2767) + 30000
-			replicas := int32(2)
-			workloadConfigs.Deployment.ObjectMeta.Namespace = namespace.Name
-			workloadConfigs.Deployment.ObjectMeta.GenerateName = "node-port-scale-"
-			workloadConfigs.Deployment.Spec.Replicas = &replicas
+	logrus.Infof("Verifying node port connectivity after scale up for deployment %s", testDeployment.Name)
+	err = networking.VerifyConnectivityFromWorkerNodes(p.client, p.cluster.ID, "", nodePort, testDeployment.Name)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Creating deployment with prefix: %s", workloadConfigs.Deployment.ObjectMeta.GenerateName)
-			testDeployment, err := deployment.CreateDeploymentFromConfig(p.downstreamClient, p.cluster.ID, workloadConfigs.Deployment)
-			require.NoError(p.T(), err)
+	logrus.Infof("Scaling down deployment %s to 2 replicas", testDeployment.Name)
+	replicas = 2
+	testDeployment.Spec.Replicas = &replicas
+	testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Verifying deployment %s is running", testDeployment.Name)
-			err = deployment.VerifyDeployment(p.client, p.cluster.ID, testDeployment.Namespace, testDeployment.Name)
-			require.NoError(p.T(), err)
+	logrus.Infof("Verifying node port connectivity after scale down for deployment %s", testDeployment.Name)
+	err = networking.VerifyConnectivityFromWorkerNodes(p.client, p.cluster.ID, "", nodePort, testDeployment.Name)
+	require.NoError(p.T(), err)
 
-			serviceName := namegen.AppendRandomString("test-service")
-			logrus.Infof("Creating NodePort service %s on port %d", serviceName, nodePort)
-			ports := []corev1.ServicePort{
-				{
-					Protocol: corev1.ProtocolTCP,
-					Port:     defaultPort,
-					NodePort: int32(nodePort),
-				},
-			}
-			nodePortService := servicesapi.NewServiceTemplate(serviceName, namespace.Name, corev1.ServiceTypeNodePort, ports, testDeployment.Spec.Template.Labels)
-			serviceResp, err := services.CreateService(p.downstreamClient, nodePortService)
-			require.NoError(p.T(), err)
+	logrus.Infof("Upgrading deployment %s container", testDeployment.Name)
+	testDeployment.Spec.Template.Spec.Containers[0].Name = namegen.AppendRandomString("test-upgrade")
+	testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
+	require.NoError(p.T(), err)
 
-			logrus.Infof("Verifying service %s is ready", serviceResp.Name)
-			err = services.VerifyService(p.downstreamClient, serviceResp)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Scaling up deployment %s to 3 replicas", testDeployment.Name)
-			replicas = 3
-			testDeployment.Spec.Replicas = &replicas
-			testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying node port connectivity after scale up for deployment %s", testDeployment.Name)
-			err = networking.VerifyNodePortConnectivity(p.client, p.cluster.ID, nodePort, testDeployment.Name)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Scaling down deployment %s to 2 replicas", testDeployment.Name)
-			replicas = 2
-			testDeployment.Spec.Replicas = &replicas
-			testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying node port connectivity after scale down for deployment %s", testDeployment.Name)
-			err = networking.VerifyNodePortConnectivity(p.client, p.cluster.ID, nodePort, testDeployment.Name)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Upgrading deployment %s container", testDeployment.Name)
-			testDeployment.Spec.Template.Spec.Containers[0].Name = namegen.AppendRandomString("test-upgrade")
-			testDeployment, err = extdeploymentapi.UpdateDeployment(p.client, p.cluster.ID, testDeployment, true)
-			require.NoError(p.T(), err)
-
-			logrus.Infof("Verifying node port connectivity after upgrade for deployment %s", testDeployment.Name)
-			err = networking.VerifyNodePortConnectivity(p.client, p.cluster.ID, nodePort, testDeployment.Name)
-			require.NoError(p.T(), err)
-		})
-	}
+	logrus.Infof("Verifying node port connectivity after upgrade for deployment %s", testDeployment.Name)
+	err = networking.VerifyConnectivityFromWorkerNodes(p.client, p.cluster.ID, "", nodePort, testDeployment.Name)
+	require.NoError(p.T(), err)
 }
 
 func (p *PortTestSuite) TestLoadBalanceScaleAndUpgrade() {
@@ -548,7 +489,8 @@ func (p *PortTestSuite) TestLoadBalanceScaleAndUpgrade() {
 	require.NoError(p.T(), err)
 
 	logrus.Infof("Verifying load balancer connectivity after scale up for deployment %s", testDeployment.Name)
-	networking.VerifyLoadBalancerConnectivity(p.T(), p.client, p.cluster.ID, serviceResp.ID, testDeployment.Name)
+	err = networking.VerifyLoadBalancerConnectivity(p.client, p.cluster.ID, serviceResp.ID, testDeployment.Name)
+	require.NoError(p.T(), err)
 
 	logrus.Infof("Scaling down deployment %s to 2 replicas", testDeployment.Name)
 	replicas = 2
@@ -557,7 +499,8 @@ func (p *PortTestSuite) TestLoadBalanceScaleAndUpgrade() {
 	require.NoError(p.T(), err)
 
 	logrus.Infof("Verifying load balancer connectivity after scale down for deployment %s", testDeployment.Name)
-	networking.VerifyLoadBalancerConnectivity(p.T(), p.client, p.cluster.ID, serviceResp.ID, testDeployment.Name)
+	err = networking.VerifyLoadBalancerConnectivity(p.client, p.cluster.ID, serviceResp.ID, testDeployment.Name)
+	require.NoError(p.T(), err)
 
 	logrus.Infof("Upgrading deployment %s container", testDeployment.Name)
 	testDeployment.Spec.Template.Spec.Containers[0].Name = namegen.AppendRandomString("test-upgrade")
@@ -565,7 +508,8 @@ func (p *PortTestSuite) TestLoadBalanceScaleAndUpgrade() {
 	require.NoError(p.T(), err)
 
 	logrus.Infof("Verifying load balancer connectivity after upgrade for deployment %s", testDeployment.Name)
-	networking.VerifyLoadBalancerConnectivity(p.T(), p.client, p.cluster.ID, serviceResp.ID, testDeployment.Name)
+	err = networking.VerifyLoadBalancerConnectivity(p.client, p.cluster.ID, serviceResp.ID, testDeployment.Name)
+	require.NoError(p.T(), err)
 }
 
 func TestPortTestSuite(t *testing.T) {

--- a/validation/upgrade/schemas/pit_schemas.yaml
+++ b/validation/upgrade/schemas/pit_schemas.yaml
@@ -1,4 +1,4 @@
-- projects: [RANCHERINT]
+- projects: [ RANCHERINT ]
   suite: Workload
   cases:
   - title: "Pre-Upgrade cluster"
@@ -30,6 +30,6 @@
       position: 2
     - action: "Upgrade the K8s version of the downstream cluster"
       expectedresult: "Validate that the upgrade was successful"
-      position: 4
+      position: 3
     custom_field:
       "15": "TestWorkloadPostUpgrade"

--- a/validation/workloads/schemas/pit_schemas.yaml
+++ b/validation/workloads/schemas/pit_schemas.yaml
@@ -1,4 +1,4 @@
-- projects: [RANCHERINT]
+- projects: [ RANCHERINT ]
   suite: Workload
   cases:
   - title: "Create Deployment workload"
@@ -165,9 +165,6 @@
       position: 3
     - action: "Scale Deployment to 2 replicas"
       expectedresult: "Pods available and running"
-      position: 4
-    - action: "Scale Deployment to 3 replicas"
-      expectedresult: "Pods available and running"
       position: 5
     custom_field:
       "15": "WorkloadPodScaleUpTest"
@@ -187,9 +184,6 @@
       expectedresult: "Deployment created successfully"
       position: 3
     - action: "Scale Deployment to 2 replicas"
-      expectedresult: "Deployment scaled successfully"
-      position: 4
-    - action: "Scale Deployment to 1 replica"
       expectedresult: "Deployment scaled successfully"
       position: 5
     custom_field:

--- a/validation/workloads/workload_test.go
+++ b/validation/workloads/workload_test.go
@@ -83,15 +83,14 @@ func (w *WorkloadTestSuite) TestDeployments() {
 		name       string
 		replicas   int32
 		image      string
-		createFunc func(client *v1.Client, clusterID string, deployment *appv1.Deployment) (*appv1.Deployment, error)
 		verifyFunc func(client *rancher.Client, clusterID, namespace, name string) error
 	}{
-		{"WorkloadDeploymentTest", 1, "nginx:latest", deployment.CreateDeploymentFromConfig, deployment.VerifyDeployment},
-		{"WorkloadSideKickTest", 1, "redis", deployment.CreateDeploymentFromConfig, deployment.VerifyDeploymentSideKick},
-		{"WorkloadUpgradeTest", 1, "nginx:latest", deployment.CreateDeploymentFromConfig, deployment.VerifyDeploymentUpgradeRollback},
-		{"WorkloadPodScaleUpTest", 1, "nginx:latest", deployment.CreateDeploymentFromConfig, deployment.VerifyDeploymentPodScaleUp},
-		{"WorkloadPodScaleDownTest", 3, "nginx:latest", deployment.CreateDeploymentFromConfig, deployment.VerifyDeploymentPodScaleDown},
-		{"WorkloadPauseOrchestrationTest", 1, "nginx:latest", deployment.CreateDeploymentFromConfig, deployment.VerifyDeploymentOrchestration},
+		{"WorkloadDeploymentTest", 1, "nginx:latest", deployment.VerifyDeployment},
+		{"WorkloadSideKickTest", 1, "redis", deployment.VerifyDeploymentSideKick},
+		{"WorkloadUpgradeTest", 1, "nginx:latest", deployment.VerifyDeploymentUpgradeRollback},
+		{"WorkloadPodScaleUpTest", 1, "nginx:latest", deployment.VerifyDeploymentPodScaleUp},
+		{"WorkloadPodScaleDownTest", 3, "nginx:latest", deployment.VerifyDeploymentPodScaleDown},
+		{"WorkloadPauseOrchestrationTest", 1, "nginx:latest", deployment.VerifyDeploymentOrchestration},
 	}
 
 	for _, workloadTest := range workloadTests {
@@ -108,7 +107,7 @@ func (w *WorkloadTestSuite) TestDeployments() {
 			workloadConfigs.Deployment.ObjectMeta.GenerateName = strings.ToLower(workloadTest.name) + "-"
 
 			logrus.Infof("Creating deployment with name prefix: %s", workloadConfigs.Deployment.ObjectMeta.GenerateName)
-			testDeployment, err := workloadTest.createFunc(w.downstreamClient, w.cluster.ID, workloadConfigs.Deployment)
+			testDeployment, err := deployment.CreateDeploymentFromConfig(w.downstreamClient, w.cluster.ID, workloadConfigs.Deployment)
 			require.NoError(w.T(), err)
 
 			logrus.Infof("Verifying deployment with name: %s", testDeployment.Name)


### PR DESCRIPTION
As part of a personal Goal, I experimented with using AI to identify discrepancies between our automated tests and their schemas and this PR is a result of trying to fix the identified discrepancies.

The more convoluted fixes here would be:
- The `helm install` commands from `TestAmbientInstallation` and `TestGatewayStandaloneInstallation` schemas were updated to match the one used on the tests.
- `TestLoadBalancer` and `TestLoadBalanceScaleAndUpgrade` were updated to test the connectivity to the actual Load Balancers instead of the Node port