### PR TITLE
Add `TestMonitoringIntegration`

### DIFF
--- a/actions/go.mod
+++ b/actions/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.2
 	github.com/longhorn/longhorn-manager v1.12.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.72.0
 	github.com/rancher/norman v0.9.9
 	github.com/rancher/rancher v0.0.0-20260527150105-ae26ccbc3fed
 	github.com/rancher/wrangler v1.1.2
@@ -190,7 +191,6 @@ require (
 	github.com/pkg/sftp v1.13.5 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.72.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect

--- a/actions/monitoring/grafana.go
+++ b/actions/monitoring/grafana.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	GrafanaProxyURLTemplate = "https://%s/k8s/clusters/%s/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"
-	LoginURL                = "/login"
 	DsQueryURL              = "/api/ds/query"
 )
 
@@ -35,11 +34,18 @@ type QueryResponse struct {
 }
 
 func doRequest(client http.Client, method string, url string, payload any) ([]byte, []*http.Cookie, error) {
-	req, _ := http.NewRequest(method, url, nil)
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	if payload != nil {
 		req.Header.Set("Content-Type", "application/json")
-		jsonPayload, _ := json.Marshal(payload)
+		jsonPayload, err := json.Marshal(payload)
+		if err != nil {
+			return nil, nil, fmt.Errorf("payload is not proper JSON: %w", err)
+		}
+
 		req.Body = io.NopCloser(bytes.NewBuffer(jsonPayload))
 	}
 
@@ -48,17 +54,21 @@ func doRequest(client http.Client, method string, url string, payload any) ([]by
 		return nil, nil, err
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
 		return body, resp.Cookies(), nil
 	}
 
-	return nil, nil, fmt.Errorf("Request to %s failed with %d: %s\n", url, resp.StatusCode, string(body))
+	return nil, nil, fmt.Errorf("request to %s failed with %d: %s", url, resp.StatusCode, string(body))
 }
 
