### PR TITLE
Updating aws config

### DIFF
--- a/validation/Jenkinsfile.e2e
+++ b/validation/Jenkinsfile.e2e
@@ -127,17 +127,17 @@ pipeline {
         )
         string(
             name: 'RANCHER_VERSION',
-            defaultValue: 'latest',
+            defaultValue: '2.15.0',
             description: 'Rancher version to deploy'
         )
         string(
             name: 'RANCHER_IMAGE_TAG',
-            defaultValue: 'head',
+            defaultValue: 'v2.15-head',
             description: 'Rancher container image tag (head for dev builds, version tag for stable)'
         )
         string(
             name: 'RANCHER_CHART_REPO_URL',
-            defaultValue: 'https://releases.rancher.com/server-charts/stable',
+            defaultValue: 'https://releases.rancher.com/server-charts/latest',
             description: 'Rancher Helm chart repository URL'
         )
         string(
@@ -207,21 +207,21 @@ pipeline {
             description: 'Terraform tfvars for the cluster_nodes module (non-airgap)',
             defaultValue: '''aws_access_key = "${AWS_ACCESS_KEY_ID}"
 aws_secret_key = "${AWS_SECRET_ACCESS_KEY}"
-aws_ami = "ami-01b0ef1ab7898646f"
+aws_ami = "ami-0600e22b69546c15c"
 instance_type = "t3a.2xlarge"
-aws_security_group = ["sg-07a98dc3474d4eb9f"]
-aws_subnet = "subnet-0377a1ca391d51cae"
+aws_security_group = ["sg-08e8243a8cfbea8a0"]
+aws_subnet = "subnet-ee8cac86"
 airgap_setup = false
 proxy_setup = false
 aws_volume_size = 500
 aws_volume_type = "gp3"
 aws_hostname_prefix = "${HOSTNAME_PREFIX}"
-aws_region = "us-west-1"
+aws_region = "us-east-2"
 aws_route53_zone = "qa.rancher.space"
-aws_ssh_user = "ec2-user"
-aws_vpc = "vpc-081cec85dbe35e9bd"
+aws_ssh_user = "ubuntu"
+aws_vpc = "vpc-bfccf4d7"
 public_ssh_key = "ssh_public_key.pub"
-private_ssh_key = "~/.ssh/\${AWS_SSH_PEM_KEY_NAME}"
+private_ssh_key = "~/.ssh/${AWS_SSH_PEM_KEY_NAME}"
 nodes = [
     {
         count = 3
@@ -240,7 +240,7 @@ nodes = [
 kubernetes_version: ${RKE2_VERSION}
 cni: calico
 kubeconfig_file: "/workspace/qa-infra-automation/ansible/rke2/default/kubeconfig.yaml"
-cert_manager_version: "1.17.4"
+cert_manager_version: "1.20.0"
 bootstrap_password: "${RANCHER_BOOTSTRAP_PASSWORD}"
 password: "${RANCHER_ADMIN_PASSWORD}"
 rancher_version: ${RANCHER_VERSION}
@@ -262,7 +262,7 @@ server_flags: |
             name: 'CATTLE_TEST_CONFIG',
             defaultValue: '''awsNodeTemplate:
     accessKey: ${AWS_ACCESS_KEY_ID}
-    ami: ami-0b8e245d9e93c05fa
+    ami: ami-0600e22b69546c15c
     blockDurationMinutes: 0
     encryptEbsVolume: false
     httpEndpoint: enabled
@@ -309,18 +309,18 @@ awsCredentials:
     defaultRegion: us-east-2
     secretKey: ${AWS_SECRET_ACCESS_KEY}
 awsEC2Configs:
-    awsAMI: ami-02ec473a7c3a2db48
+    awsAMI: ami-0600e22b69546c15c
     awsAccessKeyID: ${AWS_ACCESS_KEY_ID}
     awsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY}
     region: us-east-2
     awsEC2Config:
-    - awsAMI: ami-053835e36b16f97d0
+    - awsAMI: ami-0600e22b69546c15c
       awsCICDInstanceTag: rancher-validation
       awsIAMProfile: EngineeringUsersUS
       awsSSHKeyName: jenkins-elliptic-validation.pem
       awsSecurityGroups:
-      - sg-08e8243a8cfbea8a0 # qa_default_ipv4
-      awsUser: ec2-user
+      - sg-08e8243a8cfbea8a0
+      awsUser: ubuntu
       instanceType: t3a.2xlarge
       isWindows: false
       volumeSize: 50
@@ -448,19 +448,19 @@ cni = "calico"
 ingress-controller = "traefik"
 }
 node_config = {
-aws_access_key = "\${AWS_ACCESS_KEY_ID}"
-aws_secret_key = "\${AWS_SECRET_ACCESS_KEY}"
-access_key     = "\${AWS_ACCESS_KEY_ID}"
-secret_key     = "\${AWS_SECRET_ACCESS_KEY}"
+aws_access_key = "${AWS_ACCESS_KEY_ID}"
+aws_secret_key = "${AWS_SECRET_ACCESS_KEY}"
+access_key     = "${AWS_ACCESS_KEY_ID}"
+secret_key     = "${AWS_SECRET_ACCESS_KEY}"
 
-aws_ami = "ami-01b0ef1ab7898646f"
-aws_ssh_user = "ec2-user"
+aws_ami = ""
+aws_ssh_user = "ubuntu"
 aws_instance_type = "t3a.2xlarge"
-aws_security_group = ["allopen-dualstack"]
+aws_security_group = ["rke2-aws-node"]
 
-aws_subnet = "subnet-0377a1ca391d51cae"
-aws_availability_zone = "b"
-aws_vpc = "vpc-081cec85dbe35e9bd"
+aws_subnet = "subnet-73577c28"
+aws_availability_zone = "a"
+aws_vpc = "vpc-c30925a4"
 aws_region    = "us-west-1"
 aws_volume_size   = 50
 aws_volume_type   = "gp3"
@@ -621,7 +621,7 @@ insecure = true'''
                             // This can be overridden by explicitly setting RANCHER_CHART_REPO_URL.
                             def defaultChartRepoUrl = 'https://releases.rancher.com/server-charts/alpha'
                             if (params.RANCHER_VERSION && params.RANCHER_VERSION ==~ /v?\d+\.\d+\.\d+/) {
-                                defaultChartRepoUrl = 'https://releases.rancher.com/server-charts/stable'
+                                defaultChartRepoUrl = 'https://releases.rancher.com/server-charts/latest'
                             }
                             def rancherChartRepoUrlParam = params.RANCHER_CHART_REPO_URL ?: defaultChartRepoUrl
 

--- a/validation/Jenkinsfile.e2e
+++ b/validation/Jenkinsfile.e2e
@@ -324,7 +324,7 @@ awsEC2Configs:
       instanceType: t3a.2xlarge
       isWindows: false
       volumeSize: 50
-      roles: [etcd, contolplane, worker]
+      roles: [etcd, controlplane, worker]
 provisioningInput:
     psact: "rancher-privileged"
     cni:
@@ -526,6 +526,7 @@ insecure = true'''
     environment {
         WORKSPACE_NAME = ''
         INFRA_CLEANED  = 'false'
+        YQ_VERSION     = 'v4.47.2'
     }
 
     stages {
@@ -557,8 +558,14 @@ insecure = true'''
 
         stage('Setup Tools') {
             steps {
-                sh 'wget -qO ./yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 || true'
-                sh 'chmod +x ./yq || true'
+                sh """
+                    wget -qO ./yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64
+                    wget -qO ./yq_checksums https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/checksums
+                    grep -q '^yq_linux_amd64 ' ./yq_checksums
+                    awk '/^yq_linux_amd64 / {print \$19 "  ./yq"}' ./yq_checksums | sha256sum -c -
+                    rm -f ./yq_checksums
+                    chmod +x ./yq
+                """
             }
         }
 
@@ -802,7 +809,7 @@ rancher_use_bundled_system_charts: true
                         // Pipeline Utility Steps plugin (readJSON/writeJSON) is not installed,
                         // and python3 is not available on the Jenkins agent host.
                         sh "docker run --rm -v \$(pwd):/workspace -w /workspace rancher-go-test:latest python3 -c \"import json; d=json.load(open('rancher-token.json')); [d.pop(k,None) for k in ('token','bearerToken','accessKey','secretKey','value')]; json.dump(d,open('rancher-token-metadata.json','w'),indent=2)\""
-                        archiveArtifacts artifacts: 'rancher-token-metadata.json', fingerprint: true
+                        archiveArtifacts artifacts: 'rancher-token-metadata.json'
                         echo 'Archived redacted token metadata: rancher-token-metadata.json'
 
                         // Infrastructure, Rancher deploy, and admin token all succeeded.

--- a/validation/Jenkinsfile.individual.e2e
+++ b/validation/Jenkinsfile.individual.e2e
@@ -9,6 +9,7 @@
  *
  * Consumes shared functions from qa-jenkins-library:
  *   property.useWithProperties
+ *   naming.extractRancherHost
  *
  * Parameter names (CONFIG, REPO, BRANCH, TAGS, GOTEST_TESTCASE, etc.) match the
  * existing go-automation-freeform-job pattern for compatibility with downstream
@@ -17,19 +18,6 @@
 
 def libraryBranch = env.QA_JENKINS_LIBRARY_BRANCH ?: 'main'
 library "qa-jenkins-library@${libraryBranch}"
-
-/**
- * Extracts the Rancher hostname (rancher.host) from a cattle-config YAML string
- * so downstream naming (build display name, Qase test run name) doesn't need a
- * separate HOSTNAME_PREFIX parameter passed in from the orchestrator.
- */
-def extractRancherHost(String config) {
-    if (!config?.trim()) {
-        return ''
-    }
-    def matcher = config =~ /(?m)^\s*host:\s*(\S+)/
-    return matcher ? matcher[0][1] : ''
-}
 
 pipeline {
     agent any
@@ -126,7 +114,7 @@ pipeline {
                         userRemoteConfigs: [[url: params.REPO]]
                     ])
                     env.TESTS_DIR = pwd()
-                    env.RANCHER_HOSTNAME = extractRancherHost(params.CONFIG)
+                    env.RANCHER_HOSTNAME = naming.extractRancherHost(config: params.CONFIG)
                     def displaySuffix = env.RANCHER_HOSTNAME ? "${params.TAGS} - ${env.RANCHER_HOSTNAME}" : params.TAGS
                     currentBuild.displayName = "#${env.BUILD_NUMBER} - ${displaySuffix}"
                 }

--- a/validation/Jenkinsfile.individual.e2e
+++ b/validation/Jenkinsfile.individual.e2e
@@ -18,6 +18,19 @@
 def libraryBranch = env.QA_JENKINS_LIBRARY_BRANCH ?: 'main'
 library "qa-jenkins-library@${libraryBranch}"
 
+/**
+ * Extracts the Rancher hostname (rancher.host) from a cattle-config YAML string
+ * so downstream naming (build display name, Qase test run name) doesn't need a
+ * separate HOSTNAME_PREFIX parameter passed in from the orchestrator.
+ */
+def extractRancherHost(String config) {
+    if (!config?.trim()) {
+        return ''
+    }
+    def matcher = config =~ /(?m)^\s*host:\s*(\S+)/
+    return matcher ? matcher[0][1] : ''
+}
+
 pipeline {
     agent any
 
@@ -113,7 +126,9 @@ pipeline {
                         userRemoteConfigs: [[url: params.REPO]]
                     ])
                     env.TESTS_DIR = pwd()
-                    currentBuild.displayName = "#${env.BUILD_NUMBER} - ${params.TAGS}"
+                    env.RANCHER_HOSTNAME = extractRancherHost(params.CONFIG)
+                    def displaySuffix = env.RANCHER_HOSTNAME ? "${params.TAGS} - ${env.RANCHER_HOSTNAME}" : params.TAGS
+                    currentBuild.displayName = "#${env.BUILD_NUMBER} - ${displaySuffix}"
                 }
             }
         }
@@ -172,7 +187,8 @@ pipeline {
                         def isPitJob = env.JOB_NAME.contains('go-pit')
                         if (isPitJob) {
                             envLines += "QASE_PROJECT_ID=RANCHERINT"
-                            envLines += "TEST_RUN_NAME=${params.TAGS} Test Run"
+                            def testRunName = "${params.TAGS} ${env.RANCHER_HOSTNAME} Test Run"
+                            envLines += "TEST_RUN_NAME=${testRunName}"
                             envLines += "QASE_TEST_RUN_COMPLETE=true"
                         }
                         writeFile file: '.go_test_env', text: envLines.join('\n') + '\n'

--- a/validation/Jenkinsfile.multibranch.e2e
+++ b/validation/Jenkinsfile.multibranch.e2e
@@ -35,7 +35,7 @@ pipeline {
         )
         string(
             name: 'HOSTNAME_PREFIX',
-            defaultValue: 'recurring',
+            defaultValue: 'recurringdaily',
             description: 'Base hostname prefix — version suffix is appended automatically'
         )
 
@@ -404,9 +404,9 @@ insecure = true'''
                     if (isPitJob) {
                         recurringJob = 'go-pit-daily-job'
                         individualJob = 'go-pit-daily-individual-job'
-                        hostnamePrefix = "pit-daily-${hostnamePrefix}"
+                        hostnamePrefix = "pit-${hostnamePrefix}"
                         if (env.JOB_NAME.contains('weekly')) {
-                            hostnamePrefix = "pit-weekly-${hostnamePrefix}"
+                            hostnamePrefix = "pit-recurringweekly"
                         }
                     }
 

--- a/validation/Jenkinsfile.multibranch.e2e
+++ b/validation/Jenkinsfile.multibranch.e2e
@@ -30,7 +30,7 @@ pipeline {
         // ── Multi-version parameters ─────────────────────────────
         string(
             name: 'RANCHER_IMAGE_TAGS',
-            defaultValue: 'head',
+            defaultValue: 'v2.15-head',
             description: 'Comma-separated list of Rancher image tags to test in parallel (e.g., head,v2.10-head,v2.9-head)'
         )
         string(
@@ -74,12 +74,12 @@ pipeline {
         )
         string(
             name: 'RANCHER_VERSION',
-            defaultValue: 'latest',
+            defaultValue: '2.15.0',
             description: 'Default Rancher chart version (overridden per-tag when TAG_CHART_MAP applies)'
         )
         string(
             name: 'RANCHER_CHART_REPO_URL',
-            defaultValue: 'https://releases.rancher.com/server-charts/stable',
+            defaultValue: 'https://releases.rancher.com/server-charts/latest',
             description: 'Rancher Helm chart repository URL'
         )
         password(
@@ -124,19 +124,19 @@ pipeline {
             description: 'Terraform tfvars for the cluster_nodes module',
             defaultValue: '''aws_access_key = "${AWS_ACCESS_KEY_ID}"
 aws_secret_key = "${AWS_SECRET_ACCESS_KEY}"
-aws_ami = "ami-01b0ef1ab7898646f"
+aws_ami = "ami-0600e22b69546c15c"
 instance_type = "t3a.2xlarge"
-aws_security_group = ["sg-07a98dc3474d4eb9f"]
-aws_subnet = "subnet-0377a1ca391d51cae"
+aws_security_group = ["sg-08e8243a8cfbea8a0"]
+aws_subnet = "subnet-ee8cac86"
 airgap_setup = false
 proxy_setup = false
 aws_volume_size = 500
 aws_volume_type = "gp3"
 aws_hostname_prefix = "${HOSTNAME_PREFIX}"
-aws_region = "us-west-1"
+aws_region = "us-east-2"
 aws_route53_zone = "qa.rancher.space"
-aws_ssh_user = "ec2-user"
-aws_vpc = "vpc-081cec85dbe35e9bd"
+aws_ssh_user = "ubuntu"
+aws_vpc = "vpc-bfccf4d7"
 public_ssh_key = "ssh_public_key.pub"
 private_ssh_key = "~/.ssh/${AWS_SSH_PEM_KEY_NAME}"
 nodes = [
@@ -157,7 +157,7 @@ nodes = [
 kubernetes_version: ${RKE2_VERSION}
 cni: calico
 kubeconfig_file: "/workspace/qa-infra-automation/ansible/rke2/default/kubeconfig.yaml"
-cert_manager_version: "1.17.4"
+cert_manager_version: "1.20.0"
 bootstrap_password: "${RANCHER_BOOTSTRAP_PASSWORD}"
 password: "${RANCHER_ADMIN_PASSWORD}"
 rancher_version: ${RANCHER_VERSION}
@@ -180,7 +180,7 @@ server_flags: |
             description: 'Test configuration YAML (cattle-config). Token will be injected automatically.',
             defaultValue: '''awsNodeTemplate:
     accessKey: ${AWS_ACCESS_KEY_ID}
-    ami: ami-0b8e245d9e93c05fa
+    ami: ami-0600e22b69546c15c
     blockDurationMinutes: 0
     encryptEbsVolume: false
     httpEndpoint: enabled
@@ -227,12 +227,12 @@ awsCredentials:
     defaultRegion: us-east-2
     secretKey: ${AWS_SECRET_ACCESS_KEY}
 awsEC2Configs:
-    awsAMI: ami-02ec473a7c3a2db48
+    awsAMI: ami-0600e22b69546c15c
     awsAccessKeyID: ${AWS_ACCESS_KEY_ID}
     awsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY}
     region: us-east-2
     awsEC2Config:
-    - awsAMI: ami-053835e36b16f97d0
+    - awsAMI: ami-0600e22b69546c15c
       awsCICDInstanceTag: rancher-validation
       awsIAMProfile: EngineeringUsersUS
       awsSSHKeyName: jenkins-elliptic-validation.pem
@@ -323,14 +323,14 @@ aws_secret_key = "${AWS_SECRET_ACCESS_KEY}"
 access_key     = "${AWS_ACCESS_KEY_ID}"
 secret_key     = "${AWS_SECRET_ACCESS_KEY}"
 
-aws_ami = "ami-01b0ef1ab7898646f"
-aws_ssh_user = "ec2-user"
+aws_ami = ""
+aws_ssh_user = "ubuntu"
 aws_instance_type = "t3a.2xlarge"
-aws_security_group = ["allopen-dualstack"]
+aws_security_group = ["rke2-aws-node"]
 
-aws_subnet = "subnet-0377a1ca391d51cae"
-aws_availability_zone = "b"
-aws_vpc = "vpc-081cec85dbe35e9bd"
+aws_subnet = "subnet-73577c28"
+aws_availability_zone = "a"
+aws_vpc = "vpc-c30925a4"
 aws_region    = "us-west-1"
 aws_volume_size   = 50
 aws_volume_type   = "gp3"

--- a/validation/Jenkinsfile.multibranch.e2e
+++ b/validation/Jenkinsfile.multibranch.e2e
@@ -9,7 +9,7 @@
  * prefix, deploys the specified Rancher version, and runs tests.
  *
  * Consumes shared functions from qa-jenkins-library:
- *   property.useWithProperties
+ *   infrastructure.parseAndSubstituteVars
  */
 
 def libraryBranch = env.QA_JENKINS_LIBRARY_BRANCH ?: 'main'
@@ -391,11 +391,6 @@ insecure = true'''
             defaultValue: '',
             description: 'Schema file prefix for Qase operations, for example hostbusters or pit'
         )
-        string(
-            name: 'TEST_RUN_NAME',
-            defaultValue: 'Recurring Test Run',
-            description: 'Test run name for Qase reporting'
-        )
     }
 
     stages {
@@ -406,7 +401,6 @@ insecure = true'''
                     def recurringJob = params.RECURRING_JOB
                     def individualJob = params.INDIVIDUAL_JOB
                     def hostnamePrefix = params.HOSTNAME_PREFIX
-                    def validationTags = params.VALIDATION_TEST_TAGS
                     if (isPitJob) {
                         recurringJob = 'go-pit-daily-job'
                         individualJob = 'go-pit-daily-individual-job'
@@ -416,7 +410,31 @@ insecure = true'''
                         }
                     }
 
-                    def imageTags = params.RANCHER_IMAGE_TAGS.split(',').collect { it.trim() }
+                    // Matrix of (imageTag, validationTags) pairs to trigger per cadence.
+                    // Weekly run covers the latest version against the weekly suite plus
+                    // the two prior minor versions against the daily suite. Daily run only
+                    // covers the latest version against the daily suite.
+                    def runMatrixByJob = [
+                        'go-pit-weekly-multibranch-job': [
+                            [imageTag: 'v2.15-head', validationTags: 'pit.weekly'],
+                            [imageTag: 'v2.14-head', validationTags: 'pit.daily'],
+                            [imageTag: 'v2.13-head', validationTags: 'pit.daily']
+                        ],
+                        'go-pit-daily-multibranch-job': [
+                            [imageTag: 'v2.15-head', validationTags: 'pit.daily']
+                        ]
+                    ]
+
+                    // Fallback for manual "Build with Parameters" runs (or jobs not in the
+                    // map above): apply VALIDATION_TEST_TAGS uniformly across RANCHER_IMAGE_TAGS.
+                    def defaultMatrix = params.RANCHER_IMAGE_TAGS.split(',').collect {
+                        [imageTag: it.trim(), validationTags: params.VALIDATION_TEST_TAGS]
+                    }
+
+                    // Match against env.JOB_NAME via contains() since folder/multibranch
+                    // jobs prefix JOB_NAME with the folder path (e.g. "folder/go-pit-daily-multibranch-job").
+                    def matchedJobKey = runMatrixByJob.keySet().find { env.JOB_NAME.contains(it) }
+                    def runMatrix = matchedJobKey ? runMatrixByJob[matchedJobKey] : defaultMatrix
 
                     // Map image tags to hostname suffixes for unique DNS entries
                     def hostnameSuffixMap = [
@@ -425,6 +443,9 @@ insecure = true'''
                         'v2.10-head': 'v210',
                         'v2.11-head': 'v211',
                         'v2.12-head': 'v212',
+                        'v2.13-head': 'v213',
+                        'v2.14-head': 'v214',
+                        'v2.15-head': 'v215',
                         'head': 'main'
                     ]
 
@@ -435,6 +456,9 @@ insecure = true'''
                         'v2.10-head': '2.10.1',
                         'v2.11-head': '2.11.1',
                         'v2.12-head': '2.12.1',
+                        'v2.13-head': '2.13.1',
+                        'v2.14-head': '2.14.1',
+                        'v2.15-head': '2.15.0',
                         'head': 'latest'
                     ]
 
@@ -443,22 +467,22 @@ insecure = true'''
 
                     def jobs = [:]
 
-                    for (String imageTag : imageTags) {
-                        def tag = imageTag // capture for closure
+                    for (entry in runMatrix) {
+                        def tag = entry.imageTag // capture for closure
+                        def validationTags = entry.validationTags
                         def suffix = hostnameSuffixMap.get(tag, tag.replaceAll('[^a-zA-Z0-9]', ''))
                         def hostname = "${hostnamePrefix}${suffix}"
-                        def rancherVersion = tagChartMap.get(tag, params.RANCHER_VERSION)
+                        def rancherVersion = tagChartMap.get(tag, entry.imageTag)
 
-                        // Update TERRAFORM_CONFIG with per-tag hostname
-                        def tfConfig = params.TERRAFORM_CONFIG.replace(
-                            "aws_hostname_prefix = \"${hostnamePrefix}\"",
-                            "aws_hostname_prefix = \"${hostname}\""
+                        // Render per-tag hostname into TERRAFORM_CONFIG and CATTLE_TEST_CONFIG
+                        def tfConfig = infrastructure.parseAndSubstituteVars(
+                            content: params.TERRAFORM_CONFIG,
+                            envVars: ['HOSTNAME_PREFIX': hostname]
                         )
 
-                        // Update CATTLE_TEST_CONFIG with per-tag hostname
-                        def cattleConfig = params.CATTLE_TEST_CONFIG.replace(
-                            "host: ${hostnamePrefix}.qa.rancher.space",
-                            "host: ${hostname}.qa.rancher.space"
+                        def cattleConfig = infrastructure.parseAndSubstituteVars(
+                            content: params.CATTLE_TEST_CONFIG,
+                            envVars: ['HOSTNAME_PREFIX': hostname]
                         )
 
                         def jobParams = [
@@ -495,13 +519,14 @@ insecure = true'''
                             string(name: 'QASE_SCHEMA_PREFIX', value: params.QASE_SCHEMA_PREFIX),
                         ]
 
-                        jobs["${tag}"] = {
+                        jobs["${tag}-${validationTags}"] = {
                             build job: recurringJob, parameters: jobParams, propagate: false
                         }
                     }
 
-                    currentBuild.displayName = "#${env.BUILD_NUMBER} - ${params.RANCHER_IMAGE_TAGS}"
-                    currentBuild.description = "Testing: ${imageTags.join(', ')} on ${hostnamePrefix}"
+                    def matrixSummary = runMatrix.collect { "${it.imageTag} (${it.validationTags})" }.join(', ')
+                    currentBuild.displayName = "#${env.BUILD_NUMBER} - ${matrixSummary}"
+                    currentBuild.description = "Testing: ${matrixSummary} on ${hostnamePrefix}"
 
                     parallel jobs
                 }

--- a/validation/Jenkinsfile.multibranch.e2e
+++ b/validation/Jenkinsfile.multibranch.e2e
@@ -35,7 +35,7 @@ pipeline {
         )
         string(
             name: 'HOSTNAME_PREFIX',
-            defaultValue: 'recurringdaily',
+            defaultValue: 'recurring',
             description: 'Base hostname prefix — version suffix is appended automatically'
         )
 
@@ -404,9 +404,9 @@ insecure = true'''
                     if (isPitJob) {
                         recurringJob = 'go-pit-daily-job'
                         individualJob = 'go-pit-daily-individual-job'
-                        hostnamePrefix = "pit-${hostnamePrefix}"
+                        hostnamePrefix = "pit-daily-${hostnamePrefix}"
                         if (env.JOB_NAME.contains('weekly')) {
-                            validationTags = "pit.weekly"
+                            hostnamePrefix = "pit-weekly-${hostnamePrefix}"
                         }
                     }
 
@@ -416,19 +416,19 @@ insecure = true'''
                     // covers the latest version against the daily suite.
                     def runMatrixByJob = [
                         'go-pit-weekly-multibranch-job': [
-                            [imageTag: 'v2.15-head', validationTags: 'pit.weekly'],
-                            [imageTag: 'v2.14-head', validationTags: 'pit.daily'],
-                            [imageTag: 'v2.13-head', validationTags: 'pit.daily']
+                            [imageTag: 'v2.15-head', validationTags: 'pit.weekly', rke2Version: params.RKE2_VERSION],
+                            [imageTag: 'v2.14-head', validationTags: 'pit.daily', rke2Version: params.RKE2_VERSION],
+                            [imageTag: 'v2.13-head', validationTags: 'pit.daily', rke2Version: 'v1.34.9+rke2r1']
                         ],
                         'go-pit-daily-multibranch-job': [
-                            [imageTag: 'v2.15-head', validationTags: 'pit.daily']
+                            [imageTag: 'v2.15-head', validationTags: 'pit.daily', rke2Version: params.RKE2_VERSION]
                         ]
                     ]
 
                     // Fallback for manual "Build with Parameters" runs (or jobs not in the
                     // map above): apply VALIDATION_TEST_TAGS uniformly across RANCHER_IMAGE_TAGS.
                     def defaultMatrix = params.RANCHER_IMAGE_TAGS.split(',').collect {
-                        [imageTag: it.trim(), validationTags: params.VALIDATION_TEST_TAGS]
+                        [imageTag: it.trim(), validationTags: params.VALIDATION_TEST_TAGS, rke2Version: params.RKE2_VERSION]
                     }
 
                     // Match against env.JOB_NAME via contains() since folder/multibranch
@@ -492,7 +492,7 @@ insecure = true'''
                             string(name: 'QA_INFRA_REPO_URL', value: params.QA_INFRA_REPO_URL),
                             string(name: 'QA_INFRA_BRANCH', value: params.QA_INFRA_BRANCH),
                             string(name: 'HOSTNAME_PREFIX', value: hostname),
-                            string(name: 'RKE2_VERSION', value: params.RKE2_VERSION),
+                            string(name: 'RKE2_VERSION', value: entry.rke2Version),
                             string(name: 'RANCHER_VERSION', value: rancherVersion),
                             string(name: 'RANCHER_IMAGE_TAG', value: tag),
                             string(name: 'RANCHER_CHART_REPO_URL', value: params.RANCHER_CHART_REPO_URL),


### PR DESCRIPTION
Updates the E2E Jenkins pipelines’ default Rancher/AWS configuration to align recurring and PIT-style runs with a newer Rancher baseline and refreshed AWS infrastructure settings.

Changes:

- Bump default Rancher version/image tag defaults to 2.15.0 / v2.15-head and move chart repo defaults to server-charts/latest.
- Refresh AWS provisioning defaults (AMI, subnet, security group, region, ssh user) and update cert_manager_version to 1.20.0.
- Adjust chart repo selection logic for semver Rancher versions to use the latest repo (and update inline documentation accordingly).