### PR TITLE
Add principal search coverage to OpenLDAP and Active Directory suites

### DIFF
--- a/actions/auth/authprovider.go
+++ b/actions/auth/authprovider.go
@@ -29,6 +29,10 @@ const (
 	ActiveDirectory                      = "activedirectory"
 	OpenLdapPasswordSecretID             = "openldapconfig-serviceaccountpassword"
 	ActiveDirectoryPasswordSecretID      = "activedirectoryconfig-serviceaccountpassword"
+	PrincipalTypeUser                    = "user"
+	PrincipalTypeGroup                   = "group"
+	AccessModeMissingRequiredError       = "accessMode=MissingRequired"
+	PermissionDeniedError                = "PermissionDenied"
 )
 
 type User struct {
@@ -107,7 +111,7 @@ func LoginAsAuthUser(client *rancher.Client, user *v3.User, providerName string)
 func NewPrincipalID(authConfigID, principalType, name, userSearchBase, groupSearchBase string) string {
 	baseDN := userSearchBase
 
-	if principalType == "group" {
+	if principalType == PrincipalTypeGroup {
 		baseDN = groupSearchBase
 	}
 
@@ -206,12 +210,12 @@ func WaitForNamespaceReady(client *rancher.Client, namespaceName string) error {
 
 // GetGroupPrincipalID constructs a group principal ID using the provider's configuration
 func GetGroupPrincipalID(providerName, groupName, userSearchBase, groupSearchBase string) string {
-	return NewPrincipalID(providerName, "group", groupName, userSearchBase, groupSearchBase)
+	return NewPrincipalID(providerName, PrincipalTypeGroup, groupName, userSearchBase, groupSearchBase)
 }
 
 // GetUserPrincipalID constructs a user principal ID using the provider's configuration
 func GetUserPrincipalID(providerName, username, userSearchBase, groupSearchBase string) string {
-	return NewPrincipalID(providerName, "user", username, userSearchBase, groupSearchBase)
+	return NewPrincipalID(providerName, PrincipalTypeUser, username, userSearchBase, groupSearchBase)
 }
 
 // UpdateAccessMode updates the auth config to the specified access mode with optional allowed principal IDs

--- a/actions/auth/verify.go
+++ b/actions/auth/verify.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/rancher/norman/types"
 	"github.com/rancher/shepherd/clients/rancher"
@@ -12,23 +14,23 @@ import (
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
-// searchPrincipals runs the /v3/principals search for the given name. The principal collection is
-// listed first so the search collection action link is populated before invoking it.
-func searchPrincipals(client *rancher.Client, name string) ([]v3.Principal, error) {
+// searchPrincipals runs the /v3/principals search for the given name, restricted to principalType when it is not empty.
+func searchPrincipals(client *rancher.Client, name, principalType string) ([]v3.Principal, error) {
 	collection, err := client.Management.Principal.List(&types.ListOpts{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list principals: %w", err)
 	}
-	result, err := client.Management.Principal.CollectionActionSearch(collection, &v3.SearchPrincipalsInput{Name: name})
+	result, err := client.Management.Principal.CollectionActionSearch(collection, &v3.SearchPrincipalsInput{
+		Name:          name,
+		PrincipalType: principalType,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to search principals for %q: %w", name, err)
 	}
 	return result.Data, nil
 }
 
-// VerifyPrincipalNotLocal polls the /v3/principals search for the given name and returns an error if
-// any returned principal is from the local provider. Externally-provisioned users and groups (SCIM,
-// SAML, OAuth) have no local login and must not be surfaced as local principals
+// VerifyPrincipalNotLocal polls the /v3/principals search for the given name and returns an error if any returned principal is from the local provider.
 func VerifyPrincipalNotLocal(client *rancher.Client, name string) error {
 	var localErr, callErr error
 	_ = kwait.PollUntilContextTimeout(
@@ -37,7 +39,7 @@ func VerifyPrincipalNotLocal(client *rancher.Client, name string) error {
 		defaults.TenSecondTimeout,
 		true,
 		func(ctx context.Context) (bool, error) {
-			principals, err := searchPrincipals(client, name)
+			principals, err := searchPrincipals(client, name, "")
 			if err != nil {
 				callErr = err
 				return false, err
@@ -57,10 +59,89 @@ func VerifyPrincipalNotLocal(client *rancher.Client, name string) error {
 	return callErr
 }
 
-// VerifyPrincipalIsLocal runs the /v3/principals search for the given name and returns an error if no
-// local principal is returned. A genuine local user must still surface as local after external-user dedup.
+// VerifyPrincipalSearchReturnsID runs the /v3/principals search for the given name and returns an error if none of the returned principals carry the expected principal ID.
+func VerifyPrincipalSearchReturnsID(client *rancher.Client, name, expectedPrincipalID string) error {
+	principals, err := searchPrincipals(client, name, "")
+	if err != nil {
+		return err
+	}
+
+	returnedIDs := make([]string, 0, len(principals))
+	for i := range principals {
+		if strings.EqualFold(principals[i].ID, expectedPrincipalID) {
+			return nil
+		}
+		returnedIDs = append(returnedIDs, principals[i].ID)
+	}
+
+	return fmt.Errorf("principal search for %q did not return %q; returned %v", name, expectedPrincipalID, returnedIDs)
+}
+
+// VerifyPrincipalSearchByTypeReturnsOnly runs the /v3/principals search restricted to principalType and returns an error if the expected principal ID is missing or any returned principal has a different type.
+func VerifyPrincipalSearchByTypeReturnsOnly(client *rancher.Client, name, principalType, expectedPrincipalID string) error {
+	principals, err := searchPrincipals(client, name, principalType)
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for i := range principals {
+		if principals[i].PrincipalType != principalType {
+			return fmt.Errorf("principal search for %q restricted to type %q returned %q of type %q", name, principalType, principals[i].ID, principals[i].PrincipalType)
+		}
+		if strings.EqualFold(principals[i].ID, expectedPrincipalID) {
+			found = true
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("principal search for %q restricted to type %q did not return %q", name, principalType, expectedPrincipalID)
+	}
+
+	return nil
+}
+
+// VerifyPrincipalSearchExcludesProvider runs the /v3/principals search for the given name and returns an error if any returned principal belongs to the given provider.
+func VerifyPrincipalSearchExcludesProvider(client *rancher.Client, name, provider string) error {
+	principals, err := searchPrincipals(client, name, "")
+	if err != nil {
+		return err
+	}
+
+	for i := range principals {
+		if principals[i].Provider == provider {
+			return fmt.Errorf("principal search for %q returned principal %q while provider %q should contribute no results", name, principals[i].ID, provider)
+		}
+	}
+
+	return nil
+}
+
+// VerifyPrincipalByID resolves a principal through /v3/principals/<id> and returns an error if the lookup fails or the resolved principal does not match the expected provider and type.
+func VerifyPrincipalByID(client *rancher.Client, principalID, expectedProvider, expectedPrincipalType string) error {
+	principal, err := client.Management.Principal.ByID(url.PathEscape(principalID))
+	if err != nil {
+		return fmt.Errorf("failed to resolve principal %q: %w", principalID, err)
+	}
+
+	if principal.Provider != expectedProvider {
+		return fmt.Errorf("principal %q resolved to provider %q, expected %q", principalID, principal.Provider, expectedProvider)
+	}
+
+	if principal.PrincipalType != expectedPrincipalType {
+		return fmt.Errorf("principal %q resolved to type %q, expected %q", principalID, principal.PrincipalType, expectedPrincipalType)
+	}
+
+	if principal.Name == "" {
+		return fmt.Errorf("principal %q resolved with an empty display name", principalID)
+	}
+
+	return nil
+}
+
+// VerifyPrincipalIsLocal runs the /v3/principals search for the given name and returns an error if no local principal is returned.
 func VerifyPrincipalIsLocal(client *rancher.Client, name string) error {
-	principals, err := searchPrincipals(client, name)
+	principals, err := searchPrincipals(client, name, "")
 	if err != nil {
 		return err
 	}

--- a/validation/auth/provider/activedirectory/activedirectory_test.go
+++ b/validation/auth/provider/activedirectory/activedirectory_test.go
@@ -17,6 +17,7 @@ import (
 	authactions "github.com/rancher/tests/actions/auth"
 	projectapi "github.com/rancher/tests/actions/kubeapi/projects"
 	rbacapi "github.com/rancher/tests/actions/kubeapi/rbac"
+	userapi "github.com/rancher/tests/actions/kubeapi/users"
 	"github.com/rancher/tests/actions/rbac"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -94,6 +95,70 @@ func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryEnableProvider() {
 	require.NoError(a.T(), err, "Failed to retrieve password secret")
 
 	require.Equal(a.T(), a.client.Auth.ActiveDirectory.Config.ServiceAccount.Password, string(secret.Data["serviceaccountpassword"]), "Password mismatch")
+}
+
+func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryEnableRequiresExplicitAccessMode() {
+	subSession := a.session.NewSession()
+	defer subSession.Cleanup()
+
+	err := authactions.EnsureAuthProviderEnabled(a.client, authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to enable Active Directory")
+
+	configuredAccessMode := a.client.Auth.ActiveDirectory.Config.AccessMode
+	subSession.RegisterCleanupFunc(func() error {
+		a.client.Auth.ActiveDirectory.Config.AccessMode = configuredAccessMode
+		return authactions.EnsureAuthProviderEnabled(a.client, authactions.ActiveDirectory)
+	})
+
+	logrus.Info("Disabling Active Directory so the enable path runs against a fresh provider")
+	err = a.client.Auth.ActiveDirectory.Disable()
+	require.NoError(a.T(), err, "Failed to disable Active Directory")
+
+	_, err = authactions.WaitForAuthProviderAnnotationUpdate(a.client, authactions.ActiveDirectory, authactions.AuthProvCleanupAnnotationValLocked)
+	require.NoError(a.T(), err, "Failed waiting for annotation update")
+
+	a.client.Auth.ActiveDirectory.Config.AccessMode = ""
+
+	logrus.Info("Enabling Active Directory with no access mode in the request")
+	err = a.client.Auth.ActiveDirectory.Enable()
+	require.Error(a.T(), err, "Enabling without an access mode must be rejected so the provider can never come up open to every directory user")
+	require.Contains(a.T(), err.Error(), authactions.AccessModeMissingRequiredError, "Enable should be rejected because accessMode is a required field")
+
+	adConfig, err := a.client.Management.AuthConfig.ByID(authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to retrieve Active Directory config")
+	require.False(a.T(), adConfig.Enabled, "Active Directory should remain disabled after a rejected enable")
+}
+
+func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryEnableIntoRestrictedAccessModeIsRejected() {
+	subSession := a.session.NewSession()
+	defer subSession.Cleanup()
+
+	err := authactions.EnsureAuthProviderEnabled(a.client, authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to enable Active Directory")
+
+	configuredAccessMode := a.client.Auth.ActiveDirectory.Config.AccessMode
+	subSession.RegisterCleanupFunc(func() error {
+		a.client.Auth.ActiveDirectory.Config.AccessMode = configuredAccessMode
+		return authactions.EnsureAuthProviderEnabled(a.client, authactions.ActiveDirectory)
+	})
+
+	logrus.Info("Disabling Active Directory so the enable path runs against a fresh provider")
+	err = a.client.Auth.ActiveDirectory.Disable()
+	require.NoError(a.T(), err, "Failed to disable Active Directory")
+
+	_, err = authactions.WaitForAuthProviderAnnotationUpdate(a.client, authactions.ActiveDirectory, authactions.AuthProvCleanupAnnotationValLocked)
+	require.NoError(a.T(), err, "Failed waiting for annotation update")
+
+	a.client.Auth.ActiveDirectory.Config.AccessMode = authactions.AccessModeRestricted
+
+	logrus.Info("Enabling Active Directory directly into restricted access mode")
+	err = a.client.Auth.ActiveDirectory.Enable()
+	require.Error(a.T(), err, "Active Directory cannot be enabled directly into restricted access mode: the enabling admin is never added to allowedPrincipalIDs and every binding for the provider is deleted while it is disabled")
+	require.Contains(a.T(), err.Error(), authactions.PermissionDeniedError, "Enable should be rejected with permission denied")
+
+	adConfig, err := a.client.Management.AuthConfig.ByID(authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to retrieve Active Directory config")
+	require.False(a.T(), adConfig.Enabled, "Active Directory should remain disabled after a rejected enable")
 }
 
 func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryDisableAndReenableProvider() {
@@ -467,6 +532,273 @@ func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryRequiredModeUnauth
 
 	_, err = authactions.UpdateAccessMode(a.client, authactions.ActiveDirectory, authactions.AccessModeUnrestricted, nil)
 	require.NoError(a.T(), err, "Failed to rollback access mode")
+}
+
+func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryRequiredModeRevokedPrincipalLoginDenied() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	subSession.RegisterCleanupFunc(func() error {
+		_, rollbackErr := authactions.UpdateAccessMode(a.client, authactions.ActiveDirectory, authactions.AccessModeUnrestricted, nil)
+		return rollbackErr
+	})
+
+	userSearchBase := a.client.Auth.ActiveDirectory.Config.Users.SearchBase
+	groupSearchBase := a.client.Auth.ActiveDirectory.Config.Groups.SearchBase
+
+	grantedPrincipalIDs := []string{authactions.GetGroupPrincipalID(authactions.ActiveDirectory, a.authConfig.Group, userSearchBase, groupSearchBase)}
+	for _, user := range a.authConfig.Users {
+		grantedPrincipalIDs = append(grantedPrincipalIDs, authactions.GetUserPrincipalID(authactions.ActiveDirectory, user.Username, userSearchBase, groupSearchBase))
+	}
+
+	logrus.Infof("Granting Active Directory group [%v] and its members access in required mode", a.authConfig.Group)
+	grantedConfig, err := authactions.UpdateAccessMode(a.client, authactions.ActiveDirectory, authactions.AccessModeRequired, grantedPrincipalIDs)
+	require.NoError(a.T(), err, "Failed to update access mode")
+	require.Equal(a.T(), authactions.AccessModeRequired, grantedConfig.AccessMode, "Access mode should be required")
+	require.ElementsMatch(a.T(), grantedPrincipalIDs, grantedConfig.AllowedPrincipalIDs, "Granted principals should be persisted exactly as sent")
+
+	err = authactions.VerifyUserLogins(authAdmin, authactions.ActiveDirectory, a.authConfig.Users, "required access mode with principals granted", true)
+	require.NoError(a.T(), err, "Granted users should be able to login")
+
+	revokedPrincipalIDs := []string{authactions.GetGroupPrincipalID(authactions.ActiveDirectory, a.authConfig.NestedGroup, userSearchBase, groupSearchBase)}
+
+	logrus.Infof("Revoking Active Directory group [%v] and its members, leaving only group [%v] allowed", a.authConfig.Group, a.authConfig.NestedGroup)
+	revokedConfig, err := authactions.UpdateAccessMode(a.client, authactions.ActiveDirectory, authactions.AccessModeRequired, revokedPrincipalIDs)
+	require.NoError(a.T(), err, "Failed to revoke principals")
+	require.Equal(a.T(), authactions.AccessModeRequired, revokedConfig.AccessMode, "Access mode should remain required")
+	require.ElementsMatch(a.T(), revokedPrincipalIDs, revokedConfig.AllowedPrincipalIDs, "Revoked principals should no longer appear in the allow list")
+
+	err = authactions.VerifyUserLogins(authAdmin, authactions.ActiveDirectory, a.authConfig.Users, "required access mode after principals revoked", false)
+	require.NoError(a.T(), err, "Revoked users should NOT be able to login")
+
+	err = authactions.VerifyUserLogins(authAdmin, authactions.ActiveDirectory, a.authConfig.NestedUsers, "required access mode after principals revoked", true)
+	require.NoError(a.T(), err, "Users in the still-allowed group should be able to login")
+}
+
+func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryPrincipalSearchFindsGroups() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	groupNames := []string{a.authConfig.Group, a.authConfig.NestedGroup, a.authConfig.DoubleNestedGroup}
+	for _, groupName := range groupNames {
+		logrus.Infof("Searching principals for Active Directory group [%v]", groupName)
+		expectedPrincipalID := authactions.GetGroupPrincipalID(
+			authactions.ActiveDirectory,
+			groupName,
+			a.client.Auth.ActiveDirectory.Config.Users.SearchBase,
+			a.client.Auth.ActiveDirectory.Config.Groups.SearchBase,
+		)
+
+		err = authactions.VerifyPrincipalSearchReturnsID(authAdmin, groupName, expectedPrincipalID)
+		require.NoError(a.T(), err, "Group [%v] should be findable through principal search", groupName)
+	}
+}
+
+func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryPrincipalSearchFindsUsers() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	allUsers := slices.Concat(a.authConfig.Users, a.authConfig.NestedUsers, a.authConfig.DoubleNestedUsers)
+	for _, userInfo := range allUsers {
+		logrus.Infof("Searching principals for Active Directory user [%v]", userInfo.Username)
+		expectedPrincipalID := authactions.GetUserPrincipalID(
+			authactions.ActiveDirectory,
+			userInfo.Username,
+			a.client.Auth.ActiveDirectory.Config.Users.SearchBase,
+			a.client.Auth.ActiveDirectory.Config.Groups.SearchBase,
+		)
+
+		err = authactions.VerifyPrincipalSearchReturnsID(authAdmin, userInfo.Username, expectedPrincipalID)
+		require.NoError(a.T(), err, "User [%v] should be findable through principal search", userInfo.Username)
+	}
+}
+
+func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryPrincipalSearchFindsLocalUserByDisplayName() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	logrus.Info("Creating a local user whose display name differs from its username")
+	localUser, err := userapi.CreateUser(authAdmin)
+	require.NoError(a.T(), err, "Failed to create local user")
+	require.NotEqual(a.T(), localUser.Username, localUser.DisplayName, "Local user display name must differ from its username for this search to be meaningful")
+
+	logrus.Infof("Searching principals for local user by username [%v]", localUser.Username)
+	err = authactions.VerifyPrincipalIsLocal(a.client, localUser.Username)
+	require.NoError(a.T(), err, "Local user [%v] should be findable by username", localUser.Username)
+
+	logrus.Infof("Searching principals for local user by display name [%v]", localUser.DisplayName)
+	err = authactions.VerifyPrincipalIsLocal(a.client, localUser.DisplayName)
+	require.NoError(a.T(), err, "Local user [%v] should be findable by display name [%v]", localUser.Username, localUser.DisplayName)
+}
+
+func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryPrincipalSearchProvisionedUserIsNotLocal() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	userInfo := a.authConfig.Users[0]
+	logrus.Infof("Logging in as Active Directory user [%v] to provision the Rancher user", userInfo.Username)
+	user := &v3.User{
+		Username: userInfo.Username,
+		Password: userInfo.Password,
+	}
+	userClient, err := authactions.LoginAsAuthUser(authAdmin, user, authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to login user [%v]", userInfo.Username)
+
+	provisionedUser, err := a.client.WranglerContext.Mgmt.User().Get(userClient.UserID, metav1.GetOptions{})
+	require.NoError(a.T(), err, "Failed to retrieve the Rancher user provisioned for [%v]", userInfo.Username)
+	logrus.Infof("Active Directory user [%v] provisioned Rancher user [%v] with display name [%v], username [%v] and principals %v",
+		userInfo.Username, provisionedUser.Name, provisionedUser.DisplayName, provisionedUser.Username, provisionedUser.PrincipalIDs)
+
+	require.Empty(a.T(), provisionedUser.Username, "Externally provisioned user [%v] should carry no local login username", userInfo.Username)
+	require.Greater(a.T(), len(provisionedUser.PrincipalIDs), 1, "Externally provisioned user [%v] should carry an external principal alongside the local one", userInfo.Username)
+
+	expectedPrincipalID := authactions.GetUserPrincipalID(
+		authactions.ActiveDirectory,
+		userInfo.Username,
+		a.client.Auth.ActiveDirectory.Config.Users.SearchBase,
+		a.client.Auth.ActiveDirectory.Config.Groups.SearchBase,
+	)
+
+	for _, searchTerm := range []string{userInfo.Username, provisionedUser.DisplayName} {
+		logrus.Infof("Searching principals for provisioned user [%v] using term [%v]", userInfo.Username, searchTerm)
+		err = authactions.VerifyPrincipalSearchReturnsID(authAdmin, searchTerm, expectedPrincipalID)
+		require.NoError(a.T(), err, "Provisioned user [%v] should stay findable when searching [%v]", userInfo.Username, searchTerm)
+
+		err = authactions.VerifyPrincipalNotLocal(authAdmin, searchTerm)
+		require.NoError(a.T(), err, "Provisioned user [%v] should not surface as a local principal when searching [%v]", userInfo.Username, searchTerm)
+	}
+}
+
+func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryPrincipalSearchByPartialName() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	groupName := a.authConfig.Group
+	require.NotEmpty(a.T(), groupName, "Group name should be set in the auth configuration")
+	groupPrefix := groupName[:len(groupName)/2+1]
+
+	logrus.Infof("Searching principals for Active Directory group [%v] using partial name [%v]", groupName, groupPrefix)
+	expectedGroupPrincipalID := authactions.GetGroupPrincipalID(
+		authactions.ActiveDirectory,
+		groupName,
+		a.client.Auth.ActiveDirectory.Config.Users.SearchBase,
+		a.client.Auth.ActiveDirectory.Config.Groups.SearchBase,
+	)
+
+	err = authactions.VerifyPrincipalSearchReturnsID(authAdmin, groupPrefix, expectedGroupPrincipalID)
+	require.NoError(a.T(), err, "Group [%v] should be findable by partial name [%v]", groupName, groupPrefix)
+
+	userName := a.authConfig.Users[0].Username
+	require.NotEmpty(a.T(), userName, "User name should be set in the auth configuration")
+	userPrefix := userName[:len(userName)/2+1]
+
+	logrus.Infof("Searching principals for Active Directory user [%v] using partial name [%v]", userName, userPrefix)
+	expectedUserPrincipalID := authactions.GetUserPrincipalID(
+		authactions.ActiveDirectory,
+		userName,
+		a.client.Auth.ActiveDirectory.Config.Users.SearchBase,
+		a.client.Auth.ActiveDirectory.Config.Groups.SearchBase,
+	)
+
+	err = authactions.VerifyPrincipalSearchReturnsID(authAdmin, userPrefix, expectedUserPrincipalID)
+	require.NoError(a.T(), err, "User [%v] should be findable by partial name [%v]", userName, userPrefix)
+}
+
+func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryPrincipalSearchByPrincipalType() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	groupName := a.authConfig.Group
+	expectedGroupPrincipalID := authactions.GetGroupPrincipalID(
+		authactions.ActiveDirectory,
+		groupName,
+		a.client.Auth.ActiveDirectory.Config.Users.SearchBase,
+		a.client.Auth.ActiveDirectory.Config.Groups.SearchBase,
+	)
+
+	logrus.Infof("Searching principals for Active Directory group [%v] restricted to type [%v]", groupName, authactions.PrincipalTypeGroup)
+	err = authactions.VerifyPrincipalSearchByTypeReturnsOnly(authAdmin, groupName, authactions.PrincipalTypeGroup, expectedGroupPrincipalID)
+	require.NoError(a.T(), err, "Search restricted to groups should return group [%v] and nothing of another type", groupName)
+
+	userName := a.authConfig.Users[0].Username
+	expectedUserPrincipalID := authactions.GetUserPrincipalID(
+		authactions.ActiveDirectory,
+		userName,
+		a.client.Auth.ActiveDirectory.Config.Users.SearchBase,
+		a.client.Auth.ActiveDirectory.Config.Groups.SearchBase,
+	)
+
+	logrus.Infof("Searching principals for Active Directory user [%v] restricted to type [%v]", userName, authactions.PrincipalTypeUser)
+	err = authactions.VerifyPrincipalSearchByTypeReturnsOnly(authAdmin, userName, authactions.PrincipalTypeUser, expectedUserPrincipalID)
+	require.NoError(a.T(), err, "Search restricted to users should return user [%v] and nothing of another type", userName)
+}
+
+func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryPrincipalByIDResolvesGroupAndUser() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	groupPrincipalID := authactions.GetGroupPrincipalID(
+		authactions.ActiveDirectory,
+		a.authConfig.Group,
+		a.client.Auth.ActiveDirectory.Config.Users.SearchBase,
+		a.client.Auth.ActiveDirectory.Config.Groups.SearchBase,
+	)
+
+	logrus.Infof("Resolving Active Directory group principal [%v] by ID", groupPrincipalID)
+	err = authactions.VerifyPrincipalByID(authAdmin, groupPrincipalID, authactions.ActiveDirectory, authactions.PrincipalTypeGroup)
+	require.NoError(a.T(), err, "Group principal [%v] should resolve by ID", groupPrincipalID)
+
+	userPrincipalID := authactions.GetUserPrincipalID(
+		authactions.ActiveDirectory,
+		a.authConfig.Users[0].Username,
+		a.client.Auth.ActiveDirectory.Config.Users.SearchBase,
+		a.client.Auth.ActiveDirectory.Config.Groups.SearchBase,
+	)
+
+	logrus.Infof("Resolving Active Directory user principal [%v] by ID", userPrincipalID)
+	err = authactions.VerifyPrincipalByID(authAdmin, userPrincipalID, authactions.ActiveDirectory, authactions.PrincipalTypeUser)
+	require.NoError(a.T(), err, "User principal [%v] should resolve by ID", userPrincipalID)
+}
+
+func (a *ActiveDirectoryAuthProviderSuite) TestActiveDirectoryPrincipalSearchAfterProviderDisabled() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	groupName := a.authConfig.Group
+	expectedGroupPrincipalID := authactions.GetGroupPrincipalID(
+		authactions.ActiveDirectory,
+		groupName,
+		a.client.Auth.ActiveDirectory.Config.Users.SearchBase,
+		a.client.Auth.ActiveDirectory.Config.Groups.SearchBase,
+	)
+
+	logrus.Infof("Confirming Active Directory group [%v] is findable while the provider is enabled", groupName)
+	err = authactions.VerifyPrincipalSearchReturnsID(authAdmin, groupName, expectedGroupPrincipalID)
+	require.NoError(a.T(), err, "Group [%v] should be findable while Active Directory is enabled", groupName)
+
+	logrus.Info("Disabling Active Directory before searching principals again")
+	err = a.client.Auth.ActiveDirectory.Disable()
+	require.NoError(a.T(), err, "Failed to disable Active Directory")
+
+	subSession.RegisterCleanupFunc(func() error {
+		return authactions.EnsureAuthProviderEnabled(a.client, authactions.ActiveDirectory)
+	})
+
+	_, err = authactions.WaitForAuthProviderAnnotationUpdate(a.client, authactions.ActiveDirectory, authactions.AuthProvCleanupAnnotationValLocked)
+	require.NoError(a.T(), err, "Failed waiting for annotation update")
+
+	logrus.Infof("Searching principals for [%v] with Active Directory disabled", groupName)
+	err = authactions.VerifyPrincipalSearchExcludesProvider(a.client, groupName, authactions.ActiveDirectory)
+	require.NoError(a.T(), err, "No Active Directory principal should be returned while the provider is disabled")
 }
 
 func TestActiveDirectoryAuthProviderSuite(t *testing.T) {

--- a/validation/auth/provider/openldap/openldap_test.go
+++ b/validation/auth/provider/openldap/openldap_test.go
@@ -17,6 +17,7 @@ import (
 	authactions "github.com/rancher/tests/actions/auth"
 	projectapi "github.com/rancher/tests/actions/kubeapi/projects"
 	rbacapi "github.com/rancher/tests/actions/kubeapi/rbac"
+	userapi "github.com/rancher/tests/actions/kubeapi/users"
 	"github.com/rancher/tests/actions/rbac"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -94,6 +95,70 @@ func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPEnableProvider() {
 	require.NoError(a.T(), err, "Failed to retrieve password secret")
 
 	require.Equal(a.T(), a.client.Auth.OLDAP.Config.ServiceAccount.Password, string(secret.Data["serviceaccountpassword"]), "Password mismatch")
+}
+
+func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPEnableRequiresExplicitAccessMode() {
+	subSession := a.session.NewSession()
+	defer subSession.Cleanup()
+
+	err := authactions.EnsureAuthProviderEnabled(a.client, authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to enable OpenLDAP")
+
+	configuredAccessMode := a.client.Auth.OLDAP.Config.AccessMode
+	subSession.RegisterCleanupFunc(func() error {
+		a.client.Auth.OLDAP.Config.AccessMode = configuredAccessMode
+		return authactions.EnsureAuthProviderEnabled(a.client, authactions.OpenLdap)
+	})
+
+	logrus.Info("Disabling OpenLDAP so the enable path runs against a fresh provider")
+	err = a.client.Auth.OLDAP.Disable()
+	require.NoError(a.T(), err, "Failed to disable OpenLDAP")
+
+	_, err = authactions.WaitForAuthProviderAnnotationUpdate(a.client, authactions.OpenLdap, authactions.AuthProvCleanupAnnotationValLocked)
+	require.NoError(a.T(), err, "Failed waiting for annotation update")
+
+	a.client.Auth.OLDAP.Config.AccessMode = ""
+
+	logrus.Info("Enabling OpenLDAP with no access mode in the request")
+	err = a.client.Auth.OLDAP.Enable()
+	require.Error(a.T(), err, "Enabling without an access mode must be rejected so the provider can never come up open to every directory user")
+	require.Contains(a.T(), err.Error(), authactions.AccessModeMissingRequiredError, "Enable should be rejected because accessMode is a required field")
+
+	ldapConfig, err := a.client.Management.AuthConfig.ByID(authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to retrieve OpenLDAP config")
+	require.False(a.T(), ldapConfig.Enabled, "OpenLDAP should remain disabled after a rejected enable")
+}
+
+func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPEnableIntoRestrictedAccessModeIsRejected() {
+	subSession := a.session.NewSession()
+	defer subSession.Cleanup()
+
+	err := authactions.EnsureAuthProviderEnabled(a.client, authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to enable OpenLDAP")
+
+	configuredAccessMode := a.client.Auth.OLDAP.Config.AccessMode
+	subSession.RegisterCleanupFunc(func() error {
+		a.client.Auth.OLDAP.Config.AccessMode = configuredAccessMode
+		return authactions.EnsureAuthProviderEnabled(a.client, authactions.OpenLdap)
+	})
+
+	logrus.Info("Disabling OpenLDAP so the enable path runs against a fresh provider")
+	err = a.client.Auth.OLDAP.Disable()
+	require.NoError(a.T(), err, "Failed to disable OpenLDAP")
+
+	_, err = authactions.WaitForAuthProviderAnnotationUpdate(a.client, authactions.OpenLdap, authactions.AuthProvCleanupAnnotationValLocked)
+	require.NoError(a.T(), err, "Failed waiting for annotation update")
+
+	a.client.Auth.OLDAP.Config.AccessMode = authactions.AccessModeRestricted
+
+	logrus.Info("Enabling OpenLDAP directly into restricted access mode")
+	err = a.client.Auth.OLDAP.Enable()
+	require.Error(a.T(), err, "OpenLDAP cannot be enabled directly into restricted access mode: the enabling admin is never added to allowedPrincipalIDs and every binding for the provider is deleted while it is disabled")
+	require.Contains(a.T(), err.Error(), authactions.PermissionDeniedError, "Enable should be rejected with permission denied")
+
+	ldapConfig, err := a.client.Management.AuthConfig.ByID(authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to retrieve OpenLDAP config")
+	require.False(a.T(), ldapConfig.Enabled, "OpenLDAP should remain disabled after a rejected enable")
 }
 
 func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPDisableAndReenableProvider() {
@@ -466,6 +531,273 @@ func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPRequiredModeUnauthorizedLoginDen
 
 	_, err = authactions.UpdateAccessMode(a.client, authactions.OpenLdap, authactions.AccessModeUnrestricted, nil)
 	require.NoError(a.T(), err, "Failed to rollback access mode")
+}
+
+func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPRequiredModeRevokedPrincipalLoginDenied() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	subSession.RegisterCleanupFunc(func() error {
+		_, rollbackErr := authactions.UpdateAccessMode(a.client, authactions.OpenLdap, authactions.AccessModeUnrestricted, nil)
+		return rollbackErr
+	})
+
+	userSearchBase := a.client.Auth.OLDAP.Config.Users.SearchBase
+	groupSearchBase := a.client.Auth.OLDAP.Config.Groups.SearchBase
+
+	grantedPrincipalIDs := []string{authactions.GetGroupPrincipalID(authactions.OpenLdap, a.authConfig.Group, userSearchBase, groupSearchBase)}
+	for _, user := range a.authConfig.Users {
+		grantedPrincipalIDs = append(grantedPrincipalIDs, authactions.GetUserPrincipalID(authactions.OpenLdap, user.Username, userSearchBase, groupSearchBase))
+	}
+
+	logrus.Infof("Granting OpenLDAP group [%v] and its members access in required mode", a.authConfig.Group)
+	grantedConfig, err := authactions.UpdateAccessMode(a.client, authactions.OpenLdap, authactions.AccessModeRequired, grantedPrincipalIDs)
+	require.NoError(a.T(), err, "Failed to update access mode")
+	require.Equal(a.T(), authactions.AccessModeRequired, grantedConfig.AccessMode, "Access mode should be required")
+	require.ElementsMatch(a.T(), grantedPrincipalIDs, grantedConfig.AllowedPrincipalIDs, "Granted principals should be persisted exactly as sent")
+
+	err = authactions.VerifyUserLogins(authAdmin, authactions.OpenLdap, a.authConfig.Users, "required access mode with principals granted", true)
+	require.NoError(a.T(), err, "Granted users should be able to login")
+
+	revokedPrincipalIDs := []string{authactions.GetGroupPrincipalID(authactions.OpenLdap, a.authConfig.NestedGroup, userSearchBase, groupSearchBase)}
+
+	logrus.Infof("Revoking OpenLDAP group [%v] and its members, leaving only group [%v] allowed", a.authConfig.Group, a.authConfig.NestedGroup)
+	revokedConfig, err := authactions.UpdateAccessMode(a.client, authactions.OpenLdap, authactions.AccessModeRequired, revokedPrincipalIDs)
+	require.NoError(a.T(), err, "Failed to revoke principals")
+	require.Equal(a.T(), authactions.AccessModeRequired, revokedConfig.AccessMode, "Access mode should remain required")
+	require.ElementsMatch(a.T(), revokedPrincipalIDs, revokedConfig.AllowedPrincipalIDs, "Revoked principals should no longer appear in the allow list")
+
+	err = authactions.VerifyUserLogins(authAdmin, authactions.OpenLdap, a.authConfig.Users, "required access mode after principals revoked", false)
+	require.NoError(a.T(), err, "Revoked users should NOT be able to login")
+
+	err = authactions.VerifyUserLogins(authAdmin, authactions.OpenLdap, a.authConfig.NestedUsers, "required access mode after principals revoked", true)
+	require.NoError(a.T(), err, "Users in the still-allowed group should be able to login")
+}
+
+func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPPrincipalSearchFindsGroups() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	groupNames := []string{a.authConfig.Group, a.authConfig.NestedGroup, a.authConfig.DoubleNestedGroup}
+	for _, groupName := range groupNames {
+		logrus.Infof("Searching principals for OpenLDAP group [%v]", groupName)
+		expectedPrincipalID := authactions.GetGroupPrincipalID(
+			authactions.OpenLdap,
+			groupName,
+			a.client.Auth.OLDAP.Config.Users.SearchBase,
+			a.client.Auth.OLDAP.Config.Groups.SearchBase,
+		)
+
+		err = authactions.VerifyPrincipalSearchReturnsID(authAdmin, groupName, expectedPrincipalID)
+		require.NoError(a.T(), err, "Group [%v] should be findable through principal search", groupName)
+	}
+}
+
+func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPPrincipalSearchFindsUsers() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	allUsers := slices.Concat(a.authConfig.Users, a.authConfig.NestedUsers, a.authConfig.DoubleNestedUsers)
+	for _, userInfo := range allUsers {
+		logrus.Infof("Searching principals for OpenLDAP user [%v]", userInfo.Username)
+		expectedPrincipalID := authactions.GetUserPrincipalID(
+			authactions.OpenLdap,
+			userInfo.Username,
+			a.client.Auth.OLDAP.Config.Users.SearchBase,
+			a.client.Auth.OLDAP.Config.Groups.SearchBase,
+		)
+
+		err = authactions.VerifyPrincipalSearchReturnsID(authAdmin, userInfo.Username, expectedPrincipalID)
+		require.NoError(a.T(), err, "User [%v] should be findable through principal search", userInfo.Username)
+	}
+}
+
+func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPPrincipalSearchFindsLocalUserByDisplayName() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	logrus.Info("Creating a local user whose display name differs from its username")
+	localUser, err := userapi.CreateUser(authAdmin)
+	require.NoError(a.T(), err, "Failed to create local user")
+	require.NotEqual(a.T(), localUser.Username, localUser.DisplayName, "Local user display name must differ from its username for this search to be meaningful")
+
+	logrus.Infof("Searching principals for local user by username [%v]", localUser.Username)
+	err = authactions.VerifyPrincipalIsLocal(a.client, localUser.Username)
+	require.NoError(a.T(), err, "Local user [%v] should be findable by username", localUser.Username)
+
+	logrus.Infof("Searching principals for local user by display name [%v]", localUser.DisplayName)
+	err = authactions.VerifyPrincipalIsLocal(a.client, localUser.DisplayName)
+	require.NoError(a.T(), err, "Local user [%v] should be findable by display name [%v]", localUser.Username, localUser.DisplayName)
+}
+
+func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPPrincipalSearchProvisionedUserIsNotLocal() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	userInfo := a.authConfig.Users[0]
+	logrus.Infof("Logging in as OpenLDAP user [%v] to provision the Rancher user", userInfo.Username)
+	user := &v3.User{
+		Username: userInfo.Username,
+		Password: userInfo.Password,
+	}
+	userClient, err := authactions.LoginAsAuthUser(authAdmin, user, authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to login user [%v]", userInfo.Username)
+
+	provisionedUser, err := a.client.WranglerContext.Mgmt.User().Get(userClient.UserID, metav1.GetOptions{})
+	require.NoError(a.T(), err, "Failed to retrieve the Rancher user provisioned for [%v]", userInfo.Username)
+	logrus.Infof("OpenLDAP user [%v] provisioned Rancher user [%v] with display name [%v], username [%v] and principals %v",
+		userInfo.Username, provisionedUser.Name, provisionedUser.DisplayName, provisionedUser.Username, provisionedUser.PrincipalIDs)
+
+	require.Empty(a.T(), provisionedUser.Username, "Externally provisioned user [%v] should carry no local login username", userInfo.Username)
+	require.Greater(a.T(), len(provisionedUser.PrincipalIDs), 1, "Externally provisioned user [%v] should carry an external principal alongside the local one", userInfo.Username)
+
+	expectedPrincipalID := authactions.GetUserPrincipalID(
+		authactions.OpenLdap,
+		userInfo.Username,
+		a.client.Auth.OLDAP.Config.Users.SearchBase,
+		a.client.Auth.OLDAP.Config.Groups.SearchBase,
+	)
+
+	for _, searchTerm := range []string{userInfo.Username, provisionedUser.DisplayName} {
+		logrus.Infof("Searching principals for provisioned user [%v] using term [%v]", userInfo.Username, searchTerm)
+		err = authactions.VerifyPrincipalSearchReturnsID(authAdmin, searchTerm, expectedPrincipalID)
+		require.NoError(a.T(), err, "Provisioned user [%v] should stay findable when searching [%v]", userInfo.Username, searchTerm)
+
+		err = authactions.VerifyPrincipalNotLocal(authAdmin, searchTerm)
+		require.NoError(a.T(), err, "Provisioned user [%v] should not surface as a local principal when searching [%v]", userInfo.Username, searchTerm)
+	}
+}
+
+func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPPrincipalSearchByPartialName() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	groupName := a.authConfig.Group
+	require.NotEmpty(a.T(), groupName, "Group name should be set in the auth configuration")
+	groupPrefix := groupName[:len(groupName)/2+1]
+
+	logrus.Infof("Searching principals for OpenLDAP group [%v] using partial name [%v]", groupName, groupPrefix)
+	expectedGroupPrincipalID := authactions.GetGroupPrincipalID(
+		authactions.OpenLdap,
+		groupName,
+		a.client.Auth.OLDAP.Config.Users.SearchBase,
+		a.client.Auth.OLDAP.Config.Groups.SearchBase,
+	)
+
+	err = authactions.VerifyPrincipalSearchReturnsID(authAdmin, groupPrefix, expectedGroupPrincipalID)
+	require.NoError(a.T(), err, "Group [%v] should be findable by partial name [%v]", groupName, groupPrefix)
+
+	userName := a.authConfig.Users[0].Username
+	require.NotEmpty(a.T(), userName, "User name should be set in the auth configuration")
+	userPrefix := userName[:len(userName)/2+1]
+
+	logrus.Infof("Searching principals for OpenLDAP user [%v] using partial name [%v]", userName, userPrefix)
+	expectedUserPrincipalID := authactions.GetUserPrincipalID(
+		authactions.OpenLdap,
+		userName,
+		a.client.Auth.OLDAP.Config.Users.SearchBase,
+		a.client.Auth.OLDAP.Config.Groups.SearchBase,
+	)
+
+	err = authactions.VerifyPrincipalSearchReturnsID(authAdmin, userPrefix, expectedUserPrincipalID)
+	require.NoError(a.T(), err, "User [%v] should be findable by partial name [%v]", userName, userPrefix)
+}
+
+func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPPrincipalSearchByPrincipalType() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	groupName := a.authConfig.Group
+	expectedGroupPrincipalID := authactions.GetGroupPrincipalID(
+		authactions.OpenLdap,
+		groupName,
+		a.client.Auth.OLDAP.Config.Users.SearchBase,
+		a.client.Auth.OLDAP.Config.Groups.SearchBase,
+	)
+
+	logrus.Infof("Searching principals for OpenLDAP group [%v] restricted to type [%v]", groupName, authactions.PrincipalTypeGroup)
+	err = authactions.VerifyPrincipalSearchByTypeReturnsOnly(authAdmin, groupName, authactions.PrincipalTypeGroup, expectedGroupPrincipalID)
+	require.NoError(a.T(), err, "Search restricted to groups should return group [%v] and nothing of another type", groupName)
+
+	userName := a.authConfig.Users[0].Username
+	expectedUserPrincipalID := authactions.GetUserPrincipalID(
+		authactions.OpenLdap,
+		userName,
+		a.client.Auth.OLDAP.Config.Users.SearchBase,
+		a.client.Auth.OLDAP.Config.Groups.SearchBase,
+	)
+
+	logrus.Infof("Searching principals for OpenLDAP user [%v] restricted to type [%v]", userName, authactions.PrincipalTypeUser)
+	err = authactions.VerifyPrincipalSearchByTypeReturnsOnly(authAdmin, userName, authactions.PrincipalTypeUser, expectedUserPrincipalID)
+	require.NoError(a.T(), err, "Search restricted to users should return user [%v] and nothing of another type", userName)
+}
+
+func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPPrincipalByIDResolvesGroupAndUser() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	groupPrincipalID := authactions.GetGroupPrincipalID(
+		authactions.OpenLdap,
+		a.authConfig.Group,
+		a.client.Auth.OLDAP.Config.Users.SearchBase,
+		a.client.Auth.OLDAP.Config.Groups.SearchBase,
+	)
+
+	logrus.Infof("Resolving OpenLDAP group principal [%v] by ID", groupPrincipalID)
+	err = authactions.VerifyPrincipalByID(authAdmin, groupPrincipalID, authactions.OpenLdap, authactions.PrincipalTypeGroup)
+	require.NoError(a.T(), err, "Group principal [%v] should resolve by ID", groupPrincipalID)
+
+	userPrincipalID := authactions.GetUserPrincipalID(
+		authactions.OpenLdap,
+		a.authConfig.Users[0].Username,
+		a.client.Auth.OLDAP.Config.Users.SearchBase,
+		a.client.Auth.OLDAP.Config.Groups.SearchBase,
+	)
+
+	logrus.Infof("Resolving OpenLDAP user principal [%v] by ID", userPrincipalID)
+	err = authactions.VerifyPrincipalByID(authAdmin, userPrincipalID, authactions.OpenLdap, authactions.PrincipalTypeUser)
+	require.NoError(a.T(), err, "User principal [%v] should resolve by ID", userPrincipalID)
+}
+
+func (a *OpenLDAPAuthProviderSuite) TestOpenLDAPPrincipalSearchAfterProviderDisabled() {
+	subSession, authAdmin, err := authactions.SetupAuthenticatedSession(a.client, a.session, a.adminUser, authactions.OpenLdap)
+	require.NoError(a.T(), err, "Failed to setup authenticated test")
+	defer subSession.Cleanup()
+
+	groupName := a.authConfig.Group
+	expectedGroupPrincipalID := authactions.GetGroupPrincipalID(
+		authactions.OpenLdap,
+		groupName,
+		a.client.Auth.OLDAP.Config.Users.SearchBase,
+		a.client.Auth.OLDAP.Config.Groups.SearchBase,
+	)
+
+	logrus.Infof("Confirming OpenLDAP group [%v] is findable while the provider is enabled", groupName)
+	err = authactions.VerifyPrincipalSearchReturnsID(authAdmin, groupName, expectedGroupPrincipalID)
+	require.NoError(a.T(), err, "Group [%v] should be findable while OpenLDAP is enabled", groupName)
+
+	logrus.Info("Disabling OpenLDAP before searching principals again")
+	err = a.client.Auth.OLDAP.Disable()
+	require.NoError(a.T(), err, "Failed to disable OpenLDAP")
+
+	subSession.RegisterCleanupFunc(func() error {
+		return authactions.EnsureAuthProviderEnabled(a.client, authactions.OpenLdap)
+	})
+
+	_, err = authactions.WaitForAuthProviderAnnotationUpdate(a.client, authactions.OpenLdap, authactions.AuthProvCleanupAnnotationValLocked)
+	require.NoError(a.T(), err, "Failed waiting for annotation update")
+
+	logrus.Infof("Searching principals for [%v] with OpenLDAP disabled", groupName)
+	err = authactions.VerifyPrincipalSearchExcludesProvider(a.client, groupName, authactions.OpenLdap)
+	require.NoError(a.T(), err, "No OpenLDAP principal should be returned while the provider is disabled")
 }
 
 func TestOpenLDAPAuthProviderSuite(t *testing.T) {


### PR DESCRIPTION
## Problem

Both auth provider suites hand-construct principal IDs via `GetGroupPrincipalID` / `GetUserPrincipalID` and never call `POST /v3/principals?action=search`. A pure findability regression in the search endpoint — the one the UI uses to populate every principal picker — leaves the whole suite green.

## What this adds

Eight tests per provider (OpenLDAP and Active Directory) that assert the principal ID returned by search matches the constructed one, compared case-insensitively since DNs are not case-sensitive.

| Test | Catches |
|---|---|
| `…PrincipalSearchFindsGroups` | Groups unfindable by exact name, across nesting levels |
| `…PrincipalSearchFindsUsers` | Users unfindable by exact name, across nesting levels |
| `…PrincipalSearchFindsLocalUserByDisplayName` | A local user no longer matching on display name |
| `…PrincipalSearchProvisionedUserIsNotLocal` | An externally provisioned user surfacing as a local principal |
| `…PrincipalSearchByPartialName` | Prefix/substring matching regressions — the UI typeahead path |
| `…PrincipalSearchByPrincipalType` | A broken `principalType` filter returning off-type results |
| `…PrincipalByIDResolvesGroupAndUser` | `/v3/principals/<id>` failing to resolve provider, type or display name |
| `…PrincipalSearchAfterProviderDisabled` | Principals still served from a disabled provider |

## Context on the `IsNotLocal` tests

Related to rancher/rancher#56362. The reporter's stated root cause there does not hold — rancher/rancher#56081 changed `isLocalUser`, which filters results rather than changing what matches, and the display-name index still matches. #56081 (deduplicating external users) and #56362 want opposite behaviour, so only one can hold.

`…PrincipalSearchProvisionedUserIsNotLocal` exercises the actual discriminator: a provisioned user has an empty `username` and more than one principal ID. If `isLocalUser` is later relaxed to satisfy #56362, these tests go red across AD, OpenLDAP and the existing SCIM suite at the same time, which makes the trade-off visible rather than silent.

## Helper placement

Four new helpers in `actions/auth/verify.go`, all Action-tier per the [Actions vs Extensions](https://confluence.suse.com/spaces/RANQA/pages/1505559041/Actions+vs+Extensions) rubric — they are `Verify`-prefixed test-flow assertions with no CRUD, and they sit alongside the existing `VerifyPrincipalIsLocal` / `VerifyPrincipalNotLocal`:

- `VerifyPrincipalSearchReturnsID`
- `VerifyPrincipalSearchByTypeReturnsOnly`
- `VerifyPrincipalSearchExcludesProvider`
- `VerifyPrincipalByID`

The shared `searchPrincipals` helper takes a `principalType` (empty for unrestricted). `NewPrincipalID`, `GetGroupPrincipalID` and `GetUserPrincipalID` now use new `PrincipalTypeUser` / `PrincipalTypeGroup` constants instead of string literals.

No shepherd change is required.

## Notes for reviewers

- `…PrincipalSearchAfterProviderDisabled` mutates cluster state mid-suite. It uses the local admin client rather than the LDAP-authenticated one for the post-disable search, because disabling the provider invalidates the LDAP-issued token, and it re-enables the provider at the end.
- `VerifyPrincipalByID` path-escapes the ID: norman's `DoByID` concatenates it into the URL with no escaping, and a principal ID embeds both a scheme separator and a DN. There was no prior use of `Principal.ByID` in this repo or shepherd; it has been confirmed working against a live setup.

## Testing

All sixteen tests pass against a live Rancher with both providers configured. `go vet -tags validation ./validation/auth/provider/...` and `go build ./...` in the `actions` module are clean.