### PR TITLE
Convert insensitive GHA secrets to variables to free up space

### DIFF
--- a/.github/workflows/airgap-cluster-provisioning.yml
+++ b/.github/workflows/airgap-cluster-provisioning.yml
@@ -83,7 +83,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -108,7 +108,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AIRGAP_AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -198,7 +198,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AIRGAP_AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
@@ -208,7 +208,7 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -219,8 +219,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}-internal.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -238,8 +238,8 @@ jobs:
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
-            bastionUser: "${{ secrets.AWS_USER }}"
-            bastionWindowsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+            bastionUser: "${{ vars.AWS_USER }}"
+            bastionWindowsUser: "${{ vars.AWS_WINDOWS_USER }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -250,28 +250,28 @@ jobs:
             level: "${{ vars.LOGGING_LEVEL }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -326,35 +326,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AIRGAP_AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -402,7 +402,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -427,7 +427,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AIRGAP_AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -517,7 +517,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AIRGAP_AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
@@ -527,7 +527,7 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -538,8 +538,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}-internal.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -558,8 +558,8 @@ jobs:
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
-            bastionUser: "${{ secrets.AWS_USER }}"
-            bastionWindowsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+            bastionUser: "${{ vars.AWS_USER }}"
+            bastionWindowsUser: "${{ vars.AWS_WINDOWS_USER }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -570,28 +570,28 @@ jobs:
             level: "${{ vars.LOGGING_LEVEL }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -646,35 +646,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AIRGAP_AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -722,7 +722,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -747,7 +747,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AIRGAP_AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -837,7 +837,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AIRGAP_AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
@@ -847,7 +847,7 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -858,8 +858,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}-internal.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -878,8 +878,8 @@ jobs:
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
-            bastionUser: "${{ secrets.AWS_USER }}"
-            bastionWindowsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+            bastionUser: "${{ vars.AWS_USER }}"
+            bastionWindowsUser: "${{ vars.AWS_WINDOWS_USER }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -890,28 +890,28 @@ jobs:
             level: "${{ vars.LOGGING_LEVEL }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -966,35 +966,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AIRGAP_AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/check-rancher-tag.yml
+++ b/.github/workflows/check-rancher-tag.yml
@@ -58,7 +58,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get dispatch workflow list
         id: get-dispatch-workflow-list
@@ -230,7 +230,7 @@ jobs:
          uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
          with:
            role-to-assume: ${{ secrets.IAM_ROLE }}
-           aws-region: ${{ secrets.AWS_REGION }}
+           aws-region: ${{ vars.AWS_REGION }}
 
        - name: Check if Slack notification already sent
          id: check_marker
@@ -264,7 +264,7 @@ jobs:
          uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
          with:
            role-to-assume: ${{ secrets.IAM_ROLE }}
-           aws-region: ${{ secrets.AWS_REGION }}
+           aws-region: ${{ vars.AWS_REGION }}
 
        - name: Write Slack notification marker to S3
          if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
@@ -282,7 +282,7 @@ jobs:
          uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
          with:
            role-to-assume: ${{ secrets.IAM_ROLE }}
-           aws-region: ${{ secrets.AWS_REGION }}
+           aws-region: ${{ vars.AWS_REGION }}
 
        - name: Check if Slack notification already sent
          id: check_marker
@@ -316,7 +316,7 @@ jobs:
          uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
          with:
            role-to-assume: ${{ secrets.IAM_ROLE }}
-           aws-region: ${{ secrets.AWS_REGION }}
+           aws-region: ${{ vars.AWS_REGION }}
 
        - name: Write Slack notification marker to S3
          if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}
@@ -334,7 +334,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Check if Slack notification already sent
         id: check_marker
@@ -368,7 +368,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Write Slack notification marker to S3
         if: ${{ steps.check_marker.outputs.skip_slack == 'false' }}

--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -98,7 +98,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -123,7 +123,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -221,7 +221,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -229,10 +229,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -246,8 +246,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -286,14 +286,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -303,28 +303,28 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -386,35 +386,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -485,7 +485,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -510,7 +510,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -608,7 +608,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -616,10 +616,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -633,8 +633,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -673,14 +673,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -690,28 +690,28 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -773,35 +773,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -873,7 +873,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -898,7 +898,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -996,7 +996,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1004,10 +1004,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -1021,8 +1021,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -1062,14 +1062,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1079,28 +1079,28 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -1162,35 +1162,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -1262,7 +1262,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -1287,7 +1287,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -1385,7 +1385,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1393,10 +1393,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -1410,8 +1410,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -1451,14 +1451,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1468,28 +1468,28 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -1551,35 +1551,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/day2-ops-dualstack-rancher.yml
+++ b/.github/workflows/day2-ops-dualstack-rancher.yml
@@ -86,7 +86,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -111,7 +111,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -208,7 +208,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -216,7 +216,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
+              awsUser: "${{ vars.DUAL_STACK_AWS_USER }}"
               clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
