### PR TITLE
Add GitHub Actions workflow for CAPI PnP day-2 operations

### DIFF
--- a/.github/workflows/day2-ops-capi-pnp.yml
+++ b/.github/workflows/day2-ops-capi-pnp.yml
@@ -1,0 +1,747 @@
+---
+name: Day 2 Operations - CAPI PnP
+
+on:
+  schedule:
+    - cron: "0 9 * * 3"
+  workflow_dispatch:
+    inputs:
+      rancher_version:
+        description: "Rancher tag version"
+      rancher_chart_version:
+        description: "Rancher chart version"
+      run_all_versions:
+        description: "Run all supported versions if manually triggered"
+        required: false
+        default: false
+        type: boolean
+      reporting:
+        description: "Enable reporting to Qase and Slack"
+        required: false
+        default: false
+        type: boolean
+      local_cluster_type:
+        description: "Local cluster type to setup Rancher"
+        required: true
+        default: "rke2"
+        type: choice
+        options:
+          - k3s
+          - rke2
+  workflow_call:
+    inputs:
+      rancher_version:
+        description: "Rancher tag version provided from check-rancher-tag workflow"
+        required: true
+        type: string
+      rancher_chart_version:
+        description: "Rancher chart version provided from check-rancher-tag workflow"
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  CLOUD_PROVIDER_VERSION: "6.50.0"
+  LOCAL_CLUSTER_TYPE: >-
+    ${{ 
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.local_cluster_type) || 
+      (github.event_name == 'schedule' && 'rke2') || 'rke2' 
+    }}
+
+jobs:
+  v2-16:
+    if: |
+      github.event_name == 'schedule' ||
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
+    name: ${{ github.event.inputs.rancher_version }}
+    runs-on: ubuntu-latest
+    environment: head
+    env:
+      HOSTNAME_PREFIX: "cpnp-r216"
+      REPORTING_ENABLED: >-
+        ${{
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
+        }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          submodules: recursive
+
+      - name: Checkout tfp-automation repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          repository: rancher/tfp-automation
+          path: tfp-automation
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: "Fetch and Set DockerHub Credentials"
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Mask Dockerhub Credentials
+        run: |
+          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
+          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Set up certificates
+        id: setup-certs
+        uses: ./.github/actions/setup-certs
+        with:
+          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
+          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
+          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
+          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_16_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_16_HEAD)
+            }}
+
+      - name: Set Rancher chart version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_CHART_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) || 
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
+            }}
+
+      - name: Set Rancher repo
+        uses: ./.github/actions/set-rancher-repo
+        with:
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
+          is-prime: false
+          release-community-version: "2.16"
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_16 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_16 }}
+
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          is-prime: false
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+            cleanup: true
+          terraform:
+            cni: "${{ vars.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
+            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
+            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ vars.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ vars.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_16 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ env.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_16 }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
+
+          scalingInput:
+            nodeProvider: "ec2"
+
+          clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            nodeProvider: "ec2"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE }}"
+
+          awsEC2Configs:
+            awsEC2Config:
+              - awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsUser: "${{ vars.AWS_USER }}"
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+
+          capipnp:
+            awsCredentials:
+              accessKeyID: "$AWS_ACCESS_KEY"
+              secretAccessKey: "$AWS_SECRET_KEY"
+            awsTemplate:
+              ami: "${{ secrets.AWS_CAPA_AMI }}"
+              controlPlaneSecurityGroup: "${{ secrets.AWS_CAPA_SECURITY_GROUP }}"
+              nodeSecurityGroup: "${{ secrets.AWS_CAPA_SECURITY_GROUP }}"
+              region: "${{ vars.AWS_CAPA_REGION }}"
+              sshKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              subnetId: "${{ secrets.AWS_CAPA_SUBNET_ID }}"
+              vpcId: "${{ secrets.AWS_CAPA_VPC_ID }}"
+            clusterNamePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            provider: "capa"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/go-build.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
+
+      - name: Run Test Suites
+        env:
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
+          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
+          QASE_CUSTOM_FIELD_FILTER: Hostbusters
+          QASE_SCHEMA_PREFIX: hostbusters
+          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        with:
+          reporting: ${{ env.REPORTING_ENABLED }}
+          tags: capi
+        uses: ./.github/actions/run-hostbusters-test-suites
+
+      - name: Cleanup Infrastructure
+        if: always()
+        working-directory: tfp-automation/modules/sanity/aws
+        run: terraform destroy -auto-approve > /dev/null 2>&1
+
+      - name: Refresh AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: AWS Custodian Infrastructure Cleanup
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set job status output
+        if: always()
+        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
+        id: set-job-status
+
+      - name: Reporting Results to Slack
+        if: always() && env.REPORTING_ENABLED == 'true'
+        uses: ./.github/actions/report-to-slack
+        with:
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          job-status: ${{ steps.set-job-status.outputs.job_status }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Save test result as artifact for weekly summary
+        if: always() && github.event_name == 'schedule'
+        run: |
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-capi-pnp\", \"job\": \"v2-16\" }" > test-result-day2-ops-capi-pnp-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+        shell: bash
+
+      - name: Upload test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        with:
+          name: test-result-day2-ops-capi-pnp-v2-16-${{ github.run_id }}
+          path: test-result-day2-ops-capi-pnp-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+  
+  v2-15:
+    if: |
+      github.event_name == 'schedule' ||
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ github.event.inputs.rancher_version }}
+    runs-on: ubuntu-latest
+    environment: head
+    env:
+      HOSTNAME_PREFIX: "cpnp-r215"
+      REPORTING_ENABLED: >-
+        ${{
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
+        }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          submodules: recursive
+
+      - name: Checkout tfp-automation repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          repository: rancher/tfp-automation
+          path: tfp-automation
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: "Fetch and Set DockerHub Credentials"
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Mask Dockerhub Credentials
+        run: |
+          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
+          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Set up certificates
+        id: setup-certs
+        uses: ./.github/actions/setup-certs
+        with:
+          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
+          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
+          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
+          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_15_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_15_HEAD)
+            }}
+
+      - name: Set Rancher chart version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_CHART_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) || 
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
+            }}
+
+      - name: Set Rancher repo
+        uses: ./.github/actions/set-rancher-repo
+        with:
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
+          is-prime: false
+          release-community-version: "2.15"
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_15 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_15 }}
+
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          is-prime: false
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+            cleanup: true
+          terraform:
+            cni: "${{ vars.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
+            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
+            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ vars.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ vars.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ env.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
+
+          scalingInput:
+            nodeProvider: "ec2"
+
+          clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            nodeProvider: "ec2"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE }}"
+
+          awsEC2Configs:
+            awsEC2Config:
+              - awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsUser: "${{ vars.AWS_USER }}"
+
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+
+          capipnp:
+            awsCredentials:
+              accessKeyID: "$AWS_ACCESS_KEY"
+              secretAccessKey: "$AWS_SECRET_KEY"
+            awsTemplate:
+              ami: "${{ secrets.AWS_CAPA_AMI }}"
+              controlPlaneSecurityGroup: "${{ secrets.AWS_CAPA_SECURITY_GROUP }}"
+              nodeSecurityGroup: "${{ secrets.AWS_CAPA_SECURITY_GROUP }}"
+              region: "${{ vars.AWS_CAPA_REGION }}"
+              sshKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              subnetId: "${{ secrets.AWS_CAPA_SUBNET_ID }}"
+              vpcId: "${{ secrets.AWS_CAPA_VPC_ID }}"
+            clusterNamePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            provider: "capa"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/go-build.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
+
+      - name: Run Test Suites
+        env:
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
+          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
+          QASE_CUSTOM_FIELD_FILTER: Hostbusters
+          QASE_SCHEMA_PREFIX: hostbusters
+          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        with:
+          reporting: ${{ env.REPORTING_ENABLED }}
+          tags: capi
+        uses: ./.github/actions/run-hostbusters-test-suites
+
+      - name: Cleanup Infrastructure
+        if: always()
+        working-directory: tfp-automation/modules/sanity/aws
+        run: terraform destroy -auto-approve > /dev/null 2>&1
+
+      - name: Refresh AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: AWS Custodian Infrastructure Cleanup
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set job status output
+        if: always()
+        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
+        id: set-job-status
+
+      - name: Reporting Results to Slack
+        if: always() && env.REPORTING_ENABLED == 'true'
+        uses: ./.github/actions/report-to-slack
+        with:
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          job-status: ${{ steps.set-job-status.outputs.job_status }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Save test result as artifact for weekly summary
+        if: always() && github.event_name == 'schedule'
+        run: |
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-capi-pnp\", \"job\": \"v2-15\" }" > test-result-day2-ops-capi-pnp-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+        shell: bash
+
+      - name: Upload test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        with:
+          name: test-result-day2-ops-capi-pnp-v2-15-${{ github.run_id }}
+          path: test-result-day2-ops-capi-pnp-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json

--- a/actions/certificates/certificates.go
+++ b/actions/certificates/certificates.go
@@ -13,10 +13,12 @@ import (
 	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/defaults"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/sshkeys"
 	"github.com/rancher/shepherd/pkg/wait"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 )
@@ -26,6 +28,21 @@ const (
 	pemFileExtension             = ".pem"
 	privateKeySSHKeyRegExPattern = `-----BEGIN RSA PRIVATE KEY-{3,}\n([\s\S]*?)\n-{3,}END RSA PRIVATE KEY-----`
 )
+
+// GetCertRotationGeneration returns the current CertificateRotationGeneration from the RKEControlPlane status.
+func GetCertRotationGeneration(client *rancher.Client, clusterName string) (int64, error) {
+	rkeClient, err := client.GetKubeAPIRKEClient()
+	if err != nil {
+		return 0, err
+	}
+
+	controlPlane, err := rkeClient.RKEControlPlanes(namespaces.FleetDefault).Get(context.TODO(), clusterName, metav1.GetOptions{})
+	if err != nil {
+		return 0, err
+	}
+
+	return controlPlane.Status.CertificateRotationGeneration, nil
+}
 
 // CertRotationCompleteCheckFunc returns a watch check function that checks if the certificate rotation is complete
 func CertRotationCompleteCheckFunc(generation int64) wait.WatchCheckFunc {
@@ -131,7 +148,8 @@ func getCertificatesFromMachine(client *rancher.Client, machineNode *v1.SteveAPI
 
 	sshNode, err := sshkeys.GetSSHNodeFromMachine(client, machineNode)
 	if err != nil {
-		return nil, err
+		logrus.Debugf("Skipping cert collection for machine %s: %v", machineNode.Name, err)
+		return certificates, nil
 	}
 
 	logrus.Debugf("Getting certificates from machine: %s", machineNode.Name)

--- a/actions/encryptionkeyrotation/verify.go
+++ b/actions/encryptionkeyrotation/verify.go
@@ -1,14 +1,18 @@
 package encryptionkeyrotation
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/extensions/sshkeys"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -32,14 +36,11 @@ func VerifyEncryptionKeyRotation(client *rancher.Client, clusterStatus *provv1.C
 		return fmt.Errorf("no nodes found in cluster %s", clusterStatus.ClusterName)
 	}
 
-	controlPlaneCount := 0
-
 	for _, machine := range nodeList.Data {
 		if !isControlPlaneMachine(machine.Labels) {
 			continue
 		}
 
-		controlPlaneCount++
 		logrus.Debugf("Selected control-plane node: %s", machine.Name)
 
 		sshNode, err := sshkeys.GetSSHNodeFromMachine(client, &machine)
@@ -70,9 +71,30 @@ func VerifyEncryptionKeyRotation(client *rancher.Client, clusterStatus *provv1.C
 		}
 	}
 
-	if controlPlaneCount == 0 {
-		return fmt.Errorf("no nodes found with control-plane role in cluster %s", clusterStatus.ClusterName)
+	return nil
+}
+
+// VerifyRotationFromControlPlaneStatus checks the RKEControlPlane status for encryption key rotation completion
+func VerifyRotationFromControlPlaneStatus(client *rancher.Client, clusterName string) error {
+	rkeClient, err := client.GetKubeAPIRKEClient()
+	if err != nil {
+		return fmt.Errorf("failed to get kube RKE client for cluster %s: %w", clusterName, err)
 	}
+
+	controlPlane, err := rkeClient.RKEControlPlanes(namespaces.FleetDefault).Get(context.TODO(), clusterName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get RKEControlPlane %s/%s: %w", namespaces.FleetDefault, clusterName, err)
+	}
+
+	if controlPlane.Status.RotateEncryptionKeysPhase == rkev1.RotateEncryptionKeysPhaseFailed {
+		return fmt.Errorf("encryption key rotation failed for cluster %s", clusterName)
+	}
+
+	if controlPlane.Status.RotateEncryptionKeysPhase != rkev1.RotateEncryptionKeysPhaseDone {
+		return fmt.Errorf("expected encryption key rotation phase %q for cluster %s, got %q", rkev1.RotateEncryptionKeysPhaseDone, clusterName, controlPlane.Status.RotateEncryptionKeysPhase)
+	}
+
+	logrus.Debugf("Verified encryption key rotation via RKEControlPlane phase for cluster %s: %s", clusterName, controlPlane.Status.RotateEncryptionKeysPhase)
 
 	return nil
 }

--- a/validation/certificates/capipnp/k3s/README.md
+++ b/validation/certificates/capipnp/k3s/README.md
@@ -1,4 +1,4 @@
-# K3s Encryption Key Rotation
+# K3s Certificates Configs
 
 ## Table of Contents
 1. [Prerequisites](../README.md)
@@ -11,21 +11,21 @@
 ## Test Cases
 All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
 
-### Encryption Key Rotation Tests
+### Certificate Tests
 
 #### Description:
-The encryption key rotation test verifies that a cluster can successfully perform encryption key rotation
+The certificate test verifies that a cluster can rotate certificates.
 
 #### Required Configurations:
 1. [Cloud Credential](#cloud-credential-config)
-2. [Cluster Config](#cluster-config)
+2. [Cluster Config](#cluster-config) (with IPv6 settings)
 3. [Machine Config](#machine-config)
 
 #### Table Tests:
-1. `K3S_Encryption_Key_Rotation`
+1. `CAPI_PnP_RKE2_Certificate_Rotation`
 
 #### Run Commands:
-1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/encryptionkeyrotation/k3s --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestEncryptionKeyRotation -timeout=2h -v`
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/certificates/capipnp/k3s --junitfile results.xml --jsonfile results.json -- -tags=valdation -run TestCAPIPnPCertRotation -timeout=2h -v`
 
 ## Configurations
 
@@ -39,10 +39,39 @@ rancher:
   insecure: true
 ```
 
-NOTE: If you are providing an existing cluster, it is assumed that secrets encryption is enabled on the cluster; this is a K3s pre-requiste for encryption key rotation.
-
 ### Provisioning cluster
-This test will create a cluster if one is not provided, see the needed cluster configuration [k3s provisioning](../../provisioning/k3s/README.md)
+This test will create a cluster if one is not provided, see the section on having a defined machine pool in this reference README: [k3s provisioning](../../../provisioning/k3s/README.md). Additionally, you will need this section for CAPI configurations:
+
+```yaml
+capipnp:
+  awsCredentials:
+    accessKeyID: "<required>"
+    secretAccessKey: "<required>"
+  awsTemplate:
+    ami: "<required>"
+    controlPlaneSecurityGroup: "sg-<required>"
+    nodeSecurityGroup: "sg-<required>"
+    region: "us-west-1"
+    sshKeyName: "<required>"
+    subnetId: "subnet-<required>"
+    vpcId: "vpc-<required>"
+  vsphereCredentials:
+    username: "<required>"
+    password: "<required>"
+  vsphereTemplate:
+    datacenter: "<required>"
+    datastore: "<required>"
+    diskGiB: 40
+    folder: "<required>"
+    host: "<required>"
+    memoryMiB: 8192
+    networkName: "<required>"
+    numCPUs: 4
+    resourcePool: "<required>"
+    template: "<required>"
+  clusterNamePrefix: "<required>"
+  provider: "<required>"    # capa or capv
+```
 
 ## Defaults
 This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to: 
@@ -50,7 +79,7 @@ This package contains a defaults folder which contains default test configuratio
 2. Reduce the amount of yaml data that needs to be stored in our pipelines.
 3. Make it easier to run tests
 
-Any data the user provides will override these defaults which are stored here: [defaults](defaults/defaults.yaml). 
+Any data the user provides will override these defaults which are stored here: [defaults](../defaults/defaults.yaml). 
 
 ## Logging
 This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 

--- a/validation/certificates/capipnp/k3s/cert_rotation_test.go
+++ b/validation/certificates/capipnp/k3s/cert_rotation_test.go
@@ -1,0 +1,78 @@
+//go:build validation || capi
+
+package k3s
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/certificates"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/certificates/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCAPIPnPCertRotation(t *testing.T) {
+	t.Parallel()
+
+	c := capipnp.Setup(t, defaults.K3S)
+
+	tests := []struct {
+		name    string
+		cluster *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_K3S_Certificate_Rotation", c.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", c.Cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(c.Client, c.Cluster.Name, c.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logrus.Infof("Getting current certificate rotation generation (%s)", tt.name)
+			oldGeneration, err := certificates.GetCertRotationGeneration(c.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			logrus.Infof("Rotating certificates on cluster (%s)", tt.cluster.Name)
+			require.NoError(t, certificates.RotateCerts(c.Client, tt.cluster.Name))
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(c.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(c.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(c.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Getting new certificate rotation generation (%s)", tt.name)
+			newGeneration, err := certificates.GetCertRotationGeneration(c.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying certificate rotation generation incremented (%s)", tt.cluster.Name)
+			require.Greater(t, newGeneration, oldGeneration)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(c.Client, c.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/certificates/capipnp/k3s/schemas/hostbusters_schemas.yaml
+++ b/validation/certificates/capipnp/k3s/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,23 @@
+- suite: Go Automation/Certificates/CAPIPnP/K3S
+  projects: [RRT, RM]
+  cases:
+  - description: Rotates the clusters certificates
+    title: CAPI_PnP_K3S_Certificate_Rotation
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Rotate the clusters certificates
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/certificates/capipnp/rke2/README.md
+++ b/validation/certificates/capipnp/rke2/README.md
@@ -1,4 +1,4 @@
-# K3s Encryption Key Rotation
+# RKE2 Certificates Configs
 
 ## Table of Contents
 1. [Prerequisites](../README.md)
@@ -11,21 +11,21 @@
 ## Test Cases
 All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
 
-### Encryption Key Rotation Tests
+### Certificate Tests
 
 #### Description:
-The encryption key rotation test verifies that a cluster can successfully perform encryption key rotation
+The certificate test verifies that a cluster can rotate certificates.
 
 #### Required Configurations:
 1. [Cloud Credential](#cloud-credential-config)
-2. [Cluster Config](#cluster-config)
+2. [Cluster Config](#cluster-config) (with IPv6 settings)
 3. [Machine Config](#machine-config)
 
 #### Table Tests:
-1. `K3S_Encryption_Key_Rotation`
+1. `CAPI_PnP_RKE2_Certificate_Rotation`
 
 #### Run Commands:
-1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/encryptionkeyrotation/k3s --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestEncryptionKeyRotation -timeout=2h -v`
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/certificates/capipnp/rke2 --junitfile results.xml --jsonfile results.json -- -tags=valdation -run TestCAPIPnPCertRotation -timeout=2h -v`
 
 ## Configurations
 
@@ -39,10 +39,39 @@ rancher:
   insecure: true
 ```
 
-NOTE: If you are providing an existing cluster, it is assumed that secrets encryption is enabled on the cluster; this is a K3s pre-requiste for encryption key rotation.
-
 ### Provisioning cluster
-This test will create a cluster if one is not provided, see the needed cluster configuration [k3s provisioning](../../provisioning/k3s/README.md)
+This test will create a cluster if one is not provided, see the section on having a defined machine pool in this reference README: [rke2 provisioning](../../../provisioning/k3s/README.md). Additionally, you will need this section for CAPI configurations:
+
+```yaml
+capipnp:
+  awsCredentials:
+    accessKeyID: "<required>"
+    secretAccessKey: "<required>"
+  awsTemplate:
+    ami: "<required>"
+    controlPlaneSecurityGroup: "sg-<required>"
+    nodeSecurityGroup: "sg-<required>"
+    region: "us-west-1"
+    sshKeyName: "<required>"
+    subnetId: "subnet-<required>"
+    vpcId: "vpc-<required>"
+  vsphereCredentials:
+    username: "<required>"
+    password: "<required>"
+  vsphereTemplate:
+    datacenter: "<required>"
+    datastore: "<required>"
+    diskGiB: 40
+    folder: "<required>"
+    host: "<required>"
+    memoryMiB: 8192
+    networkName: "<required>"
+    numCPUs: 4
+    resourcePool: "<required>"
+    template: "<required>"
+  clusterNamePrefix: "<required>"
+  provider: "<required>"    # capa or capv
+```
 
 ## Defaults
 This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to: 
@@ -50,7 +79,7 @@ This package contains a defaults folder which contains default test configuratio
 2. Reduce the amount of yaml data that needs to be stored in our pipelines.
 3. Make it easier to run tests
 
-Any data the user provides will override these defaults which are stored here: [defaults](defaults/defaults.yaml). 
+Any data the user provides will override these defaults which are stored here: [defaults](../defaults/defaults.yaml). 
 
 ## Logging
 This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 

--- a/validation/certificates/capipnp/rke2/cert_rotation_test.go
+++ b/validation/certificates/capipnp/rke2/cert_rotation_test.go
@@ -1,0 +1,78 @@
+//go:build validation || capi
+
+package rke2
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/certificates"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/certificates/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCAPIPnPCertRotation(t *testing.T) {
+	t.Parallel()
+
+	c := capipnp.Setup(t, defaults.RKE2)
+
+	tests := []struct {
+		name    string
+		cluster *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_RKE2_Certificate_Rotation", c.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", c.Cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(c.Client, c.Cluster.Name, c.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			logrus.Infof("Getting current certificate rotation generation (%s)", tt.name)
+			oldGeneration, err := certificates.GetCertRotationGeneration(c.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			logrus.Infof("Rotating certificates on cluster (%s)", tt.cluster.Name)
+			require.NoError(t, certificates.RotateCerts(c.Client, tt.cluster.Name))
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(c.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(c.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(c.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Getting new certificate rotation generation (%s)", tt.name)
+			newGeneration, err := certificates.GetCertRotationGeneration(c.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying certificate rotation generation incremented (%s)", tt.cluster.Name)
+			require.Greater(t, newGeneration, oldGeneration)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(c.Client, c.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/certificates/capipnp/rke2/schemas/hostbusters_schemas.yaml
+++ b/validation/certificates/capipnp/rke2/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,23 @@
+- suite: Go Automation/Certificates/CAPIPnP/RKE2
+  projects: [RRT, RM]
+  cases:
+  - description: Rotates the clusters certificates
+    title: CAPI_PnP_RKE2_Certificate_Rotation
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Rotate the clusters certificates
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/certificates/capipnp/setup.go
+++ b/validation/certificates/capipnp/setup.go
@@ -1,0 +1,171 @@
+package capipnp
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	extclusters "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/rbac"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type certRotationTest struct {
+	suite.Suite
+	Client             *rancher.Client
+	StandardUserClient *rancher.Client
+	Session            *session.Session
+	CattleConfig       map[string]any
+	ClusterConfig      *clusters.ClusterConfig
+	RancherConfig      *rancher.Config
+	CapiConfig         *capipnp.Config
+	Cluster            *v1.SteveAPIObject
+	ClusterManifest    []byte
+}
+
+func Setup(t *testing.T, clusterType string) *certRotationTest {
+	c := &certRotationTest{}
+
+	testSession := session.NewSession()
+	c.Session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	c.Client = client
+
+	localClusterID, err := extclusters.GetClusterIDByName(c.Client, extclusterapi.LocalCluster)
+	require.NoError(t, err)
+
+	localCluster, err := c.Client.Management.Cluster.ByID(localClusterID)
+	require.NoError(t, err)
+
+	_, standardUserClient, err := rbac.AddUserWithRoleToCluster(c.Client, rbac.StandardUser.String(), rbac.ClusterOwner.String(), localCluster, nil)
+	require.NoError(t, err)
+
+	c.StandardUserClient = standardUserClient
+
+	c.CattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
+
+	_, setupFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	capipnpDir := filepath.Dir(setupFile)
+	certificatesDir := filepath.Dir(capipnpDir)
+	validationDir := filepath.Dir(certificatesDir)
+	provisioningDir := filepath.Join(validationDir, "provisioning")
+
+	provisioningDefaults := config.LoadConfigFromFile(filepath.Join(provisioningDir, "defaults", "defaults.yaml"))
+	deletingDefaults := config.LoadConfigFromFile(filepath.Join(certificatesDir, "defaults", "defaults.yaml"))
+	validationDefaults, err := defaults.DeepMerge(deletingDefaults, provisioningDefaults, true)
+	require.NoError(t, err)
+
+	c.CattleConfig, err = defaults.DeepMerge(c.CattleConfig, validationDefaults, true)
+	require.NoError(t, err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, c.CattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(t, err)
+
+	clusterConfig := new(clusters.ClusterConfig)
+	operations.LoadObjectFromMap(defaults.ClusterConfigKey, c.CattleConfig, clusterConfig)
+
+	c.ClusterConfig = clusterConfig
+
+	rancherConfig := new(rancher.Config)
+	operations.LoadObjectFromMap(defaults.RancherConfigKey, c.CattleConfig, rancherConfig)
+
+	c.RancherConfig = rancherConfig
+
+	capiConfig := new(capipnp.Config)
+	operations.LoadObjectFromMap(capipnp.ConfigurationFileKey, c.CattleConfig, capiConfig)
+
+	c.CapiConfig = capiConfig
+
+	providerManifestsPath := filepath.Join(provisioningDir, "resources", "capipnp", "providers", c.CapiConfig.Provider)
+	c.CapiConfig.ClusterYAML = filepath.Join(providerManifestsPath, clusterType+"-cluster.yaml")
+	providerManifest := filepath.Join(providerManifestsPath, "provider.yaml")
+	credentialsManifest := filepath.Join(providerManifestsPath, "creds.yaml")
+	identityManifest := filepath.Join(providerManifestsPath, "identity.yaml")
+
+	if c.RancherConfig.ClusterName == "" {
+		c.CattleConfig, err = defaults.SetK8sDefault(c.Client, clusterType, c.CattleConfig)
+		require.NoError(t, err)
+
+		resolvedK8sVersion, err := operations.GetValue([]string{defaults.ClusterConfigKey, defaults.K8SVersionKey}, c.CattleConfig)
+		require.NoError(t, err)
+
+		if resolvedK8sVersion != nil {
+			c.CapiConfig.KubernetesVersion, _ = resolvedK8sVersion.(string)
+		}
+
+		logrus.Debugf("Applying %s provider manifest...", c.CapiConfig.Provider)
+		err = capipnp.CreateProviderManifestFromPath(c.Client, c.CapiConfig, providerManifest)
+		require.NoError(t, err)
+
+		logrus.Debugf("Applying credentials manifest...")
+		err = capipnp.CreateProviderManifestFromPath(c.Client, c.CapiConfig, credentialsManifest)
+		require.NoError(t, err)
+
+		logrus.Debugf("Waiting for previous manifests to be active...")
+		err = capipnp.WaitProviderPrerequisitesReady(c.Client, c.CapiConfig)
+		require.NoError(t, err)
+
+		logrus.Debugf("Applying cluster static identity manifest...")
+		err = capipnp.CreateProviderManifestFromPath(c.Client, c.CapiConfig, identityManifest)
+		require.NoError(t, err)
+
+		clusterName := namegen.AppendRandomString(c.CapiConfig.ClusterNamePrefix)
+
+		c.ClusterManifest, err = capipnp.CreateClusterManifestFromDefaults(c.CapiConfig, c.ClusterConfig.MachinePools, clusterName)
+		require.NoError(t, err)
+
+		logrus.Infof("Provisioning %s cluster", clusterType)
+		err = capipnp.CreateCAPICluster(c.StandardUserClient, clusterName, c.ClusterManifest)
+		require.NoError(t, err)
+
+		cluster, err := clusters.GetClusterByName(c.Client, clusterName)
+		require.NoError(t, err)
+
+		err = provisioning.VerifyClusterReady(c.Client, cluster)
+		require.NoError(t, err)
+
+		err = deployment.VerifyClusterDeployments(c.Client, cluster)
+		require.NoError(t, err)
+
+		err = pods.VerifyClusterPods(c.Client, cluster)
+		require.NoError(t, err)
+
+		c.Cluster, err = c.Client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + cluster.Name)
+		require.NoError(t, err)
+	} else {
+		c.ClusterManifest, err = capipnp.CreateClusterManifestFromDefaults(c.CapiConfig, c.ClusterConfig.MachinePools, c.RancherConfig.ClusterName)
+		require.NoError(t, err)
+
+		logrus.Infof("Using existing cluster %s", c.RancherConfig.ClusterName)
+		c.Cluster, err = c.Client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + c.RancherConfig.ClusterName)
+		require.NoError(t, err)
+	}
+
+	return c
+}

--- a/validation/deleting/capipnp/k3s/README.md
+++ b/validation/deleting/capipnp/k3s/README.md
@@ -1,0 +1,129 @@
+# K3S Deleting Configs
+
+## Table of Contents
+1. [Tests Cases](#Test-Cases)
+2. [Configurations](#Configurations)
+3. [Configuration Defaults](#defaults)
+4. [Logging Levels](#Logging)
+5. [Back to general deleting](../README.md)
+
+## Test Cases
+All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
+
+### Delete cluster test
+
+#### Description:
+Verifies that a cluster can be deleted. 
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `CAPI_PnP_K3S_Delete_Cluster`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/capipnp/k3s --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestDeletingCAPIPnPCluster -timeout=1h -v`
+
+
+### Delete cluster init machine test
+
+#### Description:
+Verifies that a cluster is able to recover from deleting the init machine.
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `CAPI_PnP_K3S_Delete_Init_Machine`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/capipnp/k3s --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestDeleteInitCAPIPnPMachine -timeout=1h -v`
+
+
+### Delete machine test
+
+#### Description:
+Verifies that machines can be deleted and replaced by role (control plane, etcd, worker).
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `CAPI_PnP_K3S_Replace_Control_Plane`
+2. `CAPI_PnP_K3S_Replace_ETCD`
+3. `CAPI_PnP_K3S_Replace_Worker`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/capipnp/k3s --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestDeleteCAPIPnPMachine -timeout=1h -v`
+
+## Configurations
+
+### Existing cluster:
+```yaml
+rancher:
+  host: <rancher-fqdn>
+  adminToken: <rancher-token>
+  clusterName: "<existing cluster name>"
+  cleanup: true
+  insecure: true
+```
+
+### Provisioning cluster
+This test will create a cluster if one is not provided, see the section on having a defined machine pool in this reference README: [k3s provisioning](../../../provisioning/k3s/README.md). Additionally, you will need this section for CAPI configurations:
+
+```yaml
+capipnp:
+  awsCredentials:
+    accessKeyID: "<required>"
+    secretAccessKey: "<required>"
+  awsTemplate:
+    ami: "<required>"
+    controlPlaneSecurityGroup: "sg-<required>"
+    nodeSecurityGroup: "sg-<required>"
+    region: "us-west-1"
+    sshKeyName: "<required>"
+    subnetId: "subnet-<required>"
+    vpcId: "vpc-<required>"
+  vsphereCredentials:
+    username: "<required>"
+    password: "<required>"
+  vsphereTemplate:
+    datacenter: "<required>"
+    datastore: "<required>"
+    diskGiB: 40
+    folder: "<required>"
+    host: "<required>"
+    memoryMiB: 8192
+    networkName: "<required>"
+    numCPUs: 4
+    resourcePool: "<required>"
+    template: "<required>"
+  clusterNamePrefix: "<required>"
+  provider: "<required>"    # capa or capv
+```
+
+## Defaults
+This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to: 
+1. Reduce the number of fields the user needs to provide in the cattle_config file. 
+2. Reduce the amount of yaml data that needs to be stored in our pipelines.
+3. Make it easier to run tests
+
+Any data the user provides will override these defaults which are stored here: [defaults](../defaults/defaults.yaml). 
+
+## Logging
+This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 
+
+```yaml
+logging:
+   level: "trace" #trace debug, info, warning, error
+```
+
+## Additional
+1. If the tests passes immediately without warning, try adding the `-count=1` or run `go clean -cache`. This will avoid previous results from interfering with the new test run.
+2. All of the tests utilize parallelism when running for more finite control of how things are run in parallel use the -p and -parallel.

--- a/validation/deleting/capipnp/k3s/delete_cluster_test.go
+++ b/validation/deleting/capipnp/k3s/delete_cluster_test.go
@@ -1,0 +1,44 @@
+//go:build validation || capi
+
+package k3s
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	extClusters "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/validation/deleting/capipnp"
+	"github.com/sirupsen/logrus"
+)
+
+func TestDeletingCAPIPnPCluster(t *testing.T) {
+	t.Parallel()
+
+	d := capipnp.Setup(t, defaults.K3S, true)
+
+	tests := []struct {
+		name    string
+		cluster *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_K3S_Delete_Cluster", d.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logrus.Infof("Deleting cluster (%s)", tt.cluster.ID)
+			extClusters.DeleteK3SRKE2Cluster(d.Client, tt.cluster.ID)
+
+			logrus.Infof("Verifying cluster (%s) deletion", tt.cluster.ID)
+			provisioning.VerifyDeleteRKE2K3SCluster(t, d.Client, tt.cluster.ID)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(d.Client, d.CattleConfig)
+		err := qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/deleting/capipnp/k3s/delete_init_machine_test.go
+++ b/validation/deleting/capipnp/k3s/delete_init_machine_test.go
@@ -1,0 +1,67 @@
+package k3s
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/deleting/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteInitCAPIPnPMachine(t *testing.T) {
+	t.Parallel()
+
+	d := capipnp.Setup(t, defaults.K3S, false)
+
+	tests := []struct {
+		name    string
+		cluster *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_K3S_Delete_Init_Machine", d.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", d.Cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(d.Client, d.Cluster.Name, d.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			logrus.Infof("Deleting init machine on cluster (%s)", tt.cluster.Name)
+			err := clusters.DeleteInitMachine(d.Client, tt.cluster.ID)
+			require.NoError(t, err)
+
+			err = provisioning.WaitClusterToBeUpgradedWithRetry(d.Client, tt.cluster.ID)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(d.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(d.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(d.Client, tt.cluster)
+			require.NoError(t, err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(d.Client, d.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/deleting/capipnp/k3s/delete_machine_test.go
+++ b/validation/deleting/capipnp/k3s/delete_machine_test.go
@@ -1,0 +1,90 @@
+//go:build validation || capi
+
+package k3s
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/machinepools"
+	"github.com/rancher/tests/actions/machines"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/deleting/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteMachine(t *testing.T) {
+	t.Parallel()
+
+	d := capipnp.Setup(t, defaults.K3S, false)
+
+	nodeRolesEtcd := machinepools.NodeRoles{
+		Etcd: true,
+	}
+
+	nodeRolesControlPlane := machinepools.NodeRoles{
+		ControlPlane: true,
+	}
+
+	nodeRolesWorker := machinepools.NodeRoles{
+		Worker: true,
+	}
+
+	tests := []struct {
+		name      string
+		nodeRoles machinepools.NodeRoles
+		cluster   *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_K3S_Replace_Control_Plane", nodeRolesControlPlane, d.Cluster},
+		{"CAPI_PnP_K3S_Replace_ETCD", nodeRolesEtcd, d.Cluster},
+		{"CAPI_PnP_K3S_Replace_Worker", nodeRolesWorker, d.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", d.Cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(d.Client, d.Cluster.Name, d.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			machineList, err := machines.GetMachinesByRole(d.Client, tt.cluster, tt.nodeRoles)
+			require.NoError(t, err)
+
+			machineToDelete := machineList[0]
+			logrus.Infof("Deleting machine (%s) from cluster (%s)", machineToDelete.Name, tt.cluster.Name)
+			err = d.Client.Steve.SteveType(stevetypes.Machine).Delete(&machineToDelete)
+			require.NoError(t, err)
+
+			err = machines.VerifyMachineReplacement(d.Client, &machineToDelete)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster is ready after machine replacement (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(d.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(d.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(d.Client, tt.cluster)
+			require.NoError(t, err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(d.Client, d.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/deleting/capipnp/k3s/schemas/hostbusters_schemas.yaml
+++ b/validation/deleting/capipnp/k3s/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,103 @@
+- suite: Go Automation/Deleting/CAPIPnP/K3S
+  projects: [RRT, RM]
+  cases:
+  - description: Deletes an existing cluster
+    title: CAPIPnP_K3S_Delete_Cluster
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Delete the existing cluster
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster is deleted
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+  - description: Deletes the init machine on an existing cluster
+    title: CAPIPnP_K3S_Delete_Init_Machine
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Delete the init machine on an existing cluster
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+  - description: Deletes and replaces a control plane machine
+    title: CAPIPnP_K3S_Replace_Control_Plane
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Delete a control plane machine
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify machine replacement and cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+  - description: Deletes and replaces an ETCD machine
+    title: CAPIPnP_K3S_Replace_ETCD
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Delete an ETCD machine
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify machine replacement and cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+  - description: Deletes and replaces a worker machine
+    title: CAPIPnP_K3S_Replace_Worker
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Delete a worker machine
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify machine replacement and cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/deleting/capipnp/rke2/README.md
+++ b/validation/deleting/capipnp/rke2/README.md
@@ -1,0 +1,129 @@
+# K3S Deleting Configs
+
+## Table of Contents
+1. [Tests Cases](#Test-Cases)
+2. [Configurations](#Configurations)
+3. [Configuration Defaults](#defaults)
+4. [Logging Levels](#Logging)
+5. [Back to general deleting](../README.md)
+
+## Test Cases
+All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
+
+### Delete cluster test
+
+#### Description:
+Verifies that a cluster can be deleted. 
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `CAPI_PnP_RKE2_Delete_Cluster`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/capipnp/rke2 --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestDeletingCAPIPnPCluster -timeout=1h -v`
+
+
+### Delete cluster init machine test
+
+#### Description:
+Verifies that a cluster is able to recover from deleting the init machine.
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `CAPI_PnP_RKE2_Delete_Init_Machine`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/capipnp/rke2 --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestDeleteInitCAPIPnPMachine -timeout=1h -v`
+
+
+### Delete machine test
+
+#### Description:
+Verifies that machines can be deleted and replaced by role (control plane, etcd, worker).
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `CAPI_PnP_RKE2_Replace_Control_Plane`
+2. `CAPI_PnP_RKE2_Replace_ETCD`
+3. `CAPI_PnP_RKE2_Replace_Worker`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/deleting/capipnp/rke2 --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestDeleteCAPIPnPMachine -timeout=1h -v`
+
+## Configurations
+
+### Existing cluster:
+```yaml
+rancher:
+  host: <rancher-fqdn>
+  adminToken: <rancher-token>
+  clusterName: "<existing cluster name>"
+  cleanup: true
+  insecure: true
+```
+
+### Provisioning cluster
+This test will create a cluster if one is not provided, see the section on having a defined machine pool in this reference README: [rke2 provisioning](../../../provisioning/rke2/README.md). Additionally, you will need this section for CAPI configurations:
+
+```yaml
+capipnp:
+  awsCredentials:
+    accessKeyID: "<required>"
+    secretAccessKey: "<required>"
+  awsTemplate:
+    ami: "<required>"
+    controlPlaneSecurityGroup: "sg-<required>"
+    nodeSecurityGroup: "sg-<required>"
+    region: "us-west-1"
+    sshKeyName: "<required>"
+    subnetId: "subnet-<required>"
+    vpcId: "vpc-<required>"
+  vsphereCredentials:
+    username: "<required>"
+    password: "<required>"
+  vsphereTemplate:
+    datacenter: "<required>"
+    datastore: "<required>"
+    diskGiB: 40
+    folder: "<required>"
+    host: "<required>"
+    memoryMiB: 8192
+    networkName: "<required>"
+    numCPUs: 4
+    resourcePool: "<required>"
+    template: "<required>"
+  clusterNamePrefix: "<required>"
+  provider: "<required>"    # capa or capv
+```
+
+## Defaults
+This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to: 
+1. Reduce the number of fields the user needs to provide in the cattle_config file. 
+2. Reduce the amount of yaml data that needs to be stored in our pipelines.
+3. Make it easier to run tests
+
+Any data the user provides will override these defaults which are stored here: [defaults](../defaults/defaults.yaml). 
+
+## Logging
+This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 
+
+```yaml
+logging:
+   level: "trace" #trace debug, info, warning, error
+```
+
+## Additional
+1. If the tests passes immediately without warning, try adding the `-count=1` or run `go clean -cache`. This will avoid previous results from interfering with the new test run.
+2. All of the tests utilize parallelism when running for more finite control of how things are run in parallel use the -p and -parallel.

--- a/validation/deleting/capipnp/rke2/delete_cluster_test.go
+++ b/validation/deleting/capipnp/rke2/delete_cluster_test.go
@@ -1,0 +1,44 @@
+//go:build validation || capi
+
+package rke2
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	extClusters "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/validation/deleting/capipnp"
+	"github.com/sirupsen/logrus"
+)
+
+func TestDeletingCAPIPnPCluster(t *testing.T) {
+	t.Parallel()
+
+	d := capipnp.Setup(t, defaults.RKE2, true)
+
+	tests := []struct {
+		name    string
+		cluster *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_RKE2_Delete_Cluster", d.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logrus.Infof("Deleting cluster (%s)", tt.cluster.ID)
+			extClusters.DeleteK3SRKE2Cluster(d.Client, tt.cluster.ID)
+
+			logrus.Infof("Verifying cluster (%s) deletion", tt.cluster.ID)
+			provisioning.VerifyDeleteRKE2K3SCluster(t, d.Client, tt.cluster.ID)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(d.Client, d.CattleConfig)
+		err := qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/deleting/capipnp/rke2/delete_init_machine_test.go
+++ b/validation/deleting/capipnp/rke2/delete_init_machine_test.go
@@ -1,0 +1,69 @@
+//go:build validation || capi
+
+package rke2
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/deleting/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteInitCAPIPnPMachine(t *testing.T) {
+	t.Parallel()
+
+	d := capipnp.Setup(t, defaults.RKE2, false)
+
+	tests := []struct {
+		name    string
+		cluster *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_RKE2_Delete_Init_Machine", d.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", d.Cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(d.Client, d.Cluster.Name, d.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			logrus.Infof("Deleting init machine on cluster (%s)", tt.cluster.Name)
+			err := clusters.DeleteInitMachine(d.Client, tt.cluster.ID)
+			require.NoError(t, err)
+
+			err = provisioning.WaitClusterToBeUpgradedWithRetry(d.Client, tt.cluster.ID)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(d.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(d.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(d.Client, tt.cluster)
+			require.NoError(t, err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(d.Client, d.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/deleting/capipnp/rke2/delete_machine_test.go
+++ b/validation/deleting/capipnp/rke2/delete_machine_test.go
@@ -1,0 +1,90 @@
+//go:build validation || capi
+
+package rke2
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/machinepools"
+	"github.com/rancher/tests/actions/machines"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/deleting/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteMachine(t *testing.T) {
+	t.Parallel()
+
+	d := capipnp.Setup(t, defaults.RKE2, false)
+
+	nodeRolesEtcd := machinepools.NodeRoles{
+		Etcd: true,
+	}
+
+	nodeRolesControlPlane := machinepools.NodeRoles{
+		ControlPlane: true,
+	}
+
+	nodeRolesWorker := machinepools.NodeRoles{
+		Worker: true,
+	}
+
+	tests := []struct {
+		name      string
+		nodeRoles machinepools.NodeRoles
+		cluster   *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_RKE2_Replace_Control_Plane", nodeRolesControlPlane, d.Cluster},
+		{"CAPI_PnP_RKE2_Replace_ETCD", nodeRolesEtcd, d.Cluster},
+		{"CAPI_PnP_RKE2_Replace_Worker", nodeRolesWorker, d.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", d.Cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(d.Client, d.Cluster.Name, d.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			machineList, err := machines.GetMachinesByRole(d.Client, tt.cluster, tt.nodeRoles)
+			require.NoError(t, err)
+
+			machineToDelete := machineList[0]
+			logrus.Infof("Deleting machine (%s) from cluster (%s)", machineToDelete.Name, tt.cluster.Name)
+			err = d.Client.Steve.SteveType(stevetypes.Machine).Delete(&machineToDelete)
+			require.NoError(t, err)
+
+			err = machines.VerifyMachineReplacement(d.Client, &machineToDelete)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster is ready after machine replacement (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(d.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(d.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(d.Client, tt.cluster)
+			require.NoError(t, err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(d.Client, d.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/deleting/capipnp/rke2/schemas/hostbusters_schemas.yaml
+++ b/validation/deleting/capipnp/rke2/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,103 @@
+- suite: Go Automation/Deleting/CAPIPnP/RKE2
+  projects: [RRT, RM]
+  cases:
+  - description: Deletes an existing cluster
+    title: CAPIPnP_RKE2_Delete_Cluster
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Delete the existing cluster
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster is deleted
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+  - description: Deletes the init machine on an existing cluster
+    title: CAPIPnP_RKE2_Delete_Init_Machine
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Delete the init machine on an existing cluster
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+  - description: Deletes and replaces a control plane machine
+    title: CAPIPnP_RKE2_Replace_Control_Plane
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Delete a control plane machine
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify machine replacement and cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+  - description: Deletes and replaces an ETCD machine
+    title: CAPIPnP_RKE2_Replace_ETCD
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Delete an ETCD machine
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify machine replacement and cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+  - description: Deletes and replaces a worker machine
+    title: CAPIPnP_RKE2_Replace_Worker
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Delete a worker machine
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify machine replacement and cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/deleting/capipnp/setup.go
+++ b/validation/deleting/capipnp/setup.go
@@ -1,0 +1,186 @@
+package capipnp
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	extclusters "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/rbac"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type deleteTest struct {
+	suite.Suite
+	Client             *rancher.Client
+	StandardUserClient *rancher.Client
+	Session            *session.Session
+	CattleConfig       map[string]any
+	ClusterConfig      *clusters.ClusterConfig
+	RancherConfig      *rancher.Config
+	CapiConfig         *capipnp.Config
+	Cluster            *v1.SteveAPIObject
+	ClusterManifest    []byte
+}
+
+func Setup(t *testing.T, clusterType string, defaultNodeRoles bool) *deleteTest {
+	d := &deleteTest{}
+
+	testSession := session.NewSession()
+	d.Session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	d.Client = client
+
+	localClusterID, err := extclusters.GetClusterIDByName(d.Client, extclusterapi.LocalCluster)
+	require.NoError(t, err)
+
+	localCluster, err := d.Client.Management.Cluster.ByID(localClusterID)
+	require.NoError(t, err)
+
+	_, standardUserClient, err := rbac.AddUserWithRoleToCluster(d.Client, rbac.StandardUser.String(), rbac.ClusterOwner.String(), localCluster, nil)
+	require.NoError(t, err)
+
+	d.StandardUserClient = standardUserClient
+
+	d.CattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
+
+	_, setupFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	capipnpDir := filepath.Dir(setupFile)
+	deletingDir := filepath.Dir(capipnpDir)
+	validationDir := filepath.Dir(deletingDir)
+	provisioningDir := filepath.Join(validationDir, "provisioning")
+
+	provisioningDefaults := config.LoadConfigFromFile(filepath.Join(provisioningDir, "defaults", "defaults.yaml"))
+	deletingDefaults := config.LoadConfigFromFile(filepath.Join(deletingDir, "defaults", "defaults.yaml"))
+	validationDefaults, err := defaults.DeepMerge(deletingDefaults, provisioningDefaults, true)
+	require.NoError(t, err)
+
+	d.CattleConfig, err = defaults.DeepMerge(d.CattleConfig, validationDefaults, true)
+	require.NoError(t, err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, d.CattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(t, err)
+
+	clusterConfig := new(clusters.ClusterConfig)
+	operations.LoadObjectFromMap(defaults.ClusterConfigKey, d.CattleConfig, clusterConfig)
+
+	d.ClusterConfig = clusterConfig
+
+	rancherConfig := new(rancher.Config)
+	operations.LoadObjectFromMap(defaults.RancherConfigKey, d.CattleConfig, rancherConfig)
+
+	d.RancherConfig = rancherConfig
+
+	capiConfig := new(capipnp.Config)
+	operations.LoadObjectFromMap(capipnp.ConfigurationFileKey, d.CattleConfig, capiConfig)
+
+	d.CapiConfig = capiConfig
+
+	providerManifestsPath := filepath.Join(provisioningDir, "resources", "capipnp", "providers", d.CapiConfig.Provider)
+	d.CapiConfig.ClusterYAML = filepath.Join(providerManifestsPath, clusterType+"-cluster.yaml")
+	providerManifest := filepath.Join(providerManifestsPath, "provider.yaml")
+	credentialsManifest := filepath.Join(providerManifestsPath, "creds.yaml")
+	identityManifest := filepath.Join(providerManifestsPath, "identity.yaml")
+
+	if d.RancherConfig.ClusterName == "" {
+		d.CattleConfig, err = defaults.SetK8sDefault(d.Client, clusterType, d.CattleConfig)
+		require.NoError(t, err)
+
+		resolvedK8sVersion, err := operations.GetValue([]string{defaults.ClusterConfigKey, defaults.K8SVersionKey}, d.CattleConfig)
+		require.NoError(t, err)
+
+		if resolvedK8sVersion != nil {
+			d.CapiConfig.KubernetesVersion, _ = resolvedK8sVersion.(string)
+		}
+
+		if !defaultNodeRoles {
+			nodeRolesStandard := []provisioninginput.MachinePools{
+				provisioninginput.EtcdMachinePool,
+				provisioninginput.ControlPlaneMachinePool,
+				provisioninginput.WorkerMachinePool,
+			}
+
+			nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+			nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+			nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
+
+			clusterConfig.MachinePools = nodeRolesStandard
+		}
+
+		logrus.Debugf("Applying %s provider manifest...", d.CapiConfig.Provider)
+		err = capipnp.CreateProviderManifestFromPath(d.Client, d.CapiConfig, providerManifest)
+		require.NoError(t, err)
+
+		logrus.Debugf("Applying credentials manifest...")
+		err = capipnp.CreateProviderManifestFromPath(d.Client, d.CapiConfig, credentialsManifest)
+		require.NoError(t, err)
+
+		logrus.Debugf("Waiting for previous manifests to be active...")
+		err = capipnp.WaitProviderPrerequisitesReady(d.Client, d.CapiConfig)
+		require.NoError(t, err)
+
+		logrus.Debugf("Applying cluster static identity manifest...")
+		err = capipnp.CreateProviderManifestFromPath(d.Client, d.CapiConfig, identityManifest)
+		require.NoError(t, err)
+
+		clusterName := namegen.AppendRandomString(d.CapiConfig.ClusterNamePrefix)
+
+		d.ClusterManifest, err = capipnp.CreateClusterManifestFromDefaults(d.CapiConfig, d.ClusterConfig.MachinePools, clusterName)
+		require.NoError(t, err)
+
+		logrus.Infof("Provisioning %s cluster", clusterType)
+		err = capipnp.CreateCAPICluster(d.StandardUserClient, clusterName, d.ClusterManifest)
+		require.NoError(t, err)
+
+		cluster, err := clusters.GetClusterByName(d.Client, clusterName)
+		require.NoError(t, err)
+
+		err = provisioning.VerifyClusterReady(d.Client, cluster)
+		require.NoError(t, err)
+
+		err = deployment.VerifyClusterDeployments(d.Client, cluster)
+		require.NoError(t, err)
+
+		err = pods.VerifyClusterPods(d.Client, cluster)
+		require.NoError(t, err)
+
+		d.Cluster, err = d.Client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + cluster.Name)
+		require.NoError(t, err)
+	} else {
+		d.ClusterManifest, err = capipnp.CreateClusterManifestFromDefaults(d.CapiConfig, d.ClusterConfig.MachinePools, d.RancherConfig.ClusterName)
+		require.NoError(t, err)
+
+		logrus.Infof("Using existing cluster %s", d.RancherConfig.ClusterName)
+		d.Cluster, err = d.Client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + d.RancherConfig.ClusterName)
+		require.NoError(t, err)
+	}
+
+	return d
+}

--- a/validation/encryptionkeyrotation/capipnp/k3s/README.md
+++ b/validation/encryptionkeyrotation/capipnp/k3s/README.md
@@ -1,12 +1,11 @@
 # K3s Encryption Key Rotation
 
 ## Table of Contents
-1. [Prerequisites](../README.md)
-2. [Tests Cases](#Test-Cases)
-3. [Configurations](#Configurations)
-4. [Configuration Defaults](#defaults)
-5. [Logging Levels](#Logging)
-6. [Back to general certificates](../README.md)
+1. [Tests Cases](#Test-Cases)
+2. [Configurations](#Configurations)
+3. [Configuration Defaults](#defaults)
+4. [Logging Levels](#Logging)
+5. [Back to general certificates](../README.md)
 
 ## Test Cases
 All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
@@ -22,10 +21,10 @@ The encryption key rotation test verifies that a cluster can successfully perfor
 3. [Machine Config](#machine-config)
 
 #### Table Tests:
-1. `K3S_Encryption_Key_Rotation`
+1. `CAPI_PnP_K3S_Encryption_Key_Rotation`
 
 #### Run Commands:
-1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/encryptionkeyrotation/k3s --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestEncryptionKeyRotation -timeout=2h -v`
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/encryptionkeyrotation/capipnp/k3s --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestCAPIPnPEncryptionKeyRotation -timeout=2h -v`
 
 ## Configurations
 
@@ -42,7 +41,38 @@ rancher:
 NOTE: If you are providing an existing cluster, it is assumed that secrets encryption is enabled on the cluster; this is a K3s pre-requiste for encryption key rotation.
 
 ### Provisioning cluster
-This test will create a cluster if one is not provided, see the needed cluster configuration [k3s provisioning](../../provisioning/k3s/README.md)
+This test will create a cluster if one is not provided, see the section on having a defined machine pool in this reference README: [k3s provisioning](../../../provisioning/k3s/README.md). Additionally, you will need this section for CAPI configurations:
+
+```yaml
+capipnp:
+  awsCredentials:
+    accessKeyID: "<required>"
+    secretAccessKey: "<required>"
+  awsTemplate:
+    ami: "<required>"
+    controlPlaneSecurityGroup: "sg-<required>"
+    nodeSecurityGroup: "sg-<required>"
+    region: "us-west-1"
+    sshKeyName: "<required>"
+    subnetId: "subnet-<required>"
+    vpcId: "vpc-<required>"
+  vsphereCredentials:
+    username: "<required>"
+    password: "<required>"
+  vsphereTemplate:
+    datacenter: "<required>"
+    datastore: "<required>"
+    diskGiB: 40
+    folder: "<required>"
+    host: "<required>"
+    memoryMiB: 8192
+    networkName: "<required>"
+    numCPUs: 4
+    resourcePool: "<required>"
+    template: "<required>"
+  clusterNamePrefix: "<required>"
+  provider: "<required>"    # capa or capv
+```
 
 ## Defaults
 This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to: 
@@ -50,7 +80,7 @@ This package contains a defaults folder which contains default test configuratio
 2. Reduce the amount of yaml data that needs to be stored in our pipelines.
 3. Make it easier to run tests
 
-Any data the user provides will override these defaults which are stored here: [defaults](defaults/defaults.yaml). 
+Any data the user provides will override these defaults which are stored here: [defaults](../defaults/defaults.yaml). 
 
 ## Logging
 This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 

--- a/validation/encryptionkeyrotation/capipnp/k3s/encryption_key_rotation_test.go
+++ b/validation/encryptionkeyrotation/capipnp/k3s/encryption_key_rotation_test.go
@@ -1,0 +1,79 @@
+//go:build validation || capi
+
+package k3s
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/encryptionkeyrotation"
+	snapshot "github.com/rancher/tests/actions/etcdsnapshot"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/encryptionkeyrotation/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCAPIPnPEncryptionKeyRotation(t *testing.T) {
+	t.Parallel()
+
+	e := capipnp.Setup(t, defaults.K3S)
+
+	tests := []struct {
+		name    string
+		cluster *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_K3S_Encryption_Key_Rotation", e.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", e.Cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(e.Client, e.Cluster.Name, e.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			logrus.Infof("Creating snapshot on cluster (%s)", tt.cluster.Name)
+			_, err := snapshot.CreateRKE2K3SSnapshot(e.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			logrus.Infof("Enabling secrets encryption on cluster (%s)", tt.cluster.Name)
+			err = encryptionkeyrotation.EnableSecretsEncryption(e.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			logrus.Infof("Performing encryption key rotation on cluster (%s)", tt.cluster.Name)
+			err = encryptionkeyrotation.RotateEncryptionKey(e.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying encryption key rotated on cluster (%s)", tt.cluster.Name)
+			err = encryptionkeyrotation.VerifyRotationFromControlPlaneStatus(e.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(e.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(e.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(e.Client, tt.cluster)
+			require.NoError(t, err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(e.Client, e.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/encryptionkeyrotation/capipnp/k3s/schemas/hostbusters_schemas.yaml
+++ b/validation/encryptionkeyrotation/capipnp/k3s/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,23 @@
+- suite: Go Automation/EncryptionKeyRotation/CAPIPnP/K3S
+  projects: [RRT, RM]
+  cases:
+  - description: Rotates the clusters encryption keys
+    title: CAPI_PnP_K3S_Encryption_Key_Rotation
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Rotate the clusters encryption keys
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/encryptionkeyrotation/capipnp/rke2/README.md
+++ b/validation/encryptionkeyrotation/capipnp/rke2/README.md
@@ -1,12 +1,11 @@
-# K3s Encryption Key Rotation
+# RKE2 Encryption Key Rotation
 
 ## Table of Contents
-1. [Prerequisites](../README.md)
-2. [Tests Cases](#Test-Cases)
-3. [Configurations](#Configurations)
-4. [Configuration Defaults](#defaults)
-5. [Logging Levels](#Logging)
-6. [Back to general certificates](../README.md)
+1. [Tests Cases](#Test-Cases)
+2. [Configurations](#Configurations)
+3. [Configuration Defaults](#defaults)
+4. [Logging Levels](#Logging)
+5. [Back to general certificates](../README.md)
 
 ## Test Cases
 All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
@@ -22,10 +21,10 @@ The encryption key rotation test verifies that a cluster can successfully perfor
 3. [Machine Config](#machine-config)
 
 #### Table Tests:
-1. `K3S_Encryption_Key_Rotation`
+1. `CAPI_PnP_RKE2_Encryption_Key_Rotation`
 
 #### Run Commands:
-1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/encryptionkeyrotation/k3s --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestEncryptionKeyRotation -timeout=2h -v`
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/encryptionkeyrotation/capipnp/rke2 --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestCAPIPnPEncryptionKeyRotation -timeout=2h -v`
 
 ## Configurations
 
@@ -42,7 +41,38 @@ rancher:
 NOTE: If you are providing an existing cluster, it is assumed that secrets encryption is enabled on the cluster; this is a K3s pre-requiste for encryption key rotation.
 
 ### Provisioning cluster
-This test will create a cluster if one is not provided, see the needed cluster configuration [k3s provisioning](../../provisioning/k3s/README.md)
+This test will create a cluster if one is not provided, see the section on having a defined machine pool in this reference README: [rke2 provisioning](../../../provisioning/rke2/README.md). Additionally, you will need this section for CAPI configurations:
+
+```yaml
+capipnp:
+  awsCredentials:
+    accessKeyID: "<required>"
+    secretAccessKey: "<required>"
+  awsTemplate:
+    ami: "<required>"
+    controlPlaneSecurityGroup: "sg-<required>"
+    nodeSecurityGroup: "sg-<required>"
+    region: "us-west-1"
+    sshKeyName: "<required>"
+    subnetId: "subnet-<required>"
+    vpcId: "vpc-<required>"
+  vsphereCredentials:
+    username: "<required>"
+    password: "<required>"
+  vsphereTemplate:
+    datacenter: "<required>"
+    datastore: "<required>"
+    diskGiB: 40
+    folder: "<required>"
+    host: "<required>"
+    memoryMiB: 8192
+    networkName: "<required>"
+    numCPUs: 4
+    resourcePool: "<required>"
+    template: "<required>"
+  clusterNamePrefix: "<required>"
+  provider: "<required>"    # capa or capv
+```
 
 ## Defaults
 This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to: 
@@ -50,7 +80,7 @@ This package contains a defaults folder which contains default test configuratio
 2. Reduce the amount of yaml data that needs to be stored in our pipelines.
 3. Make it easier to run tests
 
-Any data the user provides will override these defaults which are stored here: [defaults](defaults/defaults.yaml). 
+Any data the user provides will override these defaults which are stored here: [defaults](../defaults/defaults.yaml). 
 
 ## Logging
 This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 

--- a/validation/encryptionkeyrotation/capipnp/rke2/encryption_key_rotation_test.go
+++ b/validation/encryptionkeyrotation/capipnp/rke2/encryption_key_rotation_test.go
@@ -1,0 +1,79 @@
+//go:build validation || capi
+
+package rke2
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/encryptionkeyrotation"
+	snapshot "github.com/rancher/tests/actions/etcdsnapshot"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/encryptionkeyrotation/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCAPIPnPEncryptionKeyRotation(t *testing.T) {
+	t.Parallel()
+
+	e := capipnp.Setup(t, defaults.RKE2)
+
+	tests := []struct {
+		name    string
+		cluster *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_RKE2_Encryption_Key_Rotation", e.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", e.Cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(e.Client, e.Cluster.Name, e.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			logrus.Infof("Creating snapshot on cluster (%s)", tt.cluster.Name)
+			_, err := snapshot.CreateRKE2K3SSnapshot(e.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			logrus.Infof("Enabling secrets encryption on cluster (%s)", tt.cluster.Name)
+			err = encryptionkeyrotation.EnableSecretsEncryption(e.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			logrus.Infof("Performing encryption key rotation on cluster (%s)", tt.cluster.Name)
+			err = encryptionkeyrotation.RotateEncryptionKey(e.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying encryption key rotated on cluster (%s)", tt.cluster.Name)
+			err = encryptionkeyrotation.VerifyRotationFromControlPlaneStatus(e.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(e.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(e.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(e.Client, tt.cluster)
+			require.NoError(t, err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(e.Client, e.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/encryptionkeyrotation/capipnp/rke2/schemas/hostbusters_schemas.yaml
+++ b/validation/encryptionkeyrotation/capipnp/rke2/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,23 @@
+- suite: Go Automation/EncryptionKeyRotation/CAPIPnP/RKE2
+  projects: [RRT, RM]
+  cases:
+  - description: Rotates the clusters encryption keys
+    title: CAPI_PnP_RKE2_Encryption_Key_Rotation
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Rotate the clusters encryption keys
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/encryptionkeyrotation/capipnp/setup.go
+++ b/validation/encryptionkeyrotation/capipnp/setup.go
@@ -1,0 +1,171 @@
+package capipnp
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	extclusters "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/rbac"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type encryptionKeyRotationTest struct {
+	suite.Suite
+	Client             *rancher.Client
+	StandardUserClient *rancher.Client
+	Session            *session.Session
+	CattleConfig       map[string]any
+	ClusterConfig      *clusters.ClusterConfig
+	RancherConfig      *rancher.Config
+	CapiConfig         *capipnp.Config
+	Cluster            *v1.SteveAPIObject
+	ClusterManifest    []byte
+}
+
+func Setup(t *testing.T, clusterType string) *encryptionKeyRotationTest {
+	e := &encryptionKeyRotationTest{}
+
+	testSession := session.NewSession()
+	e.Session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	e.Client = client
+
+	localClusterID, err := extclusters.GetClusterIDByName(e.Client, extclusterapi.LocalCluster)
+	require.NoError(t, err)
+
+	localCluster, err := e.Client.Management.Cluster.ByID(localClusterID)
+	require.NoError(t, err)
+
+	_, standardUserClient, err := rbac.AddUserWithRoleToCluster(e.Client, rbac.StandardUser.String(), rbac.ClusterOwner.String(), localCluster, nil)
+	require.NoError(t, err)
+
+	e.StandardUserClient = standardUserClient
+
+	e.CattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
+
+	_, setupFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	capipnpDir := filepath.Dir(setupFile)
+	ekrDir := filepath.Dir(capipnpDir)
+	validationDir := filepath.Dir(ekrDir)
+	provisioningDir := filepath.Join(validationDir, "provisioning")
+
+	provisioningDefaults := config.LoadConfigFromFile(filepath.Join(provisioningDir, "defaults", "defaults.yaml"))
+	deletingDefaults := config.LoadConfigFromFile(filepath.Join(ekrDir, "defaults", "defaults.yaml"))
+	validationDefaults, err := defaults.DeepMerge(deletingDefaults, provisioningDefaults, true)
+	require.NoError(t, err)
+
+	e.CattleConfig, err = defaults.DeepMerge(e.CattleConfig, validationDefaults, true)
+	require.NoError(t, err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, e.CattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(t, err)
+
+	clusterConfig := new(clusters.ClusterConfig)
+	operations.LoadObjectFromMap(defaults.ClusterConfigKey, e.CattleConfig, clusterConfig)
+
+	e.ClusterConfig = clusterConfig
+
+	rancherConfig := new(rancher.Config)
+	operations.LoadObjectFromMap(defaults.RancherConfigKey, e.CattleConfig, rancherConfig)
+
+	e.RancherConfig = rancherConfig
+
+	capiConfig := new(capipnp.Config)
+	operations.LoadObjectFromMap(capipnp.ConfigurationFileKey, e.CattleConfig, capiConfig)
+
+	e.CapiConfig = capiConfig
+
+	providerManifestsPath := filepath.Join(provisioningDir, "resources", "capipnp", "providers", e.CapiConfig.Provider)
+	e.CapiConfig.ClusterYAML = filepath.Join(providerManifestsPath, clusterType+"-cluster.yaml")
+	providerManifest := filepath.Join(providerManifestsPath, "provider.yaml")
+	credentialsManifest := filepath.Join(providerManifestsPath, "creds.yaml")
+	identityManifest := filepath.Join(providerManifestsPath, "identity.yaml")
+
+	if e.RancherConfig.ClusterName == "" {
+		e.CattleConfig, err = defaults.SetK8sDefault(e.Client, clusterType, e.CattleConfig)
+		require.NoError(t, err)
+
+		resolvedK8sVersion, err := operations.GetValue([]string{defaults.ClusterConfigKey, defaults.K8SVersionKey}, e.CattleConfig)
+		require.NoError(t, err)
+
+		if resolvedK8sVersion != nil {
+			e.CapiConfig.KubernetesVersion, _ = resolvedK8sVersion.(string)
+		}
+
+		logrus.Debugf("Applying %s provider manifest...", e.CapiConfig.Provider)
+		err = capipnp.CreateProviderManifestFromPath(e.Client, e.CapiConfig, providerManifest)
+		require.NoError(t, err)
+
+		logrus.Debugf("Applying credentials manifest...")
+		err = capipnp.CreateProviderManifestFromPath(e.Client, e.CapiConfig, credentialsManifest)
+		require.NoError(t, err)
+
+		logrus.Debugf("Waiting for previous manifests to be active...")
+		err = capipnp.WaitProviderPrerequisitesReady(e.Client, e.CapiConfig)
+		require.NoError(t, err)
+
+		logrus.Debugf("Applying cluster static identity manifest...")
+		err = capipnp.CreateProviderManifestFromPath(e.Client, e.CapiConfig, identityManifest)
+		require.NoError(t, err)
+
+		clusterName := namegen.AppendRandomString(e.CapiConfig.ClusterNamePrefix)
+
+		e.ClusterManifest, err = capipnp.CreateClusterManifestFromDefaults(e.CapiConfig, e.ClusterConfig.MachinePools, clusterName)
+		require.NoError(t, err)
+
+		logrus.Infof("Provisioning %s cluster", clusterType)
+		err = capipnp.CreateCAPICluster(e.StandardUserClient, clusterName, e.ClusterManifest)
+		require.NoError(t, err)
+
+		cluster, err := clusters.GetClusterByName(e.Client, clusterName)
+		require.NoError(t, err)
+
+		err = provisioning.VerifyClusterReady(e.Client, cluster)
+		require.NoError(t, err)
+
+		err = deployment.VerifyClusterDeployments(e.Client, cluster)
+		require.NoError(t, err)
+
+		err = pods.VerifyClusterPods(e.Client, cluster)
+		require.NoError(t, err)
+
+		e.Cluster, err = e.Client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + cluster.Name)
+		require.NoError(t, err)
+	} else {
+		e.ClusterManifest, err = capipnp.CreateClusterManifestFromDefaults(e.CapiConfig, e.ClusterConfig.MachinePools, e.RancherConfig.ClusterName)
+		require.NoError(t, err)
+
+		logrus.Infof("Using existing cluster %s", e.RancherConfig.ClusterName)
+		e.Cluster, err = e.Client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + e.RancherConfig.ClusterName)
+		require.NoError(t, err)
+	}
+
+	return e
+}

--- a/validation/encryptionkeyrotation/rke2/README.md
+++ b/validation/encryptionkeyrotation/rke2/README.md
@@ -18,7 +18,7 @@ The encryption key rotation test verifies that a cluster can successfully perfor
 
 #### Required Configurations:
 1. [Cloud Credential](#cloud-credential-config)
-2. [Cluster Config](#cluster-config) (with IPv6 settings)
+2. [Cluster Config](#cluster-config)
 3. [Machine Config](#machine-config)
 
 #### Table Tests:

--- a/validation/nodescaling/capipnp/k3s/README.md
+++ b/validation/nodescaling/capipnp/k3s/README.md
@@ -1,0 +1,130 @@
+# K3S Node Scaling Configs
+
+## Table of Contents
+1. [Test Cases](#Test-Cases)
+2. [Configurations](#Configurations)
+3. [Configuration Defaults](#defaults)
+4. [Logging Levels](#Logging)
+5. [Back to general node scaling](../README.md)
+
+## Test Cases
+All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
+
+### Node Scaling Test
+
+#### Description:
+The node scaling test validates that node pools can be scaled up and down. All configurations are not required if an already provisioned cluster is provided to the test.
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `CAPI_PnP_K3S_Scale_Control_Plane`
+2. `CAPI_PnP_K3S_Scale_ETCD`
+3. `CAPI_PnP_K3S_Scale_Worker`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/capipnp/k3s --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestScalingCAPIPnPNodePools -timeout=60m -v`
+
+## Configurations
+
+### Existing cluster:
+```yaml
+rancher:
+  host: <rancher-fqdn>
+  adminToken: <rancher-token>
+  clusterName: "<existing cluster name>"
+  cleanup: true
+  insecure: true
+```
+
+### Provisioning cluster
+This test will create a cluster if one is not provided. See to configure a node driver OR custom cluster depending on the node scaling test [k3s provisioning](../../../provisioning/k3s/README.md)
+
+### Cloud Credential Config
+
+```yaml
+rancher:
+  host: ""
+  adminToken: ""
+  insecure: true
+```
+
+### Cluster Config
+```yaml
+clusterConfig:
+  cni: "calico"
+  provider: "aws"
+  nodeProvider: "ec2"
+```
+
+### Machine Config
+```yaml
+awsMachineConfigs:
+  region: "us-east-2"
+  awsMachineConfig:
+  - roles: ["etcd", "controlplane", "worker"]
+    ami: ""
+    instanceType: ""
+    sshUser: ""
+    vpcId: ""
+    volumeType: ""
+    zone: "a"
+    retries: ""
+    rootSize: ""
+    securityGroup: [""]
+```
+
+### CAPI PnP Config
+```yaml
+capipnp:
+  awsCredentials:
+    accessKeyID: "<required>"
+    secretAccessKey: "<required>"
+  awsTemplate:
+    ami: "<required>"
+    controlPlaneSecurityGroup: "sg-<required>"
+    nodeSecurityGroup: "sg-<required>"
+    region: "us-west-1"
+    sshKeyName: "<required>"
+    subnetId: "subnet-<required>"
+    vpcId: "vpc-<required>"
+  vsphereCredentials:
+    username: "<required>"
+    password: "<required>"
+  vsphereTemplate:
+    datacenter: "<required>"
+    datastore: "<required>"
+    diskGiB: 40
+    folder: "<required>"
+    host: "<required>"
+    memoryMiB: 8192
+    networkName: "<required>"
+    numCPUs: 4
+    resourcePool: "<required>"
+    template: "<required>"
+  clusterNamePrefix: "<required>"
+  provider: "<required>"    # capa or capv
+```
+
+## Defaults
+This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to:
+1. Reduce the number of fields the user needs to provide in the cattle_config file.
+2. Reduce the amount of yaml data that needs to be stored in our pipelines.
+3. Make it easier to run tests
+
+Any data the user provides will override these defaults which are stored here: [defaults](../defaults/defaults.yaml).
+
+## Logging
+This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted.
+
+```yaml
+logging:
+   level: "trace" #trace, debug, info, warning, error
+```
+
+## Additional
+1. If the test passes immediately without warning, try adding the `-count=1` or run `go clean -cache`. This will avoid previous results from interfering with the new test run.
+2. All of the tests utilize parallelism when running for more finite control of how things are run in parallel use the -p and -parallel flags.

--- a/validation/nodescaling/capipnp/k3s/scaling_test.go
+++ b/validation/nodescaling/capipnp/k3s/scaling_test.go
@@ -1,0 +1,112 @@
+//go:build validation || capi
+
+package k3s
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/machinepools"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/nodescaling/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScalingCAPIPnPNodePools(t *testing.T) {
+	t.Parallel()
+
+	s := capipnp.Setup(t, defaults.K3S)
+
+	nodeRolesEtcd := machinepools.NodeRoles{
+		Etcd:     true,
+		Quantity: 1,
+	}
+
+	nodeRolesControlPlane := machinepools.NodeRoles{
+		ControlPlane: true,
+		Quantity:     1,
+	}
+
+	nodeRolesWorker := machinepools.NodeRoles{
+		Worker:   true,
+		Quantity: 1,
+	}
+
+	tests := []struct {
+		name          string
+		nodeRoles     machinepools.NodeRoles
+		scaleQuantity int32
+		cluster       *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_K3S_Scale_Control_Plane", nodeRolesControlPlane, 1, s.Cluster},
+		{"CAPI_PnP_K3S_Scale_ETCD", nodeRolesEtcd, 1, s.Cluster},
+		{"CAPI_PnP_K3S_Scale_Worker", nodeRolesWorker, 1, s.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", s.Cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(s.Client, s.Cluster.Name, s.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			tt.nodeRoles.Quantity = tt.scaleQuantity
+			logrus.Infof("Scaling up the node pool (%s)", tt.cluster.Name)
+			tt.cluster, err = machinepools.ScaleMachinePool(s.Client, tt.cluster, tt.nodeRoles)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", tt.cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(s.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			tt.nodeRoles.Quantity = -tt.scaleQuantity
+			logrus.Infof("Scaling down the node pool (%s)", tt.cluster.Name)
+			_, err = machinepools.ScaleMachinePool(s.Client, tt.cluster, tt.nodeRoles)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", tt.cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(s.Client, tt.cluster.Name)
+			require.NoError(t, err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(s.Client, s.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/nodescaling/capipnp/k3s/schemas/hostbusters_schemas.yaml
+++ b/validation/nodescaling/capipnp/k3s/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,95 @@
+- suite: Go Automation/NodeScaling/CAPIPnP/K3S
+  projects: [RRT, RM]
+  cases:
+  - description: Scales up/down the control plane node pools of an existing cluster
+    title: CAPI_PnP_K3S_Scale_Control_Plane
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Scale up the control plane node pools by 1
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Scale down the control plane node pools by 1
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 4
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
+  - description: Scales up/down the etcd node pools of an existing cluster
+    title: CAPI_PnP_K3S_Scale_ETCD
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Scale up the etcd node pools by 1
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Scale down the etcd node pools by 1
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 4
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
+  - description: Scales up/down the worker node pools of an existing cluster
+    title: CAPI_PnP_K3S_Scale_Worker
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Scale up the worker node pools by 1
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Scale down the worker node pools by 1
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 4
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/nodescaling/capipnp/rke2/README.md
+++ b/validation/nodescaling/capipnp/rke2/README.md
@@ -1,0 +1,130 @@
+# RKE2 Node Scaling Configs
+
+## Table of Contents
+1. [Test Cases](#Test-Cases)
+2. [Configurations](#Configurations)
+3. [Configuration Defaults](#defaults)
+4. [Logging Levels](#Logging)
+5. [Back to general node scaling](../README.md)
+
+## Test Cases
+All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
+
+### Node Scaling Test
+
+#### Description:
+The node scaling test validates that node pools can be scaled up and down. All configurations are not required if an already provisioned cluster is provided to the test.
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `CAPI_PnP_RKE2_Scale_Control_Plane`
+2. `CAPI_PnP_RKE2_Scale_ETCD`
+3. `CAPI_PnP_RKE2_Scale_Worker`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/nodescaling/capipnp/rke2 --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestScalingCAPIPnPNodePools -timeout=60m -v`
+
+## Configurations
+
+### Existing cluster:
+```yaml
+rancher:
+  host: <rancher-fqdn>
+  adminToken: <rancher-token>
+  clusterName: "<existing cluster name>"
+  cleanup: true
+  insecure: true
+```
+
+### Provisioning cluster
+This test will create a cluster if one is not provided. See to configure a node driver OR custom cluster depending on the node scaling test [rke2 provisioning](../../../provisioning/rke2/README.md)
+
+### Cloud Credential Config
+
+```yaml
+rancher:
+  host: ""
+  adminToken: ""
+  insecure: true
+```
+
+### Cluster Config
+```yaml
+clusterConfig:
+  cni: "calico"
+  provider: "aws"
+  nodeProvider: "ec2"
+```
+
+### Machine Config
+```yaml
+awsMachineConfigs:
+  region: "us-east-2"
+  awsMachineConfig:
+  - roles: ["etcd", "controlplane", "worker"]
+    ami: ""
+    instanceType: ""
+    sshUser: ""
+    vpcId: ""
+    volumeType: ""
+    zone: "a"
+    retries: ""
+    rootSize: ""
+    securityGroup: [""]
+```
+
+### CAPI PnP Config
+```yaml
+capipnp:
+  awsCredentials:
+    accessKeyID: "<required>"
+    secretAccessKey: "<required>"
+  awsTemplate:
+    ami: "<required>"
+    controlPlaneSecurityGroup: "sg-<required>"
+    nodeSecurityGroup: "sg-<required>"
+    region: "us-west-1"
+    sshKeyName: "<required>"
+    subnetId: "subnet-<required>"
+    vpcId: "vpc-<required>"
+  vsphereCredentials:
+    username: "<required>"
+    password: "<required>"
+  vsphereTemplate:
+    datacenter: "<required>"
+    datastore: "<required>"
+    diskGiB: 40
+    folder: "<required>"
+    host: "<required>"
+    memoryMiB: 8192
+    networkName: "<required>"
+    numCPUs: 4
+    resourcePool: "<required>"
+    template: "<required>"
+  clusterNamePrefix: "<required>"
+  provider: "<required>"    # capa or capv
+```
+
+## Defaults
+This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to:
+1. Reduce the number of fields the user needs to provide in the cattle_config file.
+2. Reduce the amount of yaml data that needs to be stored in our pipelines.
+3. Make it easier to run tests
+
+Any data the user provides will override these defaults which are stored here: [defaults](../defaults/defaults.yaml).
+
+## Logging
+This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted.
+
+```yaml
+logging:
+   level: "trace" #trace, debug, info, warning, error
+```
+
+## Additional
+1. If the test passes immediately without warning, try adding the `-count=1` or run `go clean -cache`. This will avoid previous results from interfering with the new test run.
+2. All of the tests utilize parallelism when running for more finite control of how things are run in parallel use the -p and -parallel flags.

--- a/validation/nodescaling/capipnp/rke2/scaling_test.go
+++ b/validation/nodescaling/capipnp/rke2/scaling_test.go
@@ -1,0 +1,112 @@
+//go:build validation || capi
+
+package rke2
+
+import (
+	"testing"
+
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/machinepools"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/nodescaling/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScalingCAPIPnPNodePools(t *testing.T) {
+	t.Parallel()
+
+	s := capipnp.Setup(t, defaults.RKE2)
+
+	nodeRolesEtcd := machinepools.NodeRoles{
+		Etcd:     true,
+		Quantity: 1,
+	}
+
+	nodeRolesControlPlane := machinepools.NodeRoles{
+		ControlPlane: true,
+		Quantity:     1,
+	}
+
+	nodeRolesWorker := machinepools.NodeRoles{
+		Worker:   true,
+		Quantity: 1,
+	}
+
+	tests := []struct {
+		name          string
+		nodeRoles     machinepools.NodeRoles
+		scaleQuantity int32
+		cluster       *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_RKE2_Scale_Control_Plane", nodeRolesControlPlane, 1, s.Cluster},
+		{"CAPI_PnP_RKE2_Scale_ETCD", nodeRolesEtcd, 1, s.Cluster},
+		{"CAPI_PnP_RKE2_Scale_Worker", nodeRolesWorker, 1, s.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", s.Cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(s.Client, s.Cluster.Name, s.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			tt.nodeRoles.Quantity = tt.scaleQuantity
+			logrus.Infof("Scaling up the node pool (%s)", tt.cluster.Name)
+			tt.cluster, err = machinepools.ScaleMachinePool(s.Client, tt.cluster, tt.nodeRoles)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", tt.cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(s.Client, tt.cluster.Name)
+			require.NoError(t, err)
+
+			tt.nodeRoles.Quantity = -tt.scaleQuantity
+			logrus.Infof("Scaling down the node pool (%s)", tt.cluster.Name)
+			_, err = machinepools.ScaleMachinePool(s.Client, tt.cluster, tt.nodeRoles)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", tt.cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(s.Client, tt.cluster.Name)
+			require.NoError(t, err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(s.Client, s.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/nodescaling/capipnp/rke2/schemas/hostbusters_schemas.yaml
+++ b/validation/nodescaling/capipnp/rke2/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,95 @@
+- suite: Go Automation/NodeScaling/CAPIPnP/RKE2
+  projects: [RRT, RM]
+  cases:
+  - description: Scales up/down the control plane node pools of an existing cluster
+    title: CAPI_PnP_RKE2_Scale_Control_Plane
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Scale up the control plane node pools by 1
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Scale down the control plane node pools by 1
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 4
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
+  - description: Scales up/down the etcd node pools of an existing cluster
+    title: CAPI_PnP_RKE2_Scale_ETCD
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Scale up the etcd node pools by 1
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Scale down the etcd node pools by 1
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 4
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters
+
+  - description: Scales up/down the worker node pools of an existing cluster
+    title: CAPI_PnP_RKE2_Scale_Worker
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Scale up the worker node pools by 1
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Scale down the worker node pools by 1
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 4
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/nodescaling/capipnp/setup.go
+++ b/validation/nodescaling/capipnp/setup.go
@@ -1,0 +1,171 @@
+package capipnp
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	extclusters "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/rbac"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type nodeScalingTest struct {
+	suite.Suite
+	Client             *rancher.Client
+	StandardUserClient *rancher.Client
+	Session            *session.Session
+	CattleConfig       map[string]any
+	ClusterConfig      *clusters.ClusterConfig
+	RancherConfig      *rancher.Config
+	CapiConfig         *capipnp.Config
+	Cluster            *v1.SteveAPIObject
+	ClusterManifest    []byte
+}
+
+func Setup(t *testing.T, clusterType string) *nodeScalingTest {
+	s := &nodeScalingTest{}
+
+	testSession := session.NewSession()
+	s.Session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	s.Client = client
+
+	localClusterID, err := extclusters.GetClusterIDByName(s.Client, extclusterapi.LocalCluster)
+	require.NoError(t, err)
+
+	localCluster, err := s.Client.Management.Cluster.ByID(localClusterID)
+	require.NoError(t, err)
+
+	_, standardUserClient, err := rbac.AddUserWithRoleToCluster(s.Client, rbac.StandardUser.String(), rbac.ClusterOwner.String(), localCluster, nil)
+	require.NoError(t, err)
+
+	s.StandardUserClient = standardUserClient
+
+	s.CattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
+
+	_, setupFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	capipnpDir := filepath.Dir(setupFile)
+	nodescalingDir := filepath.Dir(capipnpDir)
+	validationDir := filepath.Dir(nodescalingDir)
+	provisioningDir := filepath.Join(validationDir, "provisioning")
+
+	provisioningDefaults := config.LoadConfigFromFile(filepath.Join(provisioningDir, "defaults", "defaults.yaml"))
+	nodescalingDefaults := config.LoadConfigFromFile(filepath.Join(nodescalingDir, "defaults", "defaults.yaml"))
+	validationDefaults, err := defaults.DeepMerge(nodescalingDefaults, provisioningDefaults, true)
+	require.NoError(t, err)
+
+	s.CattleConfig, err = defaults.DeepMerge(s.CattleConfig, validationDefaults, true)
+	require.NoError(t, err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, s.CattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(t, err)
+
+	clusterConfig := new(clusters.ClusterConfig)
+	operations.LoadObjectFromMap(defaults.ClusterConfigKey, s.CattleConfig, clusterConfig)
+
+	s.ClusterConfig = clusterConfig
+
+	rancherConfig := new(rancher.Config)
+	operations.LoadObjectFromMap(defaults.RancherConfigKey, s.CattleConfig, rancherConfig)
+
+	s.RancherConfig = rancherConfig
+
+	capiConfig := new(capipnp.Config)
+	operations.LoadObjectFromMap(capipnp.ConfigurationFileKey, s.CattleConfig, capiConfig)
+
+	s.CapiConfig = capiConfig
+
+	providerManifestsPath := filepath.Join(provisioningDir, "resources", "capipnp", "providers", s.CapiConfig.Provider)
+	s.CapiConfig.ClusterYAML = filepath.Join(providerManifestsPath, clusterType+"-cluster.yaml")
+	providerManifest := filepath.Join(providerManifestsPath, "provider.yaml")
+	credentialsManifest := filepath.Join(providerManifestsPath, "creds.yaml")
+	identityManifest := filepath.Join(providerManifestsPath, "identity.yaml")
+
+	if s.RancherConfig.ClusterName == "" {
+		s.CattleConfig, err = defaults.SetK8sDefault(s.Client, clusterType, s.CattleConfig)
+		require.NoError(t, err)
+
+		resolvedK8sVersion, err := operations.GetValue([]string{defaults.ClusterConfigKey, defaults.K8SVersionKey}, s.CattleConfig)
+		require.NoError(t, err)
+
+		if resolvedK8sVersion != nil {
+			s.CapiConfig.KubernetesVersion, _ = resolvedK8sVersion.(string)
+		}
+
+		logrus.Debugf("Applying %s provider manifest...", s.CapiConfig.Provider)
+		err = capipnp.CreateProviderManifestFromPath(s.Client, s.CapiConfig, providerManifest)
+		require.NoError(t, err)
+
+		logrus.Debugf("Applying credentials manifest...")
+		err = capipnp.CreateProviderManifestFromPath(s.Client, s.CapiConfig, credentialsManifest)
+		require.NoError(t, err)
+
+		logrus.Debugf("Waiting for previous manifests to be active...")
+		err = capipnp.WaitProviderPrerequisitesReady(s.Client, s.CapiConfig)
+		require.NoError(t, err)
+
+		logrus.Debugf("Applying cluster static identity manifest...")
+		err = capipnp.CreateProviderManifestFromPath(s.Client, s.CapiConfig, identityManifest)
+		require.NoError(t, err)
+
+		clusterName := namegen.AppendRandomString(s.CapiConfig.ClusterNamePrefix)
+
+		s.ClusterManifest, err = capipnp.CreateClusterManifestFromDefaults(s.CapiConfig, s.ClusterConfig.MachinePools, clusterName)
+		require.NoError(t, err)
+
+		logrus.Infof("Provisioning %s cluster", clusterType)
+		err = capipnp.CreateCAPICluster(s.StandardUserClient, clusterName, s.ClusterManifest)
+		require.NoError(t, err)
+
+		cluster, err := clusters.GetClusterByName(s.Client, clusterName)
+		require.NoError(t, err)
+
+		err = provisioning.VerifyClusterReady(s.Client, cluster)
+		require.NoError(t, err)
+
+		err = deployment.VerifyClusterDeployments(s.Client, cluster)
+		require.NoError(t, err)
+
+		err = pods.VerifyClusterPods(s.Client, cluster)
+		require.NoError(t, err)
+
+		s.Cluster, err = s.Client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + cluster.Name)
+		require.NoError(t, err)
+	} else {
+		s.ClusterManifest, err = capipnp.CreateClusterManifestFromDefaults(s.CapiConfig, s.ClusterConfig.MachinePools, s.RancherConfig.ClusterName)
+		require.NoError(t, err)
+
+		logrus.Infof("Using existing cluster %s", s.RancherConfig.ClusterName)
+		s.Cluster, err = s.Client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + s.RancherConfig.ClusterName)
+		require.NoError(t, err)
+	}
+
+	return s
+}

--- a/validation/snapshot/capipnp/k3s/README.md
+++ b/validation/snapshot/capipnp/k3s/README.md
@@ -1,0 +1,93 @@
+# K3S Snapshot Configs
+
+## Table of Contents
+1. [Tests Cases](#Test-Cases)
+2. [Configurations](#Configurations)
+3. [Configuration Defaults](#defaults)
+4. [Logging Levels](#Logging)
+5. [Back to general snapshot](../README.md)
+
+## Test Cases
+All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
+
+### Snapshot Restore Etcd Test
+
+#### Description:
+The snapshot restore test validates that snapshots can be created and restored without any failures or longterm disruption to workloads.
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `CAPI_PnP_K3S_Restore_ETCD`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/capipnp/k3s --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestCAPIPnPSnapshotRestoreEtcd -timeout=1h -v`
+
+## Configurations
+
+### Existing cluster:
+```yaml
+rancher:
+  host: <rancher-fqdn>
+  adminToken: <rancher-token>
+  clusterName: "<existing cluster name>"
+  cleanup: true
+  insecure: true
+```
+
+### Provisioning cluster
+This test will create a cluster if one is not provided, see the section on having a defined machine pool in this reference README: [k3s provisioning](../../../provisioning/k3s/README.md). Additionally, you will need this section for CAPI configurations:
+
+```yaml
+capipnp:
+  awsCredentials:
+    accessKeyID: "<required>"
+    secretAccessKey: "<required>"
+  awsTemplate:
+    ami: "<required>"
+    controlPlaneSecurityGroup: "sg-<required>"
+    nodeSecurityGroup: "sg-<required>"
+    region: "us-west-1"
+    sshKeyName: "<required>"
+    subnetId: "subnet-<required>"
+    vpcId: "vpc-<required>"
+  vsphereCredentials:
+    username: "<required>"
+    password: "<required>"
+  vsphereTemplate:
+    datacenter: "<required>"
+    datastore: "<required>"
+    diskGiB: 40
+    folder: "<required>"
+    host: "<required>"
+    memoryMiB: 8192
+    networkName: "<required>"
+    numCPUs: 4
+    resourcePool: "<required>"
+    template: "<required>"
+  clusterNamePrefix: "<required>"
+  provider: "<required>"    # capa or capv
+```
+
+## Defaults
+This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to: 
+1. Reduce the number of fields the user needs to provide in the cattle_config file. 
+2. Reduce the amount of yaml data that needs to be stored in our pipelines.
+3. Make it easier to run tests
+
+Any data the user provides will override these defaults which are stored here: [defaults](../defaults/defaults.yaml). 
+
+## Logging
+This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 
+
+```yaml
+logging:
+   level: "trace" #trace debug, info, warning, error
+```
+
+## Additional
+1. If the tests passes immediately without warning, try adding the `-count=1` or run `go clean -cache`. This will avoid previous results from interfering with the new test run.
+2. All of the tests utilize parallelism when running for more finite control of how things are run in parallel use the -p and -parallel.

--- a/validation/snapshot/capipnp/k3s/schemas/hostbusters_schemas.yaml
+++ b/validation/snapshot/capipnp/k3s/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,28 @@
+- suite: Go Automation/Snapshot/CAPIPnP/K3S
+  projects: [RRT, RM]
+  cases:
+  - description: Creates and restores a snapshot on an existing cluster
+    title: CAPI_PnP_K3S_Restore_ETCD
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Create a snapshot
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Restore to the snapshot
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/snapshot/capipnp/k3s/snapshot_restore_etcd_test.go
+++ b/validation/snapshot/capipnp/k3s/snapshot_restore_etcd_test.go
@@ -1,0 +1,86 @@
+//go:build validation || capi
+
+package k3s
+
+import (
+	"testing"
+
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/etcdsnapshot"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/snapshot"
+	"github.com/rancher/tests/validation/snapshot/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCAPIPnPSnapshotRestoreEtcd(t *testing.T) {
+	t.Parallel()
+
+	s := capipnp.Setup(t, defaults.K3S)
+
+	snapshotRestoreNone := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        1,
+	}
+
+	tests := []struct {
+		name         string
+		etcdSnapshot *etcdsnapshot.Config
+		cluster      *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_K3S_Restore_ETCD", snapshotRestoreNone, s.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", s.Cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(s.Client, s.Cluster.Name, s.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			logrus.Infof("Creating snapshot on cluster %s", tt.cluster.Name)
+			clusterObject, snapshotName, err := etcdsnapshot.CreateAndValidateSnapshotV2Prov(s.Client, tt.cluster.Name, tt.cluster.ID, tt.etcdSnapshot)
+			require.NoError(t, err)
+
+			clusterStatus := &provv1.ClusterStatus{}
+			err = v1.ConvertToK8sType(tt.cluster.Status, clusterStatus)
+			require.NoError(t, err)
+
+			err = snapshot.CreateSnapshotDeployment(s.Client, s.WorkloadClient, clusterStatus.ClusterName, tt.cluster.Name, s.WorkloadsConfig)
+			require.NoError(t, err)
+
+			logrus.Infof("Restoring snapshot %s on cluster %s", snapshotName, tt.cluster.Name)
+			_, err = etcdsnapshot.RestoreAndValidateSnapshotV2Prov(s.Client, snapshotName, tt.etcdSnapshot, clusterObject, tt.cluster.ID)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(s.Client, tt.cluster)
+			require.NoError(t, err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(s.Client, s.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/snapshot/capipnp/rke2/README.md
+++ b/validation/snapshot/capipnp/rke2/README.md
@@ -1,0 +1,93 @@
+# RKE2 Snapshot Configs
+
+## Table of Contents
+1. [Tests Cases](#Test-Cases)
+2. [Configurations](#Configurations)
+3. [Configuration Defaults](#defaults)
+4. [Logging Levels](#Logging)
+5. [Back to general snapshot](../README.md)
+
+## Test Cases
+All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
+
+### Snapshot Restore Etcd Test
+
+#### Description:
+The snapshot restore test validates that snapshots can be created and restored without any failures or longterm disruption to workloads.
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `CAPI_PnP_RKE2_Restore_ETCD`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/snapshot/capipnp/rke2 --junitfile results.xml --jsonfile results.json -- -tags=validation -run TestCAPIPnPSnapshotRestoreEtcd -timeout=1h -v`
+
+## Configurations
+
+### Existing cluster:
+```yaml
+rancher:
+  host: <rancher-fqdn>
+  adminToken: <rancher-token>
+  clusterName: "<existing cluster name>"
+  cleanup: true
+  insecure: true
+```
+
+### Provisioning cluster
+This test will create a cluster if one is not provided, see the section on having a defined machine pool in this reference README: [rke2 provisioning](../../../provisioning/rke2/README.md). Additionally, you will need this section for CAPI configurations:
+
+```yaml
+capipnp:
+  awsCredentials:
+    accessKeyID: "<required>"
+    secretAccessKey: "<required>"
+  awsTemplate:
+    ami: "<required>"
+    controlPlaneSecurityGroup: "sg-<required>"
+    nodeSecurityGroup: "sg-<required>"
+    region: "us-west-1"
+    sshKeyName: "<required>"
+    subnetId: "subnet-<required>"
+    vpcId: "vpc-<required>"
+  vsphereCredentials:
+    username: "<required>"
+    password: "<required>"
+  vsphereTemplate:
+    datacenter: "<required>"
+    datastore: "<required>"
+    diskGiB: 40
+    folder: "<required>"
+    host: "<required>"
+    memoryMiB: 8192
+    networkName: "<required>"
+    numCPUs: 4
+    resourcePool: "<required>"
+    template: "<required>"
+  clusterNamePrefix: "<required>"
+  provider: "<required>"    # capa or capv
+```
+
+## Defaults
+This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to: 
+1. Reduce the number of fields the user needs to provide in the cattle_config file. 
+2. Reduce the amount of yaml data that needs to be stored in our pipelines.
+3. Make it easier to run tests
+
+Any data the user provides will override these defaults which are stored here: [defaults](../defaults/defaults.yaml). 
+
+## Logging
+This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 
+
+```yaml
+logging:
+   level: "trace" #trace debug, info, warning, error
+```
+
+## Additional
+1. If the tests passes immediately without warning, try adding the `-count=1` or run `go clean -cache`. This will avoid previous results from interfering with the new test run.
+2. All of the tests utilize parallelism when running for more finite control of how things are run in parallel use the -p and -parallel.

--- a/validation/snapshot/capipnp/rke2/schemas/hostbusters_schemas.yaml
+++ b/validation/snapshot/capipnp/rke2/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,28 @@
+- suite: Go Automation/Snapshot/CAPIPnP/RKE2
+  projects: [RRT, RM]
+  cases:
+  - description: Creates and restores a snapshot on an existing cluster
+    title: CAPI_PnP_RKE2_Restore_ETCD
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Create a snapshot
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Restore to the snapshot
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/snapshot/capipnp/rke2/snapshot_restore_etcd_test.go
+++ b/validation/snapshot/capipnp/rke2/snapshot_restore_etcd_test.go
@@ -1,0 +1,86 @@
+//go:build validation || capi
+
+package k3s
+
+import (
+	"testing"
+
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/etcdsnapshot"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/snapshot"
+	"github.com/rancher/tests/validation/snapshot/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCAPIPnPSnapshotRestoreEtcd(t *testing.T) {
+	t.Parallel()
+
+	s := capipnp.Setup(t, defaults.RKE2)
+
+	snapshotRestoreNone := &etcdsnapshot.Config{
+		UpgradeKubernetesVersion: "",
+		SnapshotRestore:          "none",
+		RecurringRestores:        1,
+	}
+
+	tests := []struct {
+		name         string
+		etcdSnapshot *etcdsnapshot.Config
+		cluster      *v1.SteveAPIObject
+	}{
+		{"CAPI_PnP_RKE2_Restore_ETCD", snapshotRestoreNone, s.Cluster},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", s.Cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(s.Client, s.Cluster.Name, s.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			logrus.Infof("Creating snapshot on cluster %s", tt.cluster.Name)
+			clusterObject, snapshotName, err := etcdsnapshot.CreateAndValidateSnapshotV2Prov(s.Client, tt.cluster.Name, tt.cluster.ID, tt.etcdSnapshot)
+			require.NoError(t, err)
+
+			clusterStatus := &provv1.ClusterStatus{}
+			err = v1.ConvertToK8sType(tt.cluster.Status, clusterStatus)
+			require.NoError(t, err)
+
+			err = snapshot.CreateSnapshotDeployment(s.Client, s.WorkloadClient, clusterStatus.ClusterName, tt.cluster.Name, s.WorkloadsConfig)
+			require.NoError(t, err)
+
+			logrus.Infof("Restoring snapshot %s on cluster %s", snapshotName, tt.cluster.Name)
+			_, err = etcdsnapshot.RestoreAndValidateSnapshotV2Prov(s.Client, snapshotName, tt.etcdSnapshot, clusterObject, tt.cluster.ID)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", tt.cluster.Name)
+			err = provisioning.VerifyClusterReady(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", tt.cluster.Name)
+			err = deployment.VerifyClusterDeployments(s.Client, tt.cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", tt.cluster.Name)
+			err = pods.VerifyClusterPods(s.Client, tt.cluster)
+			require.NoError(t, err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(s.Client, s.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/snapshot/capipnp/setup.go
+++ b/validation/snapshot/capipnp/setup.go
@@ -1,0 +1,187 @@
+package capipnp
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	extclusters "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/rbac"
+	"github.com/rancher/tests/actions/workloads"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type snapshotTest struct {
+	suite.Suite
+	Client             *rancher.Client
+	StandardUserClient *rancher.Client
+	WorkloadClient     *v1.Client
+	Session            *session.Session
+	CattleConfig       map[string]any
+	ClusterConfig      *clusters.ClusterConfig
+	RancherConfig      *rancher.Config
+	CapiConfig         *capipnp.Config
+	WorkloadsConfig    *workloads.Workloads
+	Cluster            *v1.SteveAPIObject
+	ClusterManifest    []byte
+}
+
+func Setup(t *testing.T, clusterType string) *snapshotTest {
+	s := &snapshotTest{}
+
+	testSession := session.NewSession()
+	s.Session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	s.Client = client
+
+	localClusterID, err := extclusters.GetClusterIDByName(s.Client, extclusterapi.LocalCluster)
+	require.NoError(t, err)
+
+	localCluster, err := s.Client.Management.Cluster.ByID(localClusterID)
+	require.NoError(t, err)
+
+	_, standardUserClient, err := rbac.AddUserWithRoleToCluster(s.Client, rbac.StandardUser.String(), rbac.ClusterOwner.String(), localCluster, nil)
+	require.NoError(t, err)
+
+	s.StandardUserClient = standardUserClient
+
+	s.CattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
+
+	_, setupFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	capipnpDir := filepath.Dir(setupFile)
+	snapshotDir := filepath.Dir(capipnpDir)
+	validationDir := filepath.Dir(snapshotDir)
+	provisioningDir := filepath.Join(validationDir, "provisioning")
+
+	provisioningDefaults := config.LoadConfigFromFile(filepath.Join(provisioningDir, "defaults", "defaults.yaml"))
+	deletingDefaults := config.LoadConfigFromFile(filepath.Join(snapshotDir, "defaults", "defaults.yaml"))
+	validationDefaults, err := defaults.DeepMerge(deletingDefaults, provisioningDefaults, true)
+	require.NoError(t, err)
+
+	s.CattleConfig, err = defaults.DeepMerge(s.CattleConfig, validationDefaults, true)
+	require.NoError(t, err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, s.CattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(t, err)
+
+	clusterConfig := new(clusters.ClusterConfig)
+	operations.LoadObjectFromMap(defaults.ClusterConfigKey, s.CattleConfig, clusterConfig)
+
+	s.ClusterConfig = clusterConfig
+
+	rancherConfig := new(rancher.Config)
+	operations.LoadObjectFromMap(defaults.RancherConfigKey, s.CattleConfig, rancherConfig)
+
+	s.RancherConfig = rancherConfig
+
+	capiConfig := new(capipnp.Config)
+	operations.LoadObjectFromMap(capipnp.ConfigurationFileKey, s.CattleConfig, capiConfig)
+
+	s.CapiConfig = capiConfig
+
+	workloadConfigs := new(workloads.Workloads)
+	operations.LoadObjectFromMap(workloads.WorkloadsConfigurationFileKey, s.CattleConfig, workloadConfigs)
+
+	s.WorkloadsConfig = workloadConfigs
+
+	providerManifestsPath := filepath.Join(provisioningDir, "resources", "capipnp", "providers", s.CapiConfig.Provider)
+	s.CapiConfig.ClusterYAML = filepath.Join(providerManifestsPath, clusterType+"-cluster.yaml")
+	providerManifest := filepath.Join(providerManifestsPath, "provider.yaml")
+	credentialsManifest := filepath.Join(providerManifestsPath, "creds.yaml")
+	identityManifest := filepath.Join(providerManifestsPath, "identity.yaml")
+
+	if s.RancherConfig.ClusterName == "" {
+		s.CattleConfig, err = defaults.SetK8sDefault(s.Client, clusterType, s.CattleConfig)
+		require.NoError(t, err)
+
+		resolvedK8sVersion, err := operations.GetValue([]string{defaults.ClusterConfigKey, defaults.K8SVersionKey}, s.CattleConfig)
+		require.NoError(t, err)
+
+		if resolvedK8sVersion != nil {
+			s.CapiConfig.KubernetesVersion, _ = resolvedK8sVersion.(string)
+		}
+
+		logrus.Debugf("Applying %s provider manifest...", s.CapiConfig.Provider)
+		err = capipnp.CreateProviderManifestFromPath(s.Client, s.CapiConfig, providerManifest)
+		require.NoError(t, err)
+
+		logrus.Debugf("Applying credentials manifest...")
+		err = capipnp.CreateProviderManifestFromPath(s.Client, s.CapiConfig, credentialsManifest)
+		require.NoError(t, err)
+
+		logrus.Debugf("Waiting for previous manifests to be active...")
+		err = capipnp.WaitProviderPrerequisitesReady(s.Client, s.CapiConfig)
+		require.NoError(t, err)
+
+		logrus.Debugf("Applying cluster static identity manifest...")
+		err = capipnp.CreateProviderManifestFromPath(s.Client, s.CapiConfig, identityManifest)
+		require.NoError(t, err)
+
+		clusterName := namegen.AppendRandomString(s.CapiConfig.ClusterNamePrefix)
+
+		s.ClusterManifest, err = capipnp.CreateClusterManifestFromDefaults(s.CapiConfig, s.ClusterConfig.MachinePools, clusterName)
+		require.NoError(t, err)
+
+		logrus.Infof("Provisioning %s cluster", clusterType)
+		err = capipnp.CreateCAPICluster(s.StandardUserClient, clusterName, s.ClusterManifest)
+		require.NoError(t, err)
+
+		cluster, err := clusters.GetClusterByName(s.Client, clusterName)
+		require.NoError(t, err)
+
+		err = provisioning.VerifyClusterReady(s.Client, cluster)
+		require.NoError(t, err)
+
+		err = deployment.VerifyClusterDeployments(s.Client, cluster)
+		require.NoError(t, err)
+
+		err = pods.VerifyClusterPods(s.Client, cluster)
+		require.NoError(t, err)
+
+		s.Cluster, err = s.Client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + cluster.Name)
+		require.NoError(t, err)
+	} else {
+		s.ClusterManifest, err = capipnp.CreateClusterManifestFromDefaults(s.CapiConfig, s.ClusterConfig.MachinePools, s.RancherConfig.ClusterName)
+		require.NoError(t, err)
+
+		logrus.Infof("Using existing cluster %s", s.RancherConfig.ClusterName)
+		s.Cluster, err = s.Client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + s.RancherConfig.ClusterName)
+		require.NoError(t, err)
+	}
+
+	clusterStatus := &provv1.ClusterStatus{}
+	err = v1.ConvertToK8sType(s.Cluster.Status, clusterStatus)
+	require.NoError(t, err)
+
+	s.WorkloadClient, err = s.Client.Steve.ProxyDownstream(clusterStatus.ClusterName)
+	require.NoError(t, err)
+
+	return s
+}

--- a/validation/upgrade/README.md
+++ b/validation/upgrade/README.md
@@ -78,7 +78,37 @@ amazonec2Config:
   usePrivateAddress: false
   volumeType: ""
   vpcId: ""
-  zone: "a"           
+  zone: "a"
+
+# Only required if running a CAPI PnP test
+capipnp:
+  awsCredentials:
+    accessKeyID: "<required>"
+    secretAccessKey: "<required>"
+  awsTemplate:
+    ami: "<required>"
+    controlPlaneSecurityGroup: "sg-<required>"
+    nodeSecurityGroup: "sg-<required>"
+    region: "us-west-1"
+    sshKeyName: "<required>"
+    subnetId: "subnet-<required>"
+    vpcId: "vpc-<required>"
+  vsphereCredentials:
+    username: "<required>"
+    password: "<required>"
+  vsphereTemplate:
+    datacenter: "<required>"
+    datastore: "<required>"
+    diskGiB: 40
+    folder: "<required>"
+    host: "<required>"
+    memoryMiB: 8192
+    networkName: "<required>"
+    numCPUs: 4
+    resourcePool: "<required>"
+    template: "<required>"
+  clusterNamePrefix: "<required>"
+  provider: "<required>"    # capa or capv
 ```
 Note: To see the `provisioningInput` in further detail, please review over the [Provisioning README](../provisioning/README.md).
 See below how to run the test:
@@ -88,6 +118,10 @@ See below how to run the test:
 #### RKE2/K3S
 `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/rke2 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestUpgradeKubernetes"` \
 `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/k3s --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestUpgradeKubernetes"`
+
+#### CAPI PnP
+`gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/capipnp/rke2 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestUpgradeCAPIPnPKubernetes"` \
+`gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/capipnp/k3s --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestUpgradeCAPIPnPKubernetes"`
 
 #### Windows
 `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/upgrade/rke2 --junitfile results.xml -- -timeout=60m -tags=validation -v -run "TestUpgradeWindowsKubernetes"`

--- a/validation/upgrade/capipnp/k3s/kubernetes_test.go
+++ b/validation/upgrade/capipnp/k3s/kubernetes_test.go
@@ -1,0 +1,82 @@
+//go:build validation || capi
+
+package k3s
+
+import (
+	"testing"
+
+	upstream "github.com/qase-tms/qase-go/qase-api-client"
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/upgrade"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/upgrade/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeCAPIPnPKubernetes(t *testing.T) {
+	t.Parallel()
+
+	u := capipnp.Setup(t, defaults.K3S)
+
+	tests := []struct {
+		name          string
+		cluster       *v1.SteveAPIObject
+		clusterConfig *clusters.ClusterConfig
+	}{
+		{"Upgrading_CAPI_PnP_K3S_cluster", u.Cluster, u.ClusterConfig},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", tt.cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(u.Client, tt.cluster.Name, u.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		latestVersion, err := kubernetesversions.Default(u.Client, defaults.K3S, nil)
+		require.NoError(t, err)
+
+		t.Run(tt.name, func(t *testing.T) {
+			logrus.Infof("Upgrading cluster (%s) to the latest Kubernetes version", tt.cluster.Name)
+			cluster, err := upgrade.UpgradeCluster(t, u.Client, tt.cluster, latestVersion[0])
+			require.NoError(t, err)
+
+			updatedClusterSpec := &provv1.ClusterSpec{}
+			err = v1.ConvertToK8sType(cluster.Spec, updatedClusterSpec)
+			require.NoError(t, err)
+			require.Equal(t, latestVersion[0], updatedClusterSpec.KubernetesVersion)
+
+			logrus.Infof("Cluster has been upgraded to: %s", updatedClusterSpec.KubernetesVersion)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			err = provisioning.VerifyClusterReady(u.Client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(u.Client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			err = pods.VerifyClusterPods(u.Client, cluster)
+			require.NoError(t, err)
+		})
+
+		upgradedK8sParam := upstream.TestCaseParameterCreate{ParameterSingle: &upstream.ParameterSingle{Title: "UpgradedK8sVersion", Values: []string{latestVersion[0]}}}
+		params := provisioning.GetProvisioningSchemaParams(u.Client, u.CattleConfig)
+		params = append(params, upgradedK8sParam)
+
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/upgrade/capipnp/k3s/schemas/hostbusters_schemas.yaml
+++ b/validation/upgrade/capipnp/k3s/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,23 @@
+- suite: Go Automation/Upgrade/CAPIPnP/K3S
+  projects: [RRT, RM]
+  cases:
+  - description: Upgrades an existing K3S cluster to the latest Kubernetes version
+    title: Upgrading_CAPI_PnP_K3S_cluster
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Upgrade the existing K3S cluster to the latest Kubernetes version
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster readiness, deployments, and pods
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/upgrade/capipnp/rke2/kubernetes_test.go
+++ b/validation/upgrade/capipnp/rke2/kubernetes_test.go
@@ -1,0 +1,82 @@
+//go:build validation || capi
+
+package rke2
+
+import (
+	"testing"
+
+	upstream "github.com/qase-tms/qase-go/qase-api-client"
+	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	capi "github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/upgrade"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/rancher/tests/validation/upgrade/capipnp"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeCAPIPnPKubernetes(t *testing.T) {
+	t.Parallel()
+
+	u := capipnp.Setup(t, defaults.RKE2)
+
+	tests := []struct {
+		name          string
+		cluster       *v1.SteveAPIObject
+		clusterConfig *clusters.ClusterConfig
+	}{
+		{"Upgrading_CAPI_PnP_RKE2_cluster", u.Cluster, u.ClusterConfig},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Cleaning up cluster (%s)", tt.cluster.Name)
+			cleanupErr := capi.DeleteCAPICluster(u.Client, tt.cluster.Name, u.ClusterManifest)
+			require.NoError(t, cleanupErr)
+		})
+
+		latestVersion, err := kubernetesversions.Default(u.Client, defaults.RKE2, nil)
+		require.NoError(t, err)
+
+		t.Run(tt.name, func(t *testing.T) {
+			logrus.Infof("Upgrading cluster (%s) to the latest Kubernetes version", tt.cluster.Name)
+			cluster, err := upgrade.UpgradeCluster(t, u.Client, tt.cluster, latestVersion[0])
+			require.NoError(t, err)
+
+			updatedClusterSpec := &provv1.ClusterSpec{}
+			err = v1.ConvertToK8sType(cluster.Spec, updatedClusterSpec)
+			require.NoError(t, err)
+			require.Equal(t, latestVersion[0], updatedClusterSpec.KubernetesVersion)
+
+			logrus.Infof("Cluster has been upgraded to: %s", updatedClusterSpec.KubernetesVersion)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			err = provisioning.VerifyClusterReady(u.Client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(u.Client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			err = pods.VerifyClusterPods(u.Client, cluster)
+			require.NoError(t, err)
+		})
+
+		upgradedK8sParam := upstream.TestCaseParameterCreate{ParameterSingle: &upstream.ParameterSingle{Title: "UpgradedK8sVersion", Values: []string{latestVersion[0]}}}
+		params := provisioning.GetProvisioningSchemaParams(u.Client, u.CattleConfig)
+		params = append(params, upgradedK8sParam)
+
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/upgrade/capipnp/rke2/schemas/hostbusters_schemas.yaml
+++ b/validation/upgrade/capipnp/rke2/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,23 @@
+- suite: Go Automation/Upgrade/CAPIPnP/RKE2
+  projects: [RRT, RM]
+  cases:
+  - description: Upgrades an existing RKE2 cluster to the latest Kubernetes version
+    title: Upgrading_CAPI_PnP_RKE2_cluster
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Upgrade the existing RKE2 cluster to the latest Kubernetes version
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster readiness, deployments, and pods
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/upgrade/capipnp/setup.go
+++ b/validation/upgrade/capipnp/setup.go
@@ -1,0 +1,202 @@
+package capipnp
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	extclusters "github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
+	extclusterapi "github.com/rancher/shepherd/extensions/kubeapi/cluster"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/capipnp"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/logging"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/rbac"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type upgradeTest struct {
+	suite.Suite
+	Client             *rancher.Client
+	StandardUserClient *rancher.Client
+	Session            *session.Session
+	CattleConfig       map[string]any
+	ClusterConfig      *clusters.ClusterConfig
+	RancherConfig      *rancher.Config
+	CapiConfig         *capipnp.Config
+	Cluster            *v1.SteveAPIObject
+	ClusterManifest    []byte
+}
+
+func Setup(t *testing.T, clusterType string) *upgradeTest {
+	u := &upgradeTest{}
+
+	testSession := session.NewSession()
+	u.Session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	u.Client = client
+
+	localClusterID, err := extclusters.GetClusterIDByName(u.Client, extclusterapi.LocalCluster)
+	require.NoError(t, err)
+
+	localCluster, err := u.Client.Management.Cluster.ByID(localClusterID)
+	require.NoError(t, err)
+
+	_, standardUserClient, err := rbac.AddUserWithRoleToCluster(u.Client, rbac.StandardUser.String(), rbac.ClusterOwner.String(), localCluster, nil)
+	require.NoError(t, err)
+
+	u.StandardUserClient = standardUserClient
+
+	u.CattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
+
+	_, setupFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	capipnpDir := filepath.Dir(setupFile)
+	nodescalingDir := filepath.Dir(capipnpDir)
+	validationDir := filepath.Dir(nodescalingDir)
+	provisioningDir := filepath.Join(validationDir, "provisioning")
+
+	provisioningDefaults := config.LoadConfigFromFile(filepath.Join(provisioningDir, "defaults", "defaults.yaml"))
+	nodescalingDefaults := config.LoadConfigFromFile(filepath.Join(nodescalingDir, "defaults", "defaults.yaml"))
+	validationDefaults, err := defaults.DeepMerge(nodescalingDefaults, provisioningDefaults, true)
+	require.NoError(t, err)
+
+	u.CattleConfig, err = defaults.DeepMerge(u.CattleConfig, validationDefaults, true)
+	require.NoError(t, err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, u.CattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(t, err)
+
+	clusterConfig := new(clusters.ClusterConfig)
+	operations.LoadObjectFromMap(defaults.ClusterConfigKey, u.CattleConfig, clusterConfig)
+
+	u.ClusterConfig = clusterConfig
+
+	rancherConfig := new(rancher.Config)
+	operations.LoadObjectFromMap(defaults.RancherConfigKey, u.CattleConfig, rancherConfig)
+
+	u.RancherConfig = rancherConfig
+
+	capiConfig := new(capipnp.Config)
+	operations.LoadObjectFromMap(capipnp.ConfigurationFileKey, u.CattleConfig, capiConfig)
+
+	u.CapiConfig = capiConfig
+
+	providerManifestsPath := filepath.Join(provisioningDir, "resources", "capipnp", "providers", u.CapiConfig.Provider)
+	u.CapiConfig.ClusterYAML = filepath.Join(providerManifestsPath, clusterType+"-cluster.yaml")
+	providerManifest := filepath.Join(providerManifestsPath, "provider.yaml")
+	credentialsManifest := filepath.Join(providerManifestsPath, "creds.yaml")
+	identityManifest := filepath.Join(providerManifestsPath, "identity.yaml")
+
+	if u.RancherConfig.ClusterName == "" {
+		u.CattleConfig, err = setSecondHighestK8sDefault(u.Client, clusterType, u.CattleConfig)
+		require.NoError(t, err)
+
+		resolvedK8sVersion, err := operations.GetValue([]string{defaults.ClusterConfigKey, defaults.K8SVersionKey}, u.CattleConfig)
+		require.NoError(t, err)
+
+		if resolvedK8sVersion != nil {
+			u.CapiConfig.KubernetesVersion, _ = resolvedK8sVersion.(string)
+		}
+
+		logrus.Debugf("Applying %s provider manifest...", u.CapiConfig.Provider)
+		err = capipnp.CreateProviderManifestFromPath(u.Client, u.CapiConfig, providerManifest)
+		require.NoError(t, err)
+
+		logrus.Debugf("Applying credentials manifest...")
+		err = capipnp.CreateProviderManifestFromPath(u.Client, u.CapiConfig, credentialsManifest)
+		require.NoError(t, err)
+
+		logrus.Debugf("Waiting for previous manifests to be active...")
+		err = capipnp.WaitProviderPrerequisitesReady(u.Client, u.CapiConfig)
+		require.NoError(t, err)
+
+		logrus.Debugf("Applying cluster static identity manifest...")
+		err = capipnp.CreateProviderManifestFromPath(u.Client, u.CapiConfig, identityManifest)
+		require.NoError(t, err)
+
+		clusterName := namegen.AppendRandomString(u.CapiConfig.ClusterNamePrefix)
+
+		u.ClusterManifest, err = capipnp.CreateClusterManifestFromDefaults(u.CapiConfig, u.ClusterConfig.MachinePools, clusterName)
+		require.NoError(t, err)
+
+		logrus.Infof("Provisioning %s cluster", clusterType)
+		err = capipnp.CreateCAPICluster(u.StandardUserClient, clusterName, u.ClusterManifest)
+		require.NoError(t, err)
+
+		cluster, err := clusters.GetClusterByName(u.Client, clusterName)
+		require.NoError(t, err)
+
+		err = provisioning.VerifyClusterReady(u.Client, cluster)
+		require.NoError(t, err)
+
+		err = deployment.VerifyClusterDeployments(u.Client, cluster)
+		require.NoError(t, err)
+
+		err = pods.VerifyClusterPods(u.Client, cluster)
+		require.NoError(t, err)
+
+		u.Cluster, err = u.Client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + cluster.Name)
+		require.NoError(t, err)
+	} else {
+		u.ClusterManifest, err = capipnp.CreateClusterManifestFromDefaults(u.CapiConfig, u.ClusterConfig.MachinePools, u.RancherConfig.ClusterName)
+		require.NoError(t, err)
+
+		logrus.Infof("Using existing cluster %s", u.RancherConfig.ClusterName)
+		u.Cluster, err = u.Client.Steve.SteveType(stevetypes.Provisioning).ByID("fleet-default/" + u.RancherConfig.ClusterName)
+		require.NoError(t, err)
+	}
+
+	return u
+}
+
+func setSecondHighestK8sDefault(client *rancher.Client, clusterType string, cattleConfig map[string]any) (map[string]any, error) {
+	if clusterConfig, ok := cattleConfig[defaults.ClusterConfigKey].(map[string]any); ok {
+		if version, exists := clusterConfig[defaults.K8SVersionKey]; exists && version != "" {
+			return cattleConfig, nil
+		}
+	}
+
+	var versions []string
+	var err error
+
+	switch clusterType {
+	case extclusters.RKE2ClusterType.String():
+		versions, err = kubernetesversions.ListRKE2AllVersions(client)
+	case extclusters.K3SClusterType.String():
+		versions, err = kubernetesversions.ListK3SAllVersions(client)
+	default:
+		versions, err = kubernetesversions.Default(client, clusterType, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if len(versions) < 2 {
+		return nil, errors.New("error: expected at least two Kubernetes versions")
+	}
+
+	return operations.ReplaceValue([]string{defaults.ClusterConfigKey, defaults.K8SVersionKey}, versions[1], cattleConfig)
+}


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow for CAPI PnP day-2 operations.
## What Changed
- Added a new GitHub Actions workflow
- Enabled automation for CAPI PnP day-2 operational tasks