### PR TITLE
Update weekly PR summary to replace outdated GitHub Models integration

### DIFF
--- a/.github/workflows/hb-weekly-pr-summary.yaml
+++ b/.github/workflows/hb-weekly-pr-summary.yaml
@@ -6,16 +6,16 @@ on:
     - cron: '0 8 * * 3'
 
 permissions:
+  copilot-requests: write
   id-token: write
   contents: read
-  models: read
 
 jobs:
   create_weekly_pr_summary:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: true
 
@@ -54,7 +54,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Report to Slack
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 #v3
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4
         with:
           webhook: ${{ secrets.HB_REVIEW_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
This change updates the weekly PR summary to remove the outdated GitHub Models integration and replace it with the current supported approach. It keeps the summary accurate and aligned with the latest implementation.