@@ -279,15 +279,15 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
@@ -301,18 +301,18 @@ jobs:
               ipv6AddressCount: "1"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -365,35 +365,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -455,7 +455,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -480,7 +480,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -577,7 +577,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -585,7 +585,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
+              awsUser: "${{ vars.DUAL_STACK_AWS_USER }}"
               clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
@@ -648,15 +648,15 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
@@ -670,18 +670,18 @@ jobs:
               ipv6AddressCount: "1"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -734,35 +734,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -823,7 +823,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -848,7 +848,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -945,7 +945,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -953,7 +953,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
+              awsUser: "${{ vars.DUAL_STACK_AWS_USER }}"
               clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
@@ -1017,15 +1017,15 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
@@ -1039,18 +1039,18 @@ jobs:
               ipv6AddressCount: "1"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -1103,35 +1103,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/day2-ops-ipv6-rancher.yml
+++ b/.github/workflows/day2-ops-ipv6-rancher.yml
@@ -86,7 +86,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -111,7 +111,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -208,7 +208,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -216,7 +216,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.IPV6_AWS_USER }}"
+              awsUser: "${{ vars.IPV6_AWS_USER }}"
               clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               enablePrimaryIPv6: true
@@ -281,14 +281,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
@@ -302,18 +302,18 @@ jobs:
               ipv6AddressCount: "1"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -366,35 +366,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -456,7 +456,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -481,7 +481,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -578,7 +578,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -586,7 +586,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.IPV6_AWS_USER }}"
+              awsUser: "${{ vars.IPV6_AWS_USER }}"
               clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               enablePrimaryIPv6: true
@@ -651,14 +651,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
@@ -672,18 +672,18 @@ jobs:
               ipv6AddressCount: "1"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -736,35 +736,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -825,7 +825,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -850,7 +850,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -947,7 +947,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -955,7 +955,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.IPV6_AWS_USER }}"
+              awsUser: "${{ vars.IPV6_AWS_USER }}"
               clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               enablePrimaryIPv6: true
@@ -1021,14 +1021,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
@@ -1042,18 +1042,18 @@ jobs:
               ipv6AddressCount: "1"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -1106,35 +1106,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/day2-ops-proxy-rancher.yml
+++ b/.github/workflows/day2-ops-proxy-rancher.yml
@@ -86,7 +86,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -111,7 +111,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -210,7 +210,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -218,7 +218,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -229,8 +229,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -276,14 +276,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -293,27 +293,27 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -377,35 +377,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -467,7 +467,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -492,7 +492,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -591,7 +591,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -599,7 +599,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -610,8 +610,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -657,14 +657,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -674,27 +674,27 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -758,35 +758,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -847,7 +847,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -872,7 +872,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -971,7 +971,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -979,7 +979,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -990,8 +990,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -1038,14 +1038,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1055,27 +1055,27 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -1139,35 +1139,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/day2-ops-rancher-prime.yml
+++ b/.github/workflows/day2-ops-rancher-prime.yml
@@ -83,7 +83,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -108,7 +108,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -203,7 +203,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -211,7 +211,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -222,8 +222,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -260,14 +260,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -322,35 +322,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -398,7 +398,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -423,7 +423,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -518,7 +518,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -526,7 +526,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -537,8 +537,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -575,14 +575,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -637,35 +637,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/day2-ops-rancher.yml
+++ b/.github/workflows/day2-ops-rancher.yml
@@ -86,7 +86,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -111,7 +111,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -208,7 +208,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -216,7 +216,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -227,8 +227,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -267,14 +267,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -284,27 +284,27 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -368,35 +368,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -457,7 +457,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -482,7 +482,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -579,7 +579,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -587,7 +587,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -598,8 +598,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -638,14 +638,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -655,27 +655,27 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -739,35 +739,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -829,7 +829,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -854,7 +854,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -951,7 +951,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -959,7 +959,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -970,8 +970,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -1011,14 +1011,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1028,27 +1028,27 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -1112,35 +1112,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -1202,7 +1202,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -1227,7 +1227,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -1324,7 +1324,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1332,7 +1332,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -1343,8 +1343,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -1384,14 +1384,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1401,27 +1401,27 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -1485,35 +1485,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -92,7 +92,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -117,7 +117,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -214,7 +214,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -222,7 +222,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
+              awsUser: "${{ vars.DUAL_STACK_AWS_USER }}"
               clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
