### PR TITLE
Enable v2.15 job in upgraded Rancher workflow by uncommenting conditional logic

### DIFF
--- a/.github/workflows/day2-ops-upgraded-rancher.yml
+++ b/.github/workflows/day2-ops-upgraded-rancher.yml
@@ -54,10 +54,10 @@ env:
 
 jobs:
   v2-15:
-    # if: |
-    #   github.event.inputs.run_all_versions == 'true' ||
-    #   (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && contains(github.event.inputs.rancher_version, '-alpha') ||
-    #   (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && contains(inputs.rancher_version, '-alpha')
+    if: |
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: upgrade-community-head


### PR DESCRIPTION
This pull request enables the v2.15 job in the upgraded Rancher workflow by removing the comment from the conditional logic that previously disabled it. The change ensures that the v2.15 job will now be executed as part of the workflow for day 2 operations, supporting upgraded Rancher scenarios.