### PR TITLE
Update rancher/shepherd commit version in go.mod and go.sum files

### DIFF
--- a/actions/go.mod
+++ b/actions/go.mod
@@ -60,7 +60,7 @@ replace (
 require (
 	github.com/qase-tms/qase-go/qase-api-client v1.2.10
 	github.com/rancher/rancher/pkg/apis v0.0.0
-	github.com/rancher/shepherd v0.0.0-20260803191617-6ad1050e7ffe
+	github.com/rancher/shepherd v0.0.0-20260804191050-69556e75d7d6
 	github.com/rancher/tfp-automation v0.0.0-20260724212646-b319279117cc
 )
 

--- a/actions/go.sum
+++ b/actions/go.sum
@@ -273,8 +273,8 @@ github.com/rancher/rancher v0.0.0-20260527150105-ae26ccbc3fed h1:G66Ag8VZXlA6Kiu
 github.com/rancher/rancher v0.0.0-20260527150105-ae26ccbc3fed/go.mod h1:wn9b239FRsjEulPTy5U1qTgT9vusgIc8Sxq0UJRdvhA=
 github.com/rancher/rancher/pkg/apis v0.0.0-20260527150105-ae26ccbc3fed h1:HoeCYnxcvP+p020CvCyNaJSwzH5I/nsQ6uRcbDbB17E=
 github.com/rancher/rancher/pkg/apis v0.0.0-20260527150105-ae26ccbc3fed/go.mod h1:TtM3SQiHWml7okiEMRndWKt1knQ/DeQC60Bzt6OBmrg=
-github.com/rancher/shepherd v0.0.0-20260803191617-6ad1050e7ffe h1:hR6t1EJoCOMPKOnFplQgnXImuCw+dsjDHeCQdKNvo1E=
-github.com/rancher/shepherd v0.0.0-20260803191617-6ad1050e7ffe/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
+github.com/rancher/shepherd v0.0.0-20260804191050-69556e75d7d6 h1:b4Wo+0EqRiNUi+waFc85Ro1LoisKW29FAjrdj4Gh7Jg=
+github.com/rancher/shepherd v0.0.0-20260804191050-69556e75d7d6/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8/go.mod h1:xDDFkXVPcCf+S6wQoIDwgIijQHcIaVdN0eQRG2GcFd4=
 github.com/rancher/tfp-automation v0.0.0-20260724212646-b319279117cc h1:Ub5lR5HmNYHIV216CQDCzE+3rDUb4hPt1CmJCTjTa7A=

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/qase-tms/qase-go/pkg/qase-go v1.0.7
 	github.com/qase-tms/qase-go/qase-api-client v1.2.10
 	github.com/rancher/rancher v0.0.0-20260527150105-ae26ccbc3fed
-	github.com/rancher/shepherd v0.0.0-20260803191617-6ad1050e7ffe
+	github.com/rancher/shepherd v0.0.0-20260804191050-69556e75d7d6
 	github.com/rancher/tests/actions v0.0.0-20260610140123-a36d05641397
 	github.com/rancher/tests/interoperability v0.0.0
 	github.com/rancher/tfp-automation v0.0.0-20260724212646-b319279117cc

--- a/go.sum
+++ b/go.sum
@@ -3750,8 +3750,8 @@ github.com/rancher/rancher v0.0.0-20260527150105-ae26ccbc3fed h1:G66Ag8VZXlA6Kiu
 github.com/rancher/rancher v0.0.0-20260527150105-ae26ccbc3fed/go.mod h1:wn9b239FRsjEulPTy5U1qTgT9vusgIc8Sxq0UJRdvhA=
 github.com/rancher/rancher/pkg/apis v0.0.0-20260527150105-ae26ccbc3fed h1:HoeCYnxcvP+p020CvCyNaJSwzH5I/nsQ6uRcbDbB17E=
 github.com/rancher/rancher/pkg/apis v0.0.0-20260527150105-ae26ccbc3fed/go.mod h1:TtM3SQiHWml7okiEMRndWKt1knQ/DeQC60Bzt6OBmrg=
-github.com/rancher/shepherd v0.0.0-20260803191617-6ad1050e7ffe h1:hR6t1EJoCOMPKOnFplQgnXImuCw+dsjDHeCQdKNvo1E=
-github.com/rancher/shepherd v0.0.0-20260803191617-6ad1050e7ffe/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
+github.com/rancher/shepherd v0.0.0-20260804191050-69556e75d7d6 h1:b4Wo+0EqRiNUi+waFc85Ro1LoisKW29FAjrdj4Gh7Jg=
+github.com/rancher/shepherd v0.0.0-20260804191050-69556e75d7d6/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8/go.mod h1:xDDFkXVPcCf+S6wQoIDwgIijQHcIaVdN0eQRG2GcFd4=
 github.com/rancher/tfp-automation v0.0.0-20260724212646-b319279117cc h1:Ub5lR5HmNYHIV216CQDCzE+3rDUb4hPt1CmJCTjTa7A=

--- a/interoperability/go.mod
+++ b/interoperability/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/rancher/norman v0.9.9
 	github.com/rancher/qa-infra-automation v0.0.0-20260514152023-976143409dc3
 	github.com/rancher/rancher/pkg/apis v0.0.0
-	github.com/rancher/shepherd v0.0.0-20260803191617-6ad1050e7ffe
+	github.com/rancher/shepherd v0.0.0-20260804191050-69556e75d7d6
 	github.com/rancher/tests/actions v0.0.0-20260610140123-a36d05641397
 	github.com/rancher/tfp-automation v0.0.0-20260724212646-b319279117cc
 	github.com/sirupsen/logrus v1.9.4

--- a/interoperability/go.sum
+++ b/interoperability/go.sum
@@ -3652,8 +3652,8 @@ github.com/rancher/rancher v0.0.0-20260527150105-ae26ccbc3fed h1:G66Ag8VZXlA6Kiu
 github.com/rancher/rancher v0.0.0-20260527150105-ae26ccbc3fed/go.mod h1:wn9b239FRsjEulPTy5U1qTgT9vusgIc8Sxq0UJRdvhA=
 github.com/rancher/rancher/pkg/apis v0.0.0-20260527150105-ae26ccbc3fed h1:HoeCYnxcvP+p020CvCyNaJSwzH5I/nsQ6uRcbDbB17E=
 github.com/rancher/rancher/pkg/apis v0.0.0-20260527150105-ae26ccbc3fed/go.mod h1:TtM3SQiHWml7okiEMRndWKt1knQ/DeQC60Bzt6OBmrg=
-github.com/rancher/shepherd v0.0.0-20260803191617-6ad1050e7ffe h1:hR6t1EJoCOMPKOnFplQgnXImuCw+dsjDHeCQdKNvo1E=
-github.com/rancher/shepherd v0.0.0-20260803191617-6ad1050e7ffe/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
+github.com/rancher/shepherd v0.0.0-20260804191050-69556e75d7d6 h1:b4Wo+0EqRiNUi+waFc85Ro1LoisKW29FAjrdj4Gh7Jg=
+github.com/rancher/shepherd v0.0.0-20260804191050-69556e75d7d6/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8 h1:7qMiCWOKZdhscekXzeIUpaGethXtj19ob6V+U91tAxI=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260519183600-f1362a3fe1a8/go.mod h1:xDDFkXVPcCf+S6wQoIDwgIijQHcIaVdN0eQRG2GcFd4=
 github.com/rancher/tfp-automation v0.0.0-20260724212646-b319279117cc h1:Ub5lR5HmNYHIV216CQDCzE+3rDUb4hPt1CmJCTjTa7A=


### PR DESCRIPTION
## Summary
Updates the pinned `rancher/shepherd` commit version in the Go module dependency files.
## Changes
- Update the `rancher/shepherd` reference in `go.mod`
- Refresh the corresponding dependency entries in `go.sum`
## Purpose
Keeps the test suite aligned with the intended `rancher/shepherd` revision and ensures dependency metadata stays in sync.