@@ -282,15 +282,15 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
@@ -300,18 +300,18 @@ jobs:
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -366,35 +366,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -461,7 +461,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -486,7 +486,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -583,7 +583,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -591,7 +591,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
+              awsUser: "${{ vars.DUAL_STACK_AWS_USER }}"
               clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
@@ -651,15 +651,15 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
@@ -669,18 +669,18 @@ jobs:
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -735,35 +735,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -829,7 +829,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -854,7 +854,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -951,7 +951,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -959,7 +959,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
+              awsUser: "${{ vars.DUAL_STACK_AWS_USER }}"
               clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
@@ -1020,15 +1020,15 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
@@ -1038,18 +1038,18 @@ jobs:
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -1104,35 +1104,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -92,7 +92,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -117,7 +117,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -214,7 +214,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -222,7 +222,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
+              awsUser: "${{ vars.DUAL_STACK_AWS_USER }}"
               clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               enablePrimaryIPv6: true
@@ -284,14 +284,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
@@ -301,18 +301,18 @@ jobs:
               subnetId: "${{ secrets.AWS_IPV6_SUBNET_ID }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -367,35 +367,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -462,7 +462,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -487,7 +487,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -584,7 +584,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -592,7 +592,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
+              awsUser: "${{ vars.DUAL_STACK_AWS_USER }}"
               clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               enablePrimaryIPv6: true
@@ -654,14 +654,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
@@ -671,18 +671,18 @@ jobs:
               subnetId: "${{ secrets.AWS_IPV6_SUBNET_ID }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -737,35 +737,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -831,7 +831,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -856,7 +856,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -953,7 +953,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -961,7 +961,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.DUAL_STACK_AWS_USER }}"
+              awsUser: "${{ vars.DUAL_STACK_AWS_USER }}"
               clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
@@ -1022,14 +1022,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
@@ -1039,18 +1039,18 @@ jobs:
               subnetId: "${{ secrets.AWS_IPV6_SUBNET_ID }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -1105,35 +1105,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -92,7 +92,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -117,7 +117,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -214,7 +214,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -222,7 +222,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.IPV6_AWS_USER }}"
+              awsUser: "${{ vars.IPV6_AWS_USER }}"
               clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               enablePrimaryIPv6: true
@@ -284,14 +284,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
@@ -301,18 +301,18 @@ jobs:
               subnetId: "${{ secrets.AWS_IPV6_SUBNET_ID }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -367,35 +367,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -462,7 +462,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -487,7 +487,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -584,7 +584,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -592,7 +592,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.IPV6_AWS_USER }}"
+              awsUser: "${{ vars.IPV6_AWS_USER }}"
               clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               enablePrimaryIPv6: true
@@ -654,14 +654,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
@@ -671,18 +671,18 @@ jobs:
               subnetId: "${{ secrets.AWS_IPV6_SUBNET_ID }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -737,35 +737,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -831,7 +831,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -856,7 +856,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -953,7 +953,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -961,7 +961,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.IPV6_AWS_USER }}"
+              awsUser: "${{ vars.IPV6_AWS_USER }}"
               clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
               serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
               enablePrimaryIPv6: true
@@ -1024,14 +1024,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
@@ -1041,18 +1041,18 @@ jobs:
               subnetId: "${{ secrets.AWS_IPV6_SUBNET_ID }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
           sshPath: 