-// LoginGrafana logs in to a Rancher-proxied Grafana and returns a client embedded with a cookie containing a Ranher user token.
-func LoginGrafana(rancherHost string, rancherToken string, clusterID string, skipTLS bool) (*http.Client, error) {
+// NewGrafanaProxyClient creates Rancher-proxied client to Grafana by embedding it with a cookie containing a Rancher user token and returns it.
+func NewGrafanaProxyClient(rancherHost string, rancherToken string, skipTLS bool) (*http.Client, error) {
 	jar, _ := cookiejar.New(nil)
 	httpClient := &http.Client{
 		Transport: &http.Transport{
@@ -104,7 +114,7 @@ func PrometheusQueryInGrafana(client *http.Client, rancherHost string, clusterID
 		}
 
 		if err := json.Unmarshal(respBytes, &resp); err != nil {
-			return false, err
+			return false, nil
 		}
 
 		if len(resp.Results.A.Frames) == 0 {

--- a/actions/monitoring/grafana.go
+++ b/actions/monitoring/grafana.go
@@ -1,0 +1,125 @@
+package monitoring
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"time"
+
+	"github.com/rancher/shepherd/extensions/defaults"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	GrafanaProxyURLTemplate = "https://%s/k8s/clusters/%s/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"
+	LoginURL                = "/login"
+	DsQueryURL              = "/api/ds/query"
+)
+
+type QueryResponse struct {
+	Results struct {
+		A struct {
+			Frames []struct {
+				Data struct {
+					Values [][]int `json:"values"`
+				} `json:"data"`
+			} `json:"frames"`
+		} `json:"A"`
+	} `json:"results"`
+}
+
+func doRequest(client http.Client, method string, url string, payload any) ([]byte, []*http.Cookie, error) {
+	req, _ := http.NewRequest(method, url, nil)
+
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+		jsonPayload, _ := json.Marshal(payload)
+		req.Body = io.NopCloser(bytes.NewBuffer(jsonPayload))
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
+		return body, resp.Cookies(), nil
+	}
+
+	return nil, nil, fmt.Errorf("Request to %s failed with %d: %s\n", url, resp.StatusCode, string(body))
+}
+
+// LoginGrafana logs in to a Rancher-proxied Grafana and returns a client embedded with a cookie containing a Ranher user token.
+func LoginGrafana(rancherHost string, rancherToken string, clusterID string, skipTLS bool) (*http.Client, error) {
+	jar, _ := cookiejar.New(nil)
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: skipTLS},
+		},
+		Jar: jar,
+	}
+
+	parsedBaseURL, err := url.Parse("https://" + rancherHost)
+	if err != nil {
+		return nil, err
+	}
+
+	cookies := []*http.Cookie{{Name: "R_SESS", Value: rancherToken}}
+	httpClient.Jar.SetCookies(parsedBaseURL, cookies)
+
+	return httpClient, nil
+}
+
+// PrometheusQueryInGrafana runs a Prometheus query using the Grafana API as the best way to check for expected values on Grafana dashboards.
+func PrometheusQueryInGrafana(client *http.Client, rancherHost string, clusterID string, query string) (int, error) {
+	body := map[string]any{
+		"queries": []map[string]any{{
+			"refId": "A",
+			"datasource": map[string]any{
+				"uid": "prometheus",
+			},
+			"expr":      query,
+			"queryType": "instant",
+			"format":    "table",
+		}},
+		"from": "now",
+		"to":   "now",
+	}
+
+	grafanaProxyURL := fmt.Sprintf(GrafanaProxyURLTemplate, rancherHost, clusterID)
+	var value int
+	var resp QueryResponse
+	err := kwait.PollUntilContextTimeout(context.Background(), defaults.FiveHundredMillisecondTimeout, 30*time.Second, false, func(context.Context) (bool, error) {
+		respBytes, _, err := doRequest(*client, http.MethodPost, grafanaProxyURL+DsQueryURL, body)
+		if err != nil {
+			return false, err
+		}
+
+		if err := json.Unmarshal(respBytes, &resp); err != nil {
+			return false, err
+		}
+
+		if len(resp.Results.A.Frames) == 0 {
+			return false, fmt.Errorf("No frames returned")
+		}
+
+		values := resp.Results.A.Frames[0].Data.Values
+
+		if len(values) < 2 || len(values[1]) == 0 {
+			return false, nil // If no values are shown, possibly this is because prometheus data takes a second to keep up.
+		}
+
+		value = values[1][0]
+		return true, nil
+	})
+
+	return value, err
+}

