### PR TITLE
Propagate system-default-registry into NeuVector chart installs

### DIFF
--- a/validation/charts/neuvector_test.go
+++ b/validation/charts/neuvector_test.go
@@ -57,6 +57,9 @@ func (n *NeuVectorTestSuite) SetupSuite() {
 	latestVersion, err := n.client.Catalog.GetLatestChartVersion(actionsCharts.NeuVectorChartName, catalog.RancherChartRepo)
 	require.NoError(n.T(), err)
 
+	registrySetting, err := n.client.Management.Setting.ByID("system-default-registry")
+	require.NoError(n.T(), err)
+
 	n.chartInstallOptions = &actionsCharts.PayloadOpts{
 		Namespace: actionsCharts.NeuVectorNamespace,
 		InstallOptions: actionsCharts.InstallOptions{
@@ -64,6 +67,7 @@ func (n *NeuVectorTestSuite) SetupSuite() {
 			Version:   latestVersion,
 			ProjectID: n.project.ID,
 		},
+		DefaultRegistry: registrySetting.Value,
 	}
 }
 

--- a/validation/charts/neuvector_test.go
+++ b/validation/charts/neuvector_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/shepherd/pkg/session"
 	actionsCharts "github.com/rancher/tests/actions/charts"
 	"github.com/rancher/tests/actions/projects"
+	"github.com/rancher/tests/actions/registries"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -109,6 +110,13 @@ func (n *NeuVectorTestSuite) TestNeuVectorInstallation() {
 	n.T().Log("Verifying all expected NeuVector services are active")
 	err = verifyNeuVectorServicesActive(client, n.cluster.ID)
 	require.NoError(n.T(), err)
+
+	if n.chartInstallOptions.DefaultRegistry != "" {
+		n.T().Logf("Verifying NeuVector pods use registry prefix %q", n.chartInstallOptions.DefaultRegistry)
+		isUsingRegistry, err := registries.CheckAllClusterPodsForRegistryPrefix(client, n.cluster.ID, n.chartInstallOptions.DefaultRegistry)
+		require.NoError(n.T(), err)
+		require.True(n.T(), isUsingRegistry, "NeuVector pods are not using the expected registry prefix %q", n.chartInstallOptions.DefaultRegistry)
+	}
 
 	n.T().Log("Verifying NeuVector manager web UI is accessible via service proxy")
 	respUI, err := verifyNeuVectorWebUIAccessible(client, n.cluster.ID)

--- a/validation/neuvector/neuvector_hardened_test.go
+++ b/validation/neuvector/neuvector_hardened_test.go
@@ -26,6 +26,7 @@ import (
 	actionsCharts "github.com/rancher/tests/actions/charts"
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/registries"
 	"github.com/rancher/tests/actions/uiplugins"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
@@ -169,6 +170,13 @@ func (n *NeuVectorHardenedTestSuite) TestNeuVectorInstallation() {
 
 	err = charts.WatchAndWaitDaemonSets(n.client, cluster.ID, payload.Namespace, metav1.ListOptions{})
 	require.NoError(n.T(), err)
+
+	if registrySetting.Value != "" {
+		n.T().Logf("Verifying NeuVector pods use registry prefix %q", registrySetting.Value)
+		isUsingRegistry, err := registries.CheckAllClusterPodsForRegistryPrefix(n.client, cluster.ID, registrySetting.Value)
+		require.NoError(n.T(), err)
+		require.True(n.T(), isUsingRegistry, "NeuVector pods are not using the expected registry prefix %q", registrySetting.Value)
+	}
 
 	n.T().Log("Verifying NeuVector manager UI is reachable via service proxy")
 	uiProxyPath := fmt.Sprintf(

--- a/validation/neuvector/neuvector_hardened_test.go
+++ b/validation/neuvector/neuvector_hardened_test.go
@@ -137,6 +137,9 @@ func (n *NeuVectorHardenedTestSuite) TestNeuVectorInstallation() {
 	latestVersions, err := n.client.Catalog.GetListChartVersions(actionsCharts.NeuVectorChartName, catalog.RancherChartRepo)
 	require.NoError(n.T(), err)
 
+	registrySetting, err := n.client.Management.Setting.ByID("system-default-registry")
+	require.NoError(n.T(), err)
+
 	payload := actionsCharts.PayloadOpts{
 		Namespace: actionsCharts.NeuVectorNamespace,
 		Host:      n.client.RancherConfig.Host,
@@ -145,8 +148,9 @@ func (n *NeuVectorHardenedTestSuite) TestNeuVectorInstallation() {
 			Version:   latestVersions[0],
 			ProjectID: project.ID,
 		},
-		K3s:      strings.Contains(n.cfg.CustomCluster.KubernetesVersion, "k3s"),
-		Hardened: true,
+		DefaultRegistry: registrySetting.Value,
+		K3s:             strings.Contains(n.cfg.CustomCluster.KubernetesVersion, "k3s"),
+		Hardened:        true,
 	}
 
 	n.T().Logf("Installing NeuVector %s on cluster %s", latestVersions[0], cluster.Name)


### PR DESCRIPTION
## Summary

Propagate the `system-default-registry` Rancher setting into NeuVector chart install payloads, and add registry prefix verification to confirm NeuVector pods pull from the configured registry.

Closes #804

## Problem

Both NeuVector test suites (`validation/neuvector/neuvector_hardened_test.go` and `validation/charts/neuvector_test.go`) built `PayloadOpts` without setting `DefaultRegistry`. In airgap environments, this caused NeuVector pods to attempt pulling images from Docker Hub instead of the private registry, resulting in `ImagePullBackOff` and test timeout.

Every sibling chart helper (monitoring, logging, etc.) already performs this lookup — NeuVector was the only one skipping it.

## Changes

### Registry propagation

- **`validation/neuvector/neuvector_hardened_test.go`**: Look up `system-default-registry` via `client.Management.Setting.ByID()` and pass the value into `PayloadOpts.DefaultRegistry`
- **`validation/charts/neuvector_test.go`**: Same lookup, same propagation

The `NewChartInstall` helper in `actions/charts/payloads.go` already writes `systemDefaultRegistry` into chart values at both `global.cattle.systemDefaultRegistry` and `global.systemDefaultRegistry` — it just needed a non-empty value.

### Registry prefix verification

Both test suites now verify (after pods are ready) that all cluster pods use the configured registry prefix via `registries.CheckAllClusterPodsForRegistryPrefix`. This is the same pattern used by `validation/charts/installations_test.go` for monitoring and logging.

The check is **skipped when `system-default-registry` is empty** (non-airgap), so existing behavior is unchanged.

## Behavior matrix

| Scenario | `system-default-registry` | Verification | Result |
|----------|--------------------------|--------------|--------|
| Non-airgap | `""` (empty) | Skipped | Same as before |
| Airgap (correct) | `registry.example.com:5000` | Runs, all pods match | Pass |
| Airgap (broken) | `registry.example.com:5000` | Runs, pods pull from Docker Hub | **Fail** — catches `ImagePullBackOff` |

## Testing

```bash
# Standard test (against existing cluster)
CATTLE_TEST_CONFIG=config.yaml go test -v -tags=validation \
  -run TestNeuVectorTestSuite ./validation/charts/...

# Hardened test (provisions its own cluster)
CATTLE_TEST_CONFIG=config.yaml go test -v -tags=validation \
  -run TestNeuVectorHardenedTestSuite ./validation/neuvector/...
```

## Related

- #803 (PRD: Make NeuVector Validation Tests Airgap-Compatible) — Slice 1
- #788 (Source issue)