### PR TITLE
Add CAPV support for provisioning CAPI PnP downstream clusters

### DIFF
--- a/actions/capipnp/capa.go
+++ b/actions/capipnp/capa.go
@@ -184,8 +184,8 @@ func waitCAPAProviderPrerequisitesReady(client *rancher.Client) error {
 	defer cleanup()
 
 	waitCommands := [][]string{
-		{"kubectl", "--kubeconfig", kubeconfigPath, "wait", "--for=condition=Ready", "capiprovider.turtles-capi.cattle.io/aws", "-n", "capa-system", "--timeout=300s"},
-		{"kubectl", "--kubeconfig", kubeconfigPath, "wait", "--for=condition=Ready", "capiprovider/aws", "-n", "capa-system", "--timeout=300s"},
+		{"kubectl", "--kubeconfig", kubeconfigPath, "--insecure-skip-tls-verify=true", "wait", "--for=condition=Ready", "capiprovider.turtles-capi.cattle.io/aws", "-n", "capa-system", "--timeout=300s"},
+		{"kubectl", "--kubeconfig", kubeconfigPath, "--insecure-skip-tls-verify=true", "wait", "--for=condition=Ready", "capiprovider/aws", "-n", "capa-system", "--timeout=300s"},
 	}
 
 	var lastOutput string
@@ -205,7 +205,7 @@ func waitCAPAProviderPrerequisitesReady(client *rancher.Client) error {
 		return fmt.Errorf("wait for CAPA provider readiness failed: %w: %s", lastErr, strings.TrimSpace(lastOutput))
 	}
 
-	output, err := runLocalKubectl([]string{"kubectl", "--kubeconfig", kubeconfigPath, "wait", "--for=create", "secret/capa-credentials", "-n", "capa-system", "--timeout=120s"}, nil)
+	output, err := runLocalKubectl([]string{"kubectl", "--kubeconfig", kubeconfigPath, "--insecure-skip-tls-verify=true", "wait", "--for=create", "secret/capa-credentials", "-n", "capa-system", "--timeout=120s"}, nil)
 	if err != nil {
 		return fmt.Errorf("wait for CAPA credentials secret failed: %w: %s", err, strings.TrimSpace(output))
 	}

--- a/actions/capipnp/capv.go
+++ b/actions/capipnp/capv.go
@@ -1,0 +1,290 @@
+package capipnp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/tests/actions/provisioninginput"
+)
+
+// capvCluster builds the CAPI cluster manifest for the CAPV provider.
+func capvCluster(documents []map[string]any, config *Config, machinePools []provisioninginput.MachinePools, clusterName string) error {
+	for index := 0; index < 3; index++ {
+		buildCAPVTemplate(documents[index], config, clusterName)
+	}
+
+	if err := buildCAPVCPISecret(documents[3], config, clusterName); err != nil {
+		return err
+	}
+	buildCAPVInfrastructureCluster(documents[4], config, clusterName)
+	buildCAPVCluster(documents[5], config, clusterName, machinePools)
+
+	return nil
+}
+
+// capvProviderManifest sets credentials for the CAPV provider manifests.
+func capvProviderManifest(documents []map[string]any, config *Config) error {
+	for _, document := range documents {
+		kind, _ := document["kind"].(string)
+		if kind != "Secret" {
+			continue
+		}
+
+		if err := capvProviderCredentials(document, config); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// capvProviderCredentials sets vSphere credentials in the provider credentials secret.
+func capvProviderCredentials(document map[string]any, config *Config) error {
+	username := config.VSphereCredentials.Username
+	password := config.VSphereCredentials.Password
+
+	if username == "" {
+		return fmt.Errorf("missing required parameter Username")
+	}
+
+	if password == "" {
+		return fmt.Errorf("missing required parameter Password")
+	}
+
+	stringData, ok := document["stringData"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("capv credentials template missing stringData")
+	}
+
+	stringData["username"] = username
+	stringData["password"] = password
+
+	return nil
+}
+
+// buildCAPVTemplate updates VSphereMachineTemplate docs with configured template data.
+func buildCAPVTemplate(document map[string]any, config *Config, clusterName string) {
+	metadata := document["metadata"].(map[string]any)
+	currentName, _ := metadata["name"].(string)
+
+	suffix := "worker"
+	switch {
+	case strings.HasSuffix(currentName, "-control-plane"):
+		suffix = "control-plane"
+	case strings.HasSuffix(currentName, "-etcd"):
+		suffix = "etcd"
+	}
+
+	metadata["name"] = fmt.Sprintf("%s-%s", clusterName, suffix)
+
+	templateSpec := document["spec"].(map[string]any)["template"].(map[string]any)["spec"].(map[string]any)
+	templateSpec["datacenter"] = config.VSphereTemplate.Datacenter
+	templateSpec["datastore"] = config.VSphereTemplate.Datastore
+	templateSpec["diskGiB"] = config.VSphereTemplate.DiskGiB
+	templateSpec["folder"] = config.VSphereTemplate.Folder
+	templateSpec["memoryMiB"] = config.VSphereTemplate.MemoryMiB
+	templateSpec["numCPUs"] = config.VSphereTemplate.NumCPUs
+	templateSpec["resourcePool"] = config.VSphereTemplate.ResourcePool
+	templateSpec["template"] = config.VSphereTemplate.Template
+
+	network := templateSpec["network"].(map[string]any)
+	devices := network["devices"].([]any)
+	devices[0].(map[string]any)["networkName"] = config.VSphereTemplate.NetworkName
+}
+
+// buildCAPVCPISecret updates the CPI credentials secret used by downstream clusters.
+func buildCAPVCPISecret(document map[string]any, config *Config, clusterName string) error {
+	metadata := document["metadata"].(map[string]any)
+	annotations := metadata["annotations"].(map[string]any)
+	annotations["rke.cattle.io/object-authorized-for-clusters"] = clusterName
+
+	host := strings.TrimSpace(config.VSphereTemplate.Host)
+	username := config.VSphereCredentials.Username
+	password := config.VSphereCredentials.Password
+
+	if host == "" || strings.Contains(host, "<required>") {
+		return fmt.Errorf("missing required parameter host")
+	}
+
+	if username == "" {
+		return fmt.Errorf("missing required parameter username")
+	}
+
+	if password == "" {
+		return fmt.Errorf("missing required parameter password")
+	}
+
+	stringData := document["stringData"].(map[string]any)
+
+	var usernameKey, passwordKey string
+	for key := range stringData {
+		if !strings.Contains(key, "<required>") {
+			continue
+		}
+
+		resolvedKey := strings.ReplaceAll(key, "<required>", host)
+		switch {
+		case strings.HasSuffix(key, ".username"):
+			usernameKey = resolvedKey
+			stringData[resolvedKey] = username
+		case strings.HasSuffix(key, ".password"):
+			passwordKey = resolvedKey
+			stringData[resolvedKey] = password
+		default:
+			stringData[resolvedKey] = stringData[key]
+		}
+
+		delete(stringData, key)
+	}
+
+	if usernameKey == "" || passwordKey == "" {
+		for key := range stringData {
+			switch {
+			case usernameKey == "" && strings.HasSuffix(key, ".username"):
+				usernameKey = key
+			case passwordKey == "" && strings.HasSuffix(key, ".password"):
+				passwordKey = key
+			}
+		}
+	}
+
+	if usernameKey == "" {
+		usernameKey = fmt.Sprintf("%s.username", host)
+	}
+
+	if passwordKey == "" {
+		passwordKey = fmt.Sprintf("%s.password", host)
+	}
+
+	stringData[usernameKey] = username
+	stringData[passwordKey] = password
+
+	return nil
+}
+
+// buildCAPVInfrastructureCluster updates the VSphereCluster infrastructure object.
+func buildCAPVInfrastructureCluster(document map[string]any, config *Config, clusterName string) {
+	metadata := document["metadata"].(map[string]any)
+	metadata["name"] = clusterName
+
+	spec := document["spec"].(map[string]any)
+	spec["server"] = config.VSphereTemplate.Host
+}
+
+// buildCAPVCluster updates the provisioning cluster object.
+func buildCAPVCluster(document map[string]any, config *Config, clusterName string, machinePools []provisioninginput.MachinePools) {
+	metadata := document["metadata"].(map[string]any)
+	metadata["name"] = clusterName
+
+	spec := document["spec"].(map[string]any)
+	spec["kubernetesVersion"] = config.KubernetesVersion
+
+	rkeConfig := spec["rkeConfig"].(map[string]any)
+	infrastructureRef := rkeConfig["infrastructureRef"].(map[string]any)
+	infrastructureRef["name"] = clusterName
+	rkeConfig["machinePools"] = buildCAPVMachinePools(clusterName, machinePools)
+
+	chartValues := rkeConfig["chartValues"].(map[string]any)
+	rancherVSphereCPI := chartValues["rancher-vsphere-cpi"].(map[string]any)
+	vCenter := rancherVSphereCPI["vCenter"].(map[string]any)
+	vCenter["datacenters"] = config.VSphereTemplate.Datacenter
+	vCenter["host"] = config.VSphereTemplate.Host
+}
+
+// buildCAPVMachinePools constructs machine pool definitions for CAPV.
+func buildCAPVMachinePools(clusterName string, machinePools []provisioninginput.MachinePools) []map[string]any {
+	rendered := make([]map[string]any, 0, len(machinePools))
+
+	for index, machinePool := range machinePools {
+		poolConfig := machinePool.MachinePoolConfig
+		templateSuffix := capvMachineTemplateSuffix(poolConfig.ControlPlane, poolConfig.Etcd, poolConfig.Worker)
+		rendered = append(rendered, map[string]any{
+			"name":             capvMachinePoolName(poolConfig.ControlPlane, poolConfig.Etcd, poolConfig.Worker, index),
+			"etcdRole":         poolConfig.Etcd,
+			"controlPlaneRole": poolConfig.ControlPlane,
+			"workerRole":       poolConfig.Worker,
+			"quantity":         poolConfig.Quantity,
+			"machineConfigRef": map[string]any{
+				"kind":       "VSphereMachineTemplate",
+				"name":       fmt.Sprintf("%s-%s", clusterName, templateSuffix),
+				"namespace":  "fleet-default",
+				"apiVersion": "infrastructure.cluster.x-k8s.io/v1beta2",
+			},
+		})
+	}
+
+	return rendered
+}
+
+func capvMachineTemplateSuffix(controlPlane, etcd, worker bool) string {
+	switch {
+	case controlPlane:
+		return "control-plane"
+	case etcd:
+		return "etcd"
+	case worker:
+		return "worker"
+	default:
+		return "worker"
+	}
+}
+
+func capvMachinePoolName(controlPlane, etcd, worker bool, index int) string {
+	switch {
+	case controlPlane && etcd && worker:
+		return "all-roles"
+	case controlPlane && etcd:
+		return "etcd-control-plane"
+	case controlPlane && worker:
+		return "control-plane-worker"
+	case etcd && worker:
+		return "etcd-worker"
+	case etcd:
+		return "etcd"
+	case controlPlane:
+		return "control-plane"
+	case worker:
+		return "worker"
+	default:
+		return fmt.Sprintf("pool-%d", index+1)
+	}
+}
+
+// waitCAPVProviderPrerequisitesReady waits for CAPV provider prerequisites in Rancher.
+func waitCAPVProviderPrerequisitesReady(client *rancher.Client) error {
+	kubeconfigPath, cleanup, err := writeKubeconfigToTempFile(client, localCluster)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	waitCommands := [][]string{
+		{"kubectl", "--kubeconfig", kubeconfigPath, "--insecure-skip-tls-verify=true", "wait", "--for=condition=Ready", "capiprovider.turtles-capi.cattle.io/vsphere", "-n", "capv-system", "--timeout=300s"},
+		{"kubectl", "--kubeconfig", kubeconfigPath, "--insecure-skip-tls-verify=true", "wait", "--for=condition=Ready", "capiprovider/vsphere", "-n", "capv-system", "--timeout=300s"},
+	}
+
+	var lastOutput string
+	var lastErr error
+	for _, command := range waitCommands {
+		output, waitErr := runLocalKubectl(command, nil)
+		if waitErr == nil {
+			lastErr = nil
+			break
+		}
+
+		lastErr = waitErr
+		lastOutput = output
+	}
+
+	if lastErr != nil {
+		return fmt.Errorf("wait for CAPV provider readiness failed: %w: %s", lastErr, strings.TrimSpace(lastOutput))
+	}
+
+	output, err := runLocalKubectl([]string{"kubectl", "--kubeconfig", kubeconfigPath, "--insecure-skip-tls-verify=true", "wait", "--for=create", "secret/vsphere-credentials", "-n", "capv-system", "--timeout=120s"}, nil)
+	if err != nil {
+		return fmt.Errorf("wait for CAPV credentials secret failed: %w: %s", err, strings.TrimSpace(output))
+	}
+
+	return nil
+}

--- a/actions/capipnp/config.go
+++ b/actions/capipnp/config.go
@@ -1,5 +1,9 @@
 package capipnp
 
+import (
+	"github.com/rancher/tests/actions/capipnp/providers"
+)
+
 const (
 	ConfigurationFileKey = "capipnp"
 )
@@ -9,29 +13,16 @@ type ManifestContent struct {
 	Content []byte
 }
 
-type AWSCredentials struct {
-	AccessKeyID     string `json:"accessKeyID,omitempty" yaml:"accessKeyID,omitempty"`
-	SecretAccessKey string `json:"secretAccessKey,omitempty" yaml:"secretAccessKey,omitempty"`
-}
-
-type AWSTemplate struct {
-	AMI                       string `json:"ami,omitempty" yaml:"ami,omitempty"`
-	ControlPlaneSecurityGroup string `json:"controlPlaneSecurityGroup,omitempty" yaml:"controlPlaneSecurityGroup,omitempty"`
-	NodeSecurityGroup         string `json:"nodeSecurityGroup,omitempty" yaml:"nodeSecurityGroup,omitempty"`
-	Region                    string `json:"region,omitempty" yaml:"region,omitempty"`
-	SSHKeyName                string `json:"sshKeyName,omitempty" yaml:"sshKeyName,omitempty"`
-	SubnetID                  string `json:"subnetId,omitempty" yaml:"subnetId,omitempty"`
-	VPCID                     string `json:"vpcId,omitempty" yaml:"vpcId,omitempty"`
-}
-
 type Config struct {
-	AWSTemplate               AWSTemplate    `json:"awsTemplate,omitempty" yaml:"awsTemplate,omitempty"`
-	AWSCredentials            AWSCredentials `json:"awsCredentials,omitempty" yaml:"awsCredentials,omitempty"`
-	CredYAML                  string         `json:"credYAML,omitempty" yaml:"credYAML,omitempty"`
-	ClusterNamePrefix         string         `json:"clusterNamePrefix,omitempty" yaml:"clusterNamePrefix,omitempty"`
-	KubernetesVersion         string         `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
-	ClusterYAML               string         `json:"clusterYAML,omitempty" yaml:"clusterYAML,omitempty"`
-	ClusterStaticIdentityYAML string         `json:"clusterStaticIdentityYAML,omitempty" yaml:"clusterStaticIdentityYAML,omitempty"`
-	Provider                  string         `json:"provider,omitempty" yaml:"provider,omitempty"`
-	ProviderYAML              string         `json:"providerYAML,omitempty" yaml:"providerYAML,omitempty"`
+	AWSTemplate               providers.AWSTemplate        `json:"awsTemplate,omitempty" yaml:"awsTemplate,omitempty"`
+	AWSCredentials            providers.AWSCredentials     `json:"awsCredentials,omitempty" yaml:"awsCredentials,omitempty"`
+	VSphereTemplate           providers.VSphereTemplate    `json:"vsphereTemplate,omitempty" yaml:"vsphereTemplate,omitempty"`
+	VSphereCredentials        providers.VSphereCredentials `json:"vsphereCredentials,omitempty" yaml:"vsphereCredentials,omitempty"`
+	CredYAML                  string                       `json:"credYAML,omitempty" yaml:"credYAML,omitempty"`
+	ClusterNamePrefix         string                       `json:"clusterNamePrefix,omitempty" yaml:"clusterNamePrefix,omitempty"`
+	KubernetesVersion         string                       `json:"kubernetesVersion,omitempty" yaml:"kubernetesVersion,omitempty"`
+	ClusterYAML               string                       `json:"clusterYAML,omitempty" yaml:"clusterYAML,omitempty"`
+	ClusterStaticIdentityYAML string                       `json:"clusterStaticIdentityYAML,omitempty" yaml:"clusterStaticIdentityYAML,omitempty"`
+	Provider                  string                       `json:"provider,omitempty" yaml:"provider,omitempty"`
+	ProviderYAML              string                       `json:"providerYAML,omitempty" yaml:"providerYAML,omitempty"`
 }

--- a/actions/capipnp/creates.go
+++ b/actions/capipnp/creates.go
@@ -208,11 +208,11 @@ func resolveManifestPath(path string) string {
 }
 
 func kubectlCreateCommand(kubeconfigPath string) []string {
-	return []string{"kubectl", "--kubeconfig", kubeconfigPath, "create", "-f", "-"}
+	return []string{"kubectl", "--kubeconfig", kubeconfigPath, "--insecure-skip-tls-verify=true", "create", "-f", "-"}
 }
 
 func kubectlGetCommand(kubeconfigPath string) []string {
-	return []string{"kubectl", "--kubeconfig", kubeconfigPath, "get", "-f", "-"}
+	return []string{"kubectl", "--kubeconfig", kubeconfigPath, "--insecure-skip-tls-verify=true", "get", "-f", "-"}
 }
 
 func runLocalKubectl(args []string, input []byte) (string, error) {

--- a/actions/capipnp/deletes.go
+++ b/actions/capipnp/deletes.go
@@ -56,5 +56,5 @@ func DeleteProviderManifestFromPath(client *rancher.Client, config *Config, yaml
 }
 
 func kubectlDeleteCommand(kubeconfigPath string) []string {
-	return []string{"kubectl", "--kubeconfig", kubeconfigPath, "delete", "-f", "-"}
+	return []string{"kubectl", "--kubeconfig", kubeconfigPath, "--insecure-skip-tls-verify=true", "delete", "-f", "-"}
 }

--- a/actions/capipnp/providers.go
+++ b/actions/capipnp/providers.go
@@ -11,6 +11,7 @@ type ProviderName string
 
 const (
 	CAPA = "capa"
+	CAPV = "capv"
 )
 
 type ProviderManifestRendererFunc func(documents []map[string]any, config *Config) error
@@ -33,6 +34,12 @@ func CreateCAPIProvider(name string) Provider {
 			RenderProviderManifestFunc:    capaProviderManifest,
 			WaitProviderPrerequisitesFunc: waitCAPAProviderPrerequisitesReady,
 			RenderClusterManifestFunc:     capaCluster,
+		}
+	case name == CAPV:
+		provider = Provider{
+			RenderProviderManifestFunc:    capvProviderManifest,
+			WaitProviderPrerequisitesFunc: waitCAPVProviderPrerequisitesReady,
+			RenderClusterManifestFunc:     capvCluster,
 		}
 	default:
 		panic(fmt.Sprintf("Provider:%v not found", name))

--- a/actions/capipnp/providers/capa_config.go
+++ b/actions/capipnp/providers/capa_config.go
@@ -1,0 +1,16 @@
+package providers
+
+type AWSCredentials struct {
+	AccessKeyID     string `json:"accessKeyID,omitempty" yaml:"accessKeyID,omitempty"`
+	SecretAccessKey string `json:"secretAccessKey,omitempty" yaml:"secretAccessKey,omitempty"`
+}
+
+type AWSTemplate struct {
+	AMI                       string `json:"ami,omitempty" yaml:"ami,omitempty"`
+	ControlPlaneSecurityGroup string `json:"controlPlaneSecurityGroup,omitempty" yaml:"controlPlaneSecurityGroup,omitempty"`
+	NodeSecurityGroup         string `json:"nodeSecurityGroup,omitempty" yaml:"nodeSecurityGroup,omitempty"`
+	Region                    string `json:"region,omitempty" yaml:"region,omitempty"`
+	SSHKeyName                string `json:"sshKeyName,omitempty" yaml:"sshKeyName,omitempty"`
+	SubnetID                  string `json:"subnetId,omitempty" yaml:"subnetId,omitempty"`
+	VPCID                     string `json:"vpcId,omitempty" yaml:"vpcId,omitempty"`
+}

--- a/actions/capipnp/providers/capv_config.go
+++ b/actions/capipnp/providers/capv_config.go
@@ -1,0 +1,19 @@
+package providers
+
+type VSphereCredentials struct {
+	Username string `json:"username,omitempty" yaml:"username,omitempty"`
+	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+}
+
+type VSphereTemplate struct {
+	Datacenter   string `json:"datacenter,omitempty" yaml:"datacenter,omitempty"`
+	Datastore    string `json:"datastore,omitempty" yaml:"datastore,omitempty"`
+	DiskGiB      int    `json:"diskGiB,omitempty" yaml:"diskGiB,omitempty"`
+	Folder       string `json:"folder,omitempty" yaml:"folder,omitempty"`
+	Host         string `json:"host,omitempty" yaml:"host,omitempty"`
+	MemoryMiB    int    `json:"memoryMiB,omitempty" yaml:"memoryMiB,omitempty"`
+	NetworkName  string `json:"networkName,omitempty" yaml:"networkName,omitempty"`
+	NumCPUs      int    `json:"numCPUs,omitempty" yaml:"numCPUs,omitempty"`
+	ResourcePool string `json:"resourcePool,omitempty" yaml:"resourcePool,omitempty"`
+	Template     string `json:"template,omitempty" yaml:"template,omitempty"`
+}

--- a/actions/provisioning/qase.go
+++ b/actions/provisioning/qase.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
 	"github.com/rancher/shepherd/pkg/config/operations"
+	"github.com/rancher/tests/actions/capipnp"
 	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
 	"github.com/rancher/tests/actions/machinepools"
@@ -24,6 +25,9 @@ func GetProvisioningSchemaParams(client *rancher.Client, cattleConfig map[string
 	terraformConfig := new(config.TerraformConfig)
 	operations.LoadObjectFromMap(config.TerraformConfigurationFileKey, cattleConfig, terraformConfig)
 
+	capiConfig := new(capipnp.Config)
+	operations.LoadObjectFromMap(capipnp.ConfigurationFileKey, cattleConfig, capiConfig)
+
 	params = append(params,
 		getRunType(terraformConfig),
 		getRancherType(terraformConfig),
@@ -32,6 +36,7 @@ func GetProvisioningSchemaParams(client *rancher.Client, cattleConfig map[string
 		getProviderParam(clusterConfig),
 		getK8sParam(clusterConfig),
 		getCNIParam(clusterConfig),
+		getCAPIParam(capiConfig),
 	)
 
 	return params
@@ -212,4 +217,12 @@ func getProviderParam(clusterConfig *clusters.ClusterConfig) upstream.TestCasePa
 
 func getCNIParam(clusterConfig *clusters.ClusterConfig) upstream.TestCaseParameterCreate {
 	return upstream.TestCaseParameterCreate{ParameterSingle: &upstream.ParameterSingle{Title: "CNI", Values: []string{clusterConfig.CNI}}}
+}
+
+func getCAPIParam(capiConfig *capipnp.Config) upstream.TestCaseParameterCreate {
+	if capiConfig == nil {
+		return upstream.TestCaseParameterCreate{}
+	}
+
+	return upstream.TestCaseParameterCreate{ParameterSingle: &upstream.ParameterSingle{Title: "CAPIProvider", Values: []string{capiConfig.Provider}}}
 }

--- a/validation/provisioning/resources/capipnp/providers/capa/creds.yaml
+++ b/validation/provisioning/resources/capipnp/providers/capa/creds.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/validation/provisioning/resources/capipnp/providers/capa/identity.yaml
+++ b/validation/provisioning/resources/capipnp/providers/capa/identity.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: AWSClusterStaticIdentity
 metadata:

--- a/validation/provisioning/resources/capipnp/providers/capv/creds.yaml
+++ b/validation/provisioning/resources/capipnp/providers/capv/creds.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-credentials
+  namespace: capv-system
+type: Opaque
+stringData:
+  username: <required>
+  password: <required>

--- a/validation/provisioning/resources/capipnp/providers/capv/identity.yaml
+++ b/validation/provisioning/resources/capipnp/providers/capv/identity.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VSphereClusterIdentity
+metadata:
+  name: vsphere-cluster-identity
+spec:
+  secretName: vsphere-credentials
+  allowedNamespaces:
+    selector:
+      matchLabels:
+        kubernetes.io/metadata.name: fleet-default

--- a/validation/provisioning/resources/capipnp/providers/capv/k3s-cluster.yaml
+++ b/validation/provisioning/resources/capipnp/providers/capv/k3s-cluster.yaml
@@ -1,0 +1,183 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VSphereMachineTemplate
+metadata:
+  name: <required>-control-plane
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      datacenter: <required>
+      datastore: <required>
+      diskGiB: <required>
+      folder: <required>
+      memoryMiB: <required>
+      network:
+        devices:
+        - dhcp4: true
+          networkName: <required>
+      numCPUs: <required>
+      os: Linux
+      resourcePool: <required>
+      template: <required>
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VSphereMachineTemplate
+metadata:
+  name: <required>-etcd
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      datacenter: <required>
+      datastore: <required>
+      diskGiB: <required>
+      folder: <required>
+      memoryMiB: <required>
+      network:
+        devices:
+        - dhcp4: true
+          networkName: <required>
+      numCPUs: <required>
+      os: Linux
+      resourcePool: <required>
+      template: <required>
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VSphereMachineTemplate
+metadata:
+  name: <required>-worker
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      datacenter: <required>
+      datastore: <required>
+      diskGiB: <required>
+      folder: <required>
+      memoryMiB: <required>
+      network:
+        devices:
+        - dhcp4: true
+          networkName: <required>
+      numCPUs: <required>
+      os: Linux
+      resourcePool: <required>
+      template: <required>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-cpi-creds
+  namespace: fleet-default
+  annotations:
+    rke.cattle.io/object-authorized-for-clusters: <required>
+    provisioning.cattle.io/sync-bootstrap: "true"
+    provisioning.cattle.io/sync-target-namespace: kube-system
+type: Opaque
+stringData:
+  <required>.username: <required>
+  <required>.password: <required>
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VSphereCluster
+metadata:
+  name: <required>
+  namespace: fleet-default
+spec:
+  identityRef:
+    kind: VSphereClusterIdentity
+    name: vsphere-cluster-identity
+  server: <required>
+---
+apiVersion: provisioning.cattle.io/v1
+kind: Cluster
+metadata:
+  name: <required>
+  namespace: fleet-default
+spec:
+  kubernetesVersion: <required>
+  rkeConfig:
+    infrastructureRef:
+      kind: VSphereCluster
+      name: <required>
+      namespace: fleet-default
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    machinePools:
+      - name: etcd
+        etcdRole: <required>
+        controlPlaneRole: <required>
+        workerRole: <required>
+        quantity: <required>
+        machineConfigRef:
+          kind: VSphereMachineTemplate
+          name: <required>-etcd
+          namespace: fleet-default
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      - name: control-plane
+        etcdRole: <required>
+        controlPlaneRole: <required>
+        workerRole: <required>
+        quantity: <required>
+        machineConfigRef:
+          kind: VSphereMachineTemplate
+          name: <required>-control-plane
+          namespace: fleet-default
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      - name: worker
+        etcdRole: <required>
+        controlPlaneRole: <required>
+        workerRole: <required>
+        quantity: <required>
+        machineConfigRef:
+          kind: VSphereMachineTemplate
+          name: <required>-worker
+          namespace: fleet-default
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    machineGlobalConfig:
+      disable-kube-proxy: false
+      etcd-expose-metrics: false
+      ingress-controller: traefik
+      protect-kernel-defaults: false
+      disable:
+        - rancher-vsphere-csi
+      cloud-provider-name: rancher-vsphere
+    machineSelectorConfig:
+      - config:
+          disable-cloud-controller: true
+          kube-controller-manager-arg:
+            - cloud-provider=external
+          kubelet-arg:
+            - cloud-provider=external
+        machineLabelSelector:
+          matchExpressions:
+            - key: rke.cattle.io/control-plane-role
+              operator: In
+              values:
+                - 'true'
+      - config:
+          disable-cloud-controller: true
+          kubelet-arg:
+            - cloud-provider=external
+        machineLabelSelector:
+          matchExpressions:
+            - key: rke.cattle.io/etcd-role
+              operator: In
+              values:
+                - 'true'
+      - config:
+          kubelet-arg:
+            - cloud-provider=external
+        machineLabelSelector:
+          matchExpressions:
+            - key: rke.cattle.io/worker-role
+              operator: In
+              values:
+                - 'true'
+    chartValues:
+      rancher-vsphere-cpi:
+        vCenter:
+          datacenters: <required>
+          host: <required>
+          credentialsSecret:
+            generate: false

--- a/validation/provisioning/resources/capipnp/providers/capv/provider.yaml
+++ b/validation/provisioning/resources/capipnp/providers/capv/provider.yaml
@@ -2,14 +2,15 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: capa-system
+  name: capv-system
 ---
 apiVersion: turtles-capi.cattle.io/v1alpha1
 kind: CAPIProvider
 metadata:
-  name: aws
-  namespace: capa-system
+  name: vsphere
+  namespace: capv-system
 spec:
   type: infrastructure
   variables:
-    AWS_B64ENCODED_CREDENTIALS: ""
+    VSPHERE_USERNAME: ""
+    VSPHERE_PASSWORD: ""

--- a/validation/provisioning/resources/capipnp/providers/capv/rke2-cluster.yaml
+++ b/validation/provisioning/resources/capipnp/providers/capv/rke2-cluster.yaml
@@ -1,0 +1,152 @@
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VSphereMachineTemplate
+metadata:
+  name: <required>-control-plane
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      datacenter: <required>
+      datastore: <required>
+      diskGiB: <required>
+      folder: <required>
+      memoryMiB: <required>
+      network:
+        devices:
+        - dhcp4: true
+          networkName: <required>
+      numCPUs: <required>
+      os: Linux
+      resourcePool: <required>
+      template: <required>
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VSphereMachineTemplate
+metadata:
+  name: <required>-etcd
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      datacenter: <required>
+      datastore: <required>
+      diskGiB: <required>
+      folder: <required>
+      memoryMiB: <required>
+      network:
+        devices:
+        - dhcp4: true
+          networkName: <required>
+      numCPUs: <required>
+      os: Linux
+      resourcePool: <required>
+      template: <required>
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VSphereMachineTemplate
+metadata:
+  name: <required>-worker
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      datacenter: <required>
+      datastore: <required>
+      diskGiB: <required>
+      folder: <required>
+      memoryMiB: <required>
+      network:
+        devices:
+        - dhcp4: true
+          networkName: <required>
+      numCPUs: <required>
+      os: Linux
+      resourcePool: <required>
+      template: <required>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-cpi-creds
+  namespace: fleet-default
+  annotations:
+    rke.cattle.io/object-authorized-for-clusters: <required>
+    provisioning.cattle.io/sync-bootstrap: "true"
+    provisioning.cattle.io/sync-target-namespace: kube-system
+type: Opaque
+stringData:
+  <required>.username: <required>
+  <required>.password: <required>
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: VSphereCluster
+metadata:
+  name: <required>
+  namespace: fleet-default
+spec:
+  identityRef:
+    kind: VSphereClusterIdentity
+    name: vsphere-cluster-identity
+  server: <required>
+---
+apiVersion: provisioning.cattle.io/v1
+kind: Cluster
+metadata:
+  name: <required>
+  namespace: fleet-default
+spec:
+  kubernetesVersion: <required>
+  rkeConfig:
+    infrastructureRef:
+      kind: VSphereCluster
+      name: <required>
+      namespace: fleet-default
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    machinePools:
+      - name: etcd
+        etcdRole: <required>
+        controlPlaneRole: <required>
+        workerRole: <required>
+        quantity: <required>
+        machineConfigRef:
+          kind: VSphereMachineTemplate
+          name: <required>-etcd
+          namespace: fleet-default
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      - name: control-plane
+        etcdRole: <required>
+        controlPlaneRole: <required>
+        workerRole: <required>
+        quantity: <required>
+        machineConfigRef:
+          kind: VSphereMachineTemplate
+          name: <required>-control-plane
+          namespace: fleet-default
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+      - name: worker
+        etcdRole: <required>
+        controlPlaneRole: <required>
+        workerRole: <required>
+        quantity: <required>
+        machineConfigRef:
+          kind: VSphereMachineTemplate
+          name: <required>-worker
+          namespace: fleet-default
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+    machineGlobalConfig:
+      cni: calico
+      disable-kube-proxy: false
+      etcd-expose-metrics: false
+      ingress-controller: traefik
+      protect-kernel-defaults: false
+      disable:
+        - rancher-vsphere-csi
+      cloud-provider-name: rancher-vsphere
+    chartValues:
+      rancher-vsphere-cpi:
+        vCenter:
+          datacenters: <required>
+          host: <required>
+          credentialsSecret:
+            generate: false


### PR DESCRIPTION
This PR adds support for Cluster API Provider vSphere (CAPV) in provisioning Cluster API Plug and Play (CAPI PnP) downstream clusters. This enhancement allows users to leverage CAPV for deploying and managing downstream clusters using CAPI PnP workflows.