--- a/actions/monitoring/monitor.go
+++ b/actions/monitoring/monitor.go
@@ -1,0 +1,52 @@
+package monitoring
+
+import (
+	"context"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// CreateServiceMonitor creates a service monitor using Wrangler/Public API. The ServiceMonitor object follows the example on https://support.scc.suse.com/s/kb/Longhorn-monitoring-with-grafana-and-prometheus.
+func CreateServiceMonitor(client *rancher.Client, clusterID string, name string, namespace string, serviceMonitorSpec monitoringv1.ServiceMonitorSpec) (*monitoringv1.ServiceMonitor, error) {
+	wrangler, err := cluster.GetClusterWranglerContext(client, clusterID)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceMonitorController, err := wrangler.ControllerFactory.ForKind(schema.GroupVersionKind{
+		Group:   monitoringv1.SchemeGroupVersion.Group,
+		Version: monitoringv1.SchemeGroupVersion.Version,
+		Kind:    monitoringv1.ServiceMonitorsKind,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	serviceMonitor := monitoringv1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{"name": name},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       monitoringv1.ServiceMonitorsKind,
+			APIVersion: monitoringv1.SchemeGroupVersion.Group + "/" + monitoringv1.SchemeGroupVersion.Version,
+		},
+		Spec: serviceMonitorSpec,
+	}
+
+	err = serviceMonitorController.Client().Create(context.Background(), namespace, &serviceMonitor, &serviceMonitor, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	client.Session.RegisterCleanupFunc(func() error {
+		return serviceMonitorController.Client().Delete(context.Background(), namespace, name, *metav1.NewDeleteOptions(60))
+	})
+
+	return &serviceMonitor, nil
+}

--- a/validation/longhorn/longhorn_test.go
+++ b/validation/longhorn/longhorn_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/rancher/shepherd/clients/rancher/catalog"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
-	extencharts "github.com/rancher/shepherd/extensions/charts"
 	shepherdCharts "github.com/rancher/shepherd/extensions/charts"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
 	"github.com/rancher/shepherd/extensions/clusters"
@@ -58,7 +57,7 @@ var (
 	LonghornEncryptionSecretBaseName       = "longhorn-crypto"
 	LonghornEncryptionStorageClassBaseName = "longhorn-crypto-global"
 	volumeBytesPrometheusQueryTemplate     = "longhorn_volume_capacity_bytes{volume=\"%s\"}"
-	numberVolumesPrometheusQuery           = "count(longhorn_volume_capacity_bytes) OR on() vector(0)"
+	numberVolumesPrometheusQuery           = "count(longhorn_volume_capacity_bytes) OR on() vector(0)" // Return an empty list instead of nil with OR on() vector(0).
 )
 
 type LonghornTestSuite struct {
@@ -434,7 +433,7 @@ func (l *LonghornTestSuite) TestVolumeEncryption() {
 
 func (l *LonghornTestSuite) TestMonitoringIntegration() {
 	l.T().Log("Checking if the monitoring chart is already installed")
-	initialMonitoringChart, err := extencharts.GetChartStatus(l.client, l.cluster.ID, charts.RancherMonitoringNamespace, charts.RancherMonitoringName)
+	initialMonitoringChart, err := shepherdCharts.GetChartStatus(l.client, l.cluster.ID, charts.RancherMonitoringNamespace, charts.RancherMonitoringName)
 	require.NoError(l.T(), err)
 
 	if !initialMonitoringChart.IsAlreadyInstalled {
@@ -480,7 +479,7 @@ func (l *LonghornTestSuite) TestMonitoringIntegration() {
 	require.NoError(l.T(), err)
 	l.T().Logf("ServiceMonitor %s for Longhorn created", serviceMonitorName)
 
-	loggedClient, err := monitoring.LoginGrafana(l.client.RancherConfig.Host, l.client.RancherConfig.AdminToken, l.cluster.ID, true)
+	loggedClient, err := monitoring.NewGrafanaProxyClient(l.client.RancherConfig.Host, l.client.RancherConfig.AdminToken, true)
 	require.NoError(l.T(), err)
 
 	l.T().Logf("Checking number of volumes with Prometheus through Grafana API (%s)", numberVolumesPrometheusQuery)

--- a/validation/longhorn/longhorn_test.go
+++ b/validation/longhorn/longhorn_test.go
@@ -499,7 +499,8 @@ func (l *LonghornTestSuite) TestMonitoringIntegration() {
 	l.T().Logf("Checking volume %s's size with Prometheus through Grafana API (%s)", volumeName, volumeSizeQuery)
 	value, err = monitoring.PrometheusQueryInGrafana(loggedClient, l.client.RancherConfig.Host, l.cluster.ID, volumeSizeQuery)
 	require.NoError(l.T(), err)
-	require.Equal(l.T(), 1*1024*1024*1024, value)
+	gigabyte := 1024 * 1024 * 1024
+	require.Equal(l.T(), gigabyte, value)
 
 	l.T().Logf("Checking new number of volumes with Prometheus through Grafana API (%s)", numberVolumesPrometheusQuery)
 	value, err = monitoring.PrometheusQueryInGrafana(loggedClient, l.client.RancherConfig.Host, l.cluster.ID, numberVolumesPrometheusQuery)

--- a/validation/longhorn/longhorn_test.go
+++ b/validation/longhorn/longhorn_test.go
@@ -10,13 +10,16 @@ import (
 	"net/url"
 	"os"
 	"slices"
+	"strings"
 	"testing"
 
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/rancher/norman/types"
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/clients/rancher/catalog"
 	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
 	steveV1 "github.com/rancher/shepherd/clients/rancher/v1"
+	extencharts "github.com/rancher/shepherd/extensions/charts"
 	shepherdCharts "github.com/rancher/shepherd/extensions/charts"
 	"github.com/rancher/shepherd/extensions/cloudcredentials"
 	"github.com/rancher/shepherd/extensions/clusters"
@@ -36,7 +39,9 @@ import (
 	"github.com/rancher/tests/actions/kubeapi/volumes/persistentvolumeclaims"
 	podapi "github.com/rancher/tests/actions/kubeapi/workloads/pods"
 	statefulsetapi "github.com/rancher/tests/actions/kubeapi/workloads/statefulsets"
+	"github.com/rancher/tests/actions/monitoring"
 	namespaceActions "github.com/rancher/tests/actions/namespaces"
+	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/rbac"
 	"github.com/rancher/tests/actions/storage"
 	s3Actions "github.com/rancher/tests/actions/storage/s3"
@@ -52,6 +57,8 @@ import (
 var (
 	LonghornEncryptionSecretBaseName       = "longhorn-crypto"
 	LonghornEncryptionStorageClassBaseName = "longhorn-crypto-global"
+	volumeBytesPrometheusQueryTemplate     = "longhorn_volume_capacity_bytes{volume=\"%s\"}"
+	numberVolumesPrometheusQuery           = "count(longhorn_volume_capacity_bytes) OR on() vector(0)"
 )
 
 type LonghornTestSuite struct {
@@ -423,6 +430,82 @@ func (l *LonghornTestSuite) TestVolumeEncryption() {
 	l.T().Logf("Validating that the old volume %s and the new volume %s are writable", volumeName, secondVolumeName)
 	storage.CheckMountedVolume(l.T(), kubeConfig, l.cluster.ID, namespaces.Default, otherPod.Name, storage.MountPath)
 	storage.CheckMountedVolume(l.T(), kubeConfig, l.cluster.ID, namespaces.Default, pod.Name, storage.MountPath)
+}
+
+func (l *LonghornTestSuite) TestMonitoringIntegration() {
+	l.T().Log("Checking if the monitoring chart is already installed")
+	initialMonitoringChart, err := extencharts.GetChartStatus(l.client, l.cluster.ID, charts.RancherMonitoringNamespace, charts.RancherMonitoringName)
+	require.NoError(l.T(), err)
+
+	if !initialMonitoringChart.IsAlreadyInstalled {
+		// Get latest versions of the monitoring chart
+		latestMonitoringVersion, err := l.client.Catalog.GetLatestChartVersion(charts.RancherMonitoringName, catalog.RancherChartRepo)
+		require.NoError(l.T(), err)
+
+		// Get project system projectId
+		monitoringProject, err := projects.GetProjectByName(l.client, l.cluster.ID, charts.SystemProject)
+		require.NoError(l.T(), err)
+
+		chartInstallOptions := &charts.InstallOptions{
+			Cluster:   l.cluster,
+			Version:   latestMonitoringVersion,
+			ProjectID: string(monitoringProject.ID),
+		}
+
+		l.T().Log("Installing monitoring chart")
+		err = charts.InstallRancherMonitoringChart(l.client, chartInstallOptions, &charts.RancherMonitoringOpts{
+			IngressNginx:      true,
+			ControllerManager: true,
+			Etcd:              true,
+			Proxy:             true,
+			Scheduler:         true,
+		})
+		require.NoError(l.T(), err)
+	}
+
+	serviceMonitorSpec := monitoringv1.ServiceMonitorSpec{
+		Selector: metav1.LabelSelector{
+			MatchLabels: map[string]string{"app": "longhorn-manager"},
+		},
+		NamespaceSelector: monitoringv1.NamespaceSelector{
+			MatchNames: []string{charts.LonghornNamespace},
+		},
+		Endpoints: []monitoringv1.Endpoint{
+			{Port: "manager"},
+		},
+	}
+
+	serviceMonitorName := namegenerator.AppendRandomString("longhorn-monitor")
+	_, err = monitoring.CreateServiceMonitor(l.client, l.cluster.ID, serviceMonitorName, charts.LonghornNamespace, serviceMonitorSpec)
+	require.NoError(l.T(), err)
+	l.T().Logf("ServiceMonitor %s for Longhorn created", serviceMonitorName)
+
+	loggedClient, err := monitoring.LoginGrafana(l.client.RancherConfig.Host, l.client.RancherConfig.AdminToken, l.cluster.ID, true)
+	require.NoError(l.T(), err)
+
+	l.T().Logf("Checking number of volumes with Prometheus through Grafana API (%s)", numberVolumesPrometheusQuery)
+	previousNumberOfVolumes, err := longhornActions.GetNumberOfLonghornVolumes(l.client, l.cluster.ID)
+	require.NoError(l.T(), err)
+
+	value, err := monitoring.PrometheusQueryInGrafana(loggedClient, l.client.RancherConfig.Host, l.cluster.ID, numberVolumesPrometheusQuery)
+	require.NoError(l.T(), err)
+	require.Equal(l.T(), previousNumberOfVolumes, value)
+
+	_, volumeName, err := storage.CreatePVC(l.client, l.cluster.ID, charts.LonghornStorageClass)
+	require.NoError(l.T(), err)
+	l.T().Logf("Volume %s created using %s PVC", volumeName, charts.LonghornStorageClass)
+
+	// CreatePVC creates a 1GiB volume.
+	volumeSizeQuery := fmt.Sprintf(volumeBytesPrometheusQueryTemplate, strings.TrimSpace(volumeName))
+	l.T().Logf("Checking volume %s's size with Prometheus through Grafana API (%s)", volumeName, volumeSizeQuery)
+	value, err = monitoring.PrometheusQueryInGrafana(loggedClient, l.client.RancherConfig.Host, l.cluster.ID, volumeSizeQuery)
+	require.NoError(l.T(), err)
+	require.Equal(l.T(), 1*1024*1024*1024, value)
+
+	l.T().Logf("Checking new number of volumes with Prometheus through Grafana API (%s)", numberVolumesPrometheusQuery)
+	value, err = monitoring.PrometheusQueryInGrafana(loggedClient, l.client.RancherConfig.Host, l.cluster.ID, numberVolumesPrometheusQuery)
+	require.NoError(l.T(), err)
+	require.Equal(l.T(), previousNumberOfVolumes+1, value)
 }
 
 // In order for 'go test' to run this suite, we need to create

--- a/validation/longhorn/schemas/pit_schemas.yaml
+++ b/validation/longhorn/schemas/pit_schemas.yaml
@@ -201,7 +201,7 @@
       data: ""
       expectedresult: "ServiceMonitor created and Longhorn data is shown in Grafana"
       position: 3
-    - action: "Check current number of existing Longhorn volumes"
+    - action: "Check current number of existing Longhorn volumes (count(longhorn_volume_capacity_bytes) OR on() vector(0))"
       data: ""
       expectedresult: "The query runs successfully"
       position: 4
@@ -209,11 +209,11 @@
       data: ""
       expectedresult: "PVC and Volume are created"
       position: 5
-    - action: "Query Grafana for the volume size of the newly created volume"
+    - action: "Query Grafana for the volume size of the newly created volume (longhorn_volume_capacity_bytes{volume=<volumeName>})"
       data: ""
       expectedresult: "Volume size shows as 1 GiB"
       position: 6
-    - action: "Query Grafana for the new number of existing Longhorn volumes"
+    - action: "Query Grafana for the new number of existing Longhorn volumes (count(longhorn_volume_capacity_bytes) OR on() vector(0))"
       data: ""
       expectedresult: "Number of volumes is equal to the previously quered value + 1"
       position: 7

--- a/validation/longhorn/schemas/pit_schemas.yaml
+++ b/validation/longhorn/schemas/pit_schemas.yaml
@@ -215,7 +215,7 @@
       position: 6
     - action: "Query Grafana for the new number of existing Longhorn volumes (count(longhorn_volume_capacity_bytes) OR on() vector(0))"
       data: ""
-      expectedresult: "Number of volumes is equal to the previously quered value + 1"
+      expectedresult: "Number of volumes is equal to the previously queried value + 1"
       position: 7
     custom_field:
       "15": "TestMonitoringIntegration"

--- a/validation/longhorn/schemas/pit_schemas.yaml
+++ b/validation/longhorn/schemas/pit_schemas.yaml
@@ -189,7 +189,7 @@
     description: "Verify Longhorn metrics collection and visualization through Rancher's Prometheus and Grafana monitoring stack."
     automation: 0
     steps:
-    - action: "Install Rancher monitoring stack from Apps catalog"
+    - action: "Install Rancher monitoring stack from Apps catalog if not already installed"
       data: ""
       expectedresult: "Monitoring deployment completes"
       position: 1
@@ -197,42 +197,28 @@
       data: ""
       expectedresult: "All monitoring components operational"
       position: 2
-    - action: "Access Longhorn Settings and enable 'Longhorn System Monitoring'"
+    - action: "Create ServiceMonitor resource for Longhorn named 'longhorn-monitor'"
       data: ""
-      expectedresult: "Monitoring integration enabled"
+      expectedresult: "ServiceMonitor created and Longhorn data is shown in Grafana"
       position: 3
-    - action: "Access Grafana through Rancher monitoring section"
+    - action: "Check current number of existing Longhorn volumes"
       data: ""
-      expectedresult: "Grafana dashboard opens"
+      expectedresult: "The query runs successfully"
       position: 4
-    - action: "Search for 'Longhorn' dashboards in Grafana"
+    - action: "Create a new Longhorn PVC with a 1 GiB Volume"
       data: ""
-      expectedresult: "Longhorn dashboards appear in search results"
+      expectedresult: "PVC and Volume are created"
       position: 5
-    - action: "Open 'Longhorn - Volume' dashboard"
+    - action: "Query Grafana for the volume size of the newly created volume"
       data: ""
-      expectedresult: "Volume metrics dashboard displays"
+      expectedresult: "Volume size shows as 1 GiB"
       position: 6
-    - action: "Open 'Longhorn - Node' dashboard"
+    - action: "Query Grafana for the new number of existing Longhorn volumes"
       data: ""
-      expectedresult: "Node metrics dashboard displays"
+      expectedresult: "Number of volumes is equal to the previously quered value + 1"
       position: 7
-    - action: "Verify volume health metrics display correctly"
-      data: ""
-      expectedresult: "Volume status, replica count, and health shown"
-      position: 8
-    - action: "Verify storage utilization metrics display"
-      data: ""
-      expectedresult: "Storage usage percentages and capacity shown"
-      position: 9
-    - action: "Verify performance metrics (IOPS, throughput) display"
-      data: ""
-      expectedresult: "Performance data visible and updating"
-      position: 10
-    - action: "Create test volume and verify new metrics appear"
-      data: ""
-      expectedresult: "New volume metrics reflected in dashboard"
-      position: 11
+    custom_field:
+      "15": "TestMonitoringIntegration"
   - title: "Alert Manager Integration"
     description: "Test Longhorn alert integration with Rancher Alert Manager for storage-related events and notifications."
     automation: 0


### PR DESCRIPTION
Implementing this test clearly required a schema update since:
1- The old schema relied heavily on the use of UI;
2- The set up of Longhorn metrics on Grafana was innacurate;

So this is my attempt at improving it, running Prometheus queries with the Grafana API while using Rancher as a proxy to check the values shown in Grafana without relying on the UI. 

Part of https://github.com/rancher/qa-tasks/issues/2403