@@ -1107,35 +1107,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/platform-qa-test-runner.yml
+++ b/.github/workflows/platform-qa-test-runner.yml
@@ -124,7 +124,7 @@ jobs:
           AWS_ACCESS_KEY: ${{ secrets.PQA_AWS_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.PQA_AWS_SECRET_ACCESS_KEY }}
           AWS_AMI: ${{ secrets.AWS_AMI }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
           AWS_VPC_ID: ${{ secrets.PQA_AWS_VPC_ID }}
           AWS_SUBNET_ID: ${{ secrets.PQA_AWS_SUBNET_ID }}
           AWS_SECURITY_GROUP_NAMES: ${{ secrets.PQA_AWS_SECURITY_GROUP_NAMES }}
@@ -145,10 +145,10 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ env.DOCKERHUB_PASSWORD }}
           AWS_ACCESS_KEY: ${{ secrets.PQA_AWS_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.PQA_AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_REGION: ${{ vars.AWS_REGION }}
           AWS_IAM_PROFILE: ${{ secrets.AWS_IAM_PROFILE }}
           AWS_AMI: ${{ secrets.AWS_AMI }}
-          AWS_USER: ${{ secrets.AWS_USER }}
+          AWS_USER: ${{ vars.AWS_USER }}
           AWS_VPC_ID: ${{ secrets.PQA_AWS_VPC_ID }}
           AWS_SUBNET_ID: ${{ secrets.PQA_AWS_SUBNET_ID }}
           AWS_SECURITY_GROUPS: ${{ secrets.PQA_AWS_SECURITY_GROUPS }}

--- a/.github/workflows/post-release-prime.yml
+++ b/.github/workflows/post-release-prime.yml
@@ -107,7 +107,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -132,7 +132,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -206,7 +206,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -214,7 +214,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -225,8 +225,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -295,21 +295,21 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -361,7 +361,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -386,7 +386,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -460,7 +460,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -468,7 +468,7 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -479,8 +479,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -549,21 +549,21 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/proxy-cluster-provisioning.yml
+++ b/.github/workflows/proxy-cluster-provisioning.yml
@@ -93,7 +93,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -118,7 +118,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -217,7 +217,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -225,10 +225,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -242,8 +242,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -289,14 +289,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -306,28 +306,28 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -391,35 +391,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -487,7 +487,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -512,7 +512,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -611,7 +611,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -619,10 +619,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -636,8 +636,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -683,14 +683,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -700,28 +700,28 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -785,35 +785,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -880,7 +880,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -905,7 +905,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -1004,7 +1004,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1012,10 +1012,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -1029,8 +1029,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -1077,14 +1077,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1094,28 +1094,28 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -1179,35 +1179,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
@@ -83,7 +83,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -108,7 +108,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AIRGAP_AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -199,7 +199,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AIRGAP_AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
@@ -209,7 +209,7 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -220,8 +220,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}-internal.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -245,8 +245,8 @@ jobs:
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
-            bastionUser: "${{ secrets.AWS_USER }}"
-            bastionWindowsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+            bastionUser: "${{ vars.AWS_USER }}"
+            bastionWindowsUser: "${{ vars.AWS_WINDOWS_USER }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -257,28 +257,28 @@ jobs:
             level: "${{ vars.LOGGING_LEVEL }}"
           
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -333,35 +333,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AIRGAP_AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -409,7 +409,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -434,7 +434,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AIRGAP_AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -525,7 +525,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AIRGAP_AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
@@ -535,7 +535,7 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -546,8 +546,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}-internal.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -573,8 +573,8 @@ jobs:
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
-            bastionUser: "${{ secrets.AWS_USER }}"
-            bastionWindowsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+            bastionUser: "${{ vars.AWS_USER }}"
+            bastionWindowsUser: "${{ vars.AWS_WINDOWS_USER }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -585,28 +585,28 @@ jobs:
             level: "${{ vars.LOGGING_LEVEL }}"
           
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -661,35 +661,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AIRGAP_AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -737,7 +737,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -762,7 +762,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AIRGAP_AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -853,7 +853,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AIRGAP_AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
@@ -863,7 +863,7 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -874,8 +874,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}-internal.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -901,8 +901,8 @@ jobs:
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
-            bastionUser: "${{ secrets.AWS_USER }}"
-            bastionWindowsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+            bastionUser: "${{ vars.AWS_USER }}"
+            bastionWindowsUser: "${{ vars.AWS_WINDOWS_USER }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
@@ -913,28 +913,28 @@ jobs:
             level: "${{ vars.LOGGING_LEVEL }}"
           
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -989,35 +989,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AIRGAP_AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -97,7 +97,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -122,7 +122,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -222,7 +222,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -230,10 +230,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -247,8 +247,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -292,14 +292,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
@@ -307,28 +307,28 @@ jobs:
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -390,35 +390,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -489,7 +489,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -514,7 +514,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -614,7 +614,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -622,10 +622,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -639,8 +639,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -684,14 +684,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
@@ -699,28 +699,28 @@ jobs:
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -782,35 +782,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -882,7 +882,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -907,7 +907,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -1007,7 +1007,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1015,10 +1015,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -1032,8 +1032,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -1078,14 +1078,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
@@ -1093,28 +1093,28 @@ jobs:
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -1176,35 +1176,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -1276,7 +1276,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -1301,7 +1301,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -1401,7 +1401,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1409,10 +1409,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -1426,8 +1426,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -1472,14 +1472,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
@@ -1487,28 +1487,28 @@ jobs:
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -1570,35 +1570,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
@@ -93,7 +93,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -118,7 +118,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -219,7 +219,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -227,10 +227,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -244,8 +244,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -296,14 +296,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
@@ -311,28 +311,28 @@ jobs:
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -396,35 +396,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -492,7 +492,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -517,7 +517,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -618,7 +618,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -626,10 +626,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -643,8 +643,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -695,14 +695,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
@@ -710,28 +710,28 @@ jobs:
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -795,35 +795,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -890,7 +890,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -915,7 +915,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -1016,7 +1016,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1024,10 +1024,10 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ secrets.AWS_WINDOWS_USER }}" 
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
               windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
               windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
               windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
@@ -1041,8 +1041,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
@@ -1094,14 +1094,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
@@ -1109,28 +1109,28 @@ jobs:
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -1194,35 +1194,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/registries-cluster-provisioning.yml
+++ b/.github/workflows/registries-cluster-provisioning.yml
@@ -82,7 +82,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -107,7 +107,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -195,7 +195,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -204,7 +204,7 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -215,8 +215,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -253,14 +253,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -270,28 +270,28 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -346,35 +346,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -422,7 +422,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -447,7 +447,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -535,7 +535,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -544,7 +544,7 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -555,8 +555,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -593,14 +593,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -610,28 +610,28 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -686,35 +686,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()
@@ -762,7 +762,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Get AWS credentials from Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
@@ -787,7 +787,7 @@ jobs:
         uses: ./.github/actions/whitelist-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set up SSH Keys
         uses: ./.github/actions/setup-ssh-keys
@@ -875,7 +875,7 @@ jobs:
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ secrets.AWS_REGION }}"
+              region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
               awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
               awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -884,7 +884,7 @@ jobs:
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               registryRootSize: ${{ vars.AWS_ROOT_SIZE_REGISTRY }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ secrets.AWS_USER }}"
+              awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
@@ -895,8 +895,8 @@ jobs:
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ secrets.OS_USER }}"
-              osGroup: "${{ secrets.OS_GROUP }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
               rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
@@ -933,14 +933,14 @@ jobs:
           awsCredentials:
             secretKey: "$AWS_SECRET_KEY"
             accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ secrets.AWS_REGION }}"
+            defaultRegion: "${{ vars.AWS_REGION }}"
 
           awsMachineConfigs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
-              sshUser: "${{ secrets.AWS_USER }}"
+              sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -950,28 +950,28 @@ jobs:
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE }}"
 
           awsEC2Configs:
-            region: "${{ secrets.AWS_REGION }}"
+            region: "${{ vars.AWS_REGION }}"
             awsSecretAccessKey: "$AWS_SECRET_KEY"
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
-              - awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ secrets.AWS_USER }}"
+                awsUser: "${{ vars.AWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["etcd", "controlplane", "worker"]
               - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ secrets.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ secrets.AWS_WINDOWS_USER }}"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
@@ -1026,35 +1026,35 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: AWS Custodian Infrastructure Cleanup
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Node driver
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: AWS Custodian Downstream Cleanup - Custom
         if: always()
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
         with:
           prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ secrets.AWS_REGION }}"
+          region: "${{ vars.AWS_REGION }}"
 
       - name: Set job status output
         if: always()

--- a/.github/workflows/rke-validations.yml
+++ b/.github/workflows/rke-validations.yml
@@ -26,7 +26,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Create Qase test run
         id: qase
@@ -88,7 +88,7 @@ jobs:
             --subnet-id ${{ secrets.AWS_SUBNET_ID }} \
             --tag-specifications 'ResourceType=instance,Tags=[{Key=Name,Value=rke-validations-${{ github.run_id }}}]' \
             --block-device-mappings '[{"DeviceName":"/dev/sda1","Ebs":{"VolumeSize":100}}]' \
-            --region ${{ secrets.AWS_REGION }} \
+            --region ${{ vars.AWS_REGION }} \
             --query 'Instances[0].InstanceId' \
             --output text)
 


### PR DESCRIPTION
This pull request replaces insensitive GitHub Actions (GHA) secrets with variables, helping to free up space in the secrets store. By migrating information that does not require strict confidentiality from secrets to variables, the GHA configuration becomes more efficient and easier to maintain.