### PR TITLE
Make NeuVector UI extension repo URL configurable for airgap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea/
 .kube/
 *.pem
+.venv-ansible/

--- a/actions/neuvector/config.go
+++ b/actions/neuvector/config.go
@@ -1,0 +1,21 @@
+package neuvector
+
+const (
+	// ConfigurationFileKey is the top-level key used to unmarshal neuvectorTest config from the Rancher config file.
+	ConfigurationFileKey = "neuvectorTest"
+
+	// DefaultUIPluginChartsURL is the public ui-plugin-charts repository used when no override is configured.
+	DefaultUIPluginChartsURL = "https://github.com/rancher/ui-plugin-charts"
+	// DefaultUIPluginChartsBranch is the ui-plugin-charts branch used when no override is configured.
+	DefaultUIPluginChartsBranch = "main"
+)
+
+// NeuVectorTestConfig holds configuration for NeuVector validation tests.
+type NeuVectorTestConfig struct {
+	// UIPluginChartsURL overrides the git repository used for the UI plugin charts ClusterRepo (e.g. an internal mirror in airgap environments).
+	UIPluginChartsURL string `json:"uiPluginChartsURL,omitempty" yaml:"uiPluginChartsURL,omitempty"`
+	// UIPluginChartsBranch overrides the git branch of the UI plugin charts repository.
+	UIPluginChartsBranch string `json:"uiPluginChartsBranch,omitempty" yaml:"uiPluginChartsBranch,omitempty"`
+	// SkipUIExtension skips ClusterRepo creation and UI extension install entirely (e.g. when the extension is pre-installed in airgap environments).
+	SkipUIExtension bool `json:"skipUIExtension,omitempty" yaml:"skipUIExtension,omitempty"`
+}

--- a/actions/neuvector/config.go
+++ b/actions/neuvector/config.go
@@ -16,6 +16,6 @@ type NeuVectorTestConfig struct {
 	UIPluginChartsURL string `json:"uiPluginChartsURL,omitempty" yaml:"uiPluginChartsURL,omitempty"`
 	// UIPluginChartsBranch overrides the git branch of the UI plugin charts repository.
 	UIPluginChartsBranch string `json:"uiPluginChartsBranch,omitempty" yaml:"uiPluginChartsBranch,omitempty"`
-	// SkipUIExtension skips ClusterRepo creation and UI extension install entirely (e.g. when the extension is pre-installed in airgap environments).
+	// SkipUIExtension skips ClusterRepo creation and UI extension install entirely (e.g. airgap environments where the Rancher server cannot reach github.com and no uiPluginChartsURL mirror is configured). Not required when the extension is already installed; that case is auto-detected.
 	SkipUIExtension bool `json:"skipUIExtension,omitempty" yaml:"skipUIExtension,omitempty"`
 }

--- a/validation/neuvector/README.md
+++ b/validation/neuvector/README.md
@@ -49,10 +49,19 @@ neuvectorTest:
   skipUIExtension: false
 ```
 
-Skip ClusterRepo creation and extension install entirely when the NeuVector UI extension is
-pre-installed (e.g. airgap environments where the Rancher server cannot reach github.com):
+Skip the UI extension install entirely (airgap without a `ui-plugin-charts` mirror):
+
+Use `skipUIExtension: true` when the Rancher server cannot reach `github.com` **and** no
+internal mirror is configured via `uiPluginChartsURL`. In that case the ClusterRepo would
+never sync and the install would fail, so the test skips it rather than attempting the install.
 
 ```yaml
 neuvectorTest:
   skipUIExtension: true
 ```
+
+> **Note:** This flag is **not** needed when the extension is already installed — the test
+> auto-detects an existing install via chart status and skips the install on its own.
+> With the extension skipped, the suite still installs and validates the NeuVector backend
+> chart and reaches the manager UI through the Kubernetes service proxy, so the test remains
+> meaningful without the Rancher UI extension.

--- a/validation/neuvector/README.md
+++ b/validation/neuvector/README.md
@@ -34,3 +34,25 @@ qaInfraAutomation:
 
 **Note:** Infrastructure cleanup is registered via `t.Cleanup()` inside the provisioning helpers, so it
 runs automatically when the test finishes (pass or fail).
+
+### NeuVector test options
+
+Top-level key: `neuvectorTest`. All fields are optional; without any override the test uses the public
+`https://github.com/rancher/ui-plugin-charts` repo on the `main` branch, same as before.
+
+Point the UI plugin charts ClusterRepo at an internal git mirror (e.g. airgap):
+
+```yaml
+neuvectorTest:
+  uiPluginChartsURL: "https://internal-git.example.com/rancher/ui-plugin-charts"
+  uiPluginChartsBranch: "main"
+  skipUIExtension: false
+```
+
+Skip ClusterRepo creation and extension install entirely when the NeuVector UI extension is
+pre-installed (e.g. airgap environments where the Rancher server cannot reach github.com):
+
+```yaml
+neuvectorTest:
+  skipUIExtension: true
+```

--- a/validation/neuvector/neuvector_hardened_test.go
+++ b/validation/neuvector/neuvector_hardened_test.go
@@ -6,20 +6,17 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/clients/rancher/catalog"
-	v1 "github.com/rancher/shepherd/clients/rancher/v1"
 
 	"github.com/rancher/shepherd/extensions/charts"
+	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/extensions/ingresses"
 	interoperablecharts "github.com/rancher/tests/interoperability/charts"
-	qaconfig "github.com/rancher/tests/interoperability/qainfraautomation/config"
 	"github.com/sirupsen/logrus"
 
-	"github.com/rancher/shepherd/extensions/clusters"
 	"github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
@@ -31,6 +28,7 @@ import (
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
 	"github.com/rancher/tests/interoperability/qainfraautomation"
+	qaconfig "github.com/rancher/tests/interoperability/qainfraautomation/config"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -43,10 +41,11 @@ const (
 
 type NeuVectorHardenedTestSuite struct {
 	suite.Suite
-	client  *rancher.Client
-	session *session.Session
-	cfg     *qaconfig.Config
-	cluster *v1.SteveAPIObject
+	client          *rancher.Client
+	session         *session.Session
+	cfg             *qaconfig.Config
+	cluster         *clusters.ClusterMeta
+	defaultRegistry string
 }
 
 func (n *NeuVectorHardenedTestSuite) TearDownSuite() {
@@ -64,12 +63,7 @@ func (n *NeuVectorHardenedTestSuite) SetupSuite() {
 
 	cattleConfig := config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
 
-	n.cfg = new(qaconfig.Config)
-	operations.LoadObjectFromMap(qaconfig.ConfigurationFileKey, cattleConfig, n.cfg)
-
-	require.NotNil(n.T(), n.cfg.CustomCluster, "customCluster config is required under qaInfraAutomation.customCluster")
-	n.cfg.CustomCluster.Harden = true
-
+	// Load NeuVector-specific config (UI extension URL/branch, skip flag).
 	neuvectorConfig := new(neuvector.NeuVectorTestConfig)
 	operations.LoadObjectFromMap(neuvector.ConfigurationFileKey, cattleConfig, neuvectorConfig)
 	if neuvectorConfig.UIPluginChartsURL == "" {
@@ -109,37 +103,57 @@ func (n *NeuVectorHardenedTestSuite) SetupSuite() {
 		require.NoError(n.T(), err)
 	}
 
-	clusterObj := qainfraautomation.ProvisionCustomCluster(
-		n.T(),
-		n.client,
-		n.cfg,
-		n.cfg.CustomCluster,
-	)
+	// Use an existing downstream cluster when rancher.clusterName is set;
+	// otherwise provision a new hardened custom cluster.
+	clusterName := client.RancherConfig.ClusterName
+	if clusterName != "" {
+		n.T().Logf("Targeting existing cluster %q", clusterName)
+		n.cluster, err = clusters.NewClusterMeta(n.client, clusterName)
+		require.NoError(n.T(), err)
+	} else {
+		n.T().Log("rancher.clusterName not set; provisioning a new hardened custom cluster")
 
-	require.NotNil(n.T(), clusterObj, "expected a non-nil cluster object")
-	n.T().Logf("cluster %q is ready", clusterObj.Name)
+		n.cfg = new(qaconfig.Config)
+		operations.LoadObjectFromMap(qaconfig.ConfigurationFileKey, cattleConfig, n.cfg)
+		require.NotNil(n.T(), n.cfg.CustomCluster, "customCluster config is required under qaInfraAutomation.customCluster when rancher.clusterName is not set")
+		n.cfg.CustomCluster.Harden = true
 
-	logrus.Infof("Verifying the cluster is ready (%s)", clusterObj.Name)
-	err = provisioning.VerifyClusterReady(n.client, clusterObj)
+		clusterObj := qainfraautomation.ProvisionCustomCluster(
+			n.T(),
+			n.client,
+			n.cfg,
+			n.cfg.CustomCluster,
+		)
+		require.NotNil(n.T(), clusterObj, "expected a non-nil cluster object")
+		n.T().Logf("cluster %q is ready", clusterObj.Name)
+
+		logrus.Infof("Verifying the cluster is ready (%s)", clusterObj.Name)
+		err = provisioning.VerifyClusterReady(n.client, clusterObj)
+		require.NoError(n.T(), err)
+
+		logrus.Infof("Verifying cluster deployments (%s)", clusterObj.Name)
+		err = deployment.VerifyClusterDeployments(n.client, clusterObj)
+		require.NoError(n.T(), err)
+
+		logrus.Infof("Verifying cluster pods (%s)", clusterObj.Name)
+		err = pods.VerifyClusterPods(n.client, clusterObj)
+		require.NoError(n.T(), err)
+
+		// Normalize to ClusterMeta so both paths share the same type downstream.
+		n.cluster, err = clusters.NewClusterMeta(n.client, clusterObj.Name)
+		require.NoError(n.T(), err)
+	}
+
+	// Look up system-default-registry for airgap compatibility (Slice 1, #804).
+	// In non-airgap environments this setting exists but is empty.
+	registrySetting, err := n.client.Management.Setting.ByID("system-default-registry")
 	require.NoError(n.T(), err)
-
-	logrus.Infof("Verifying cluster deployments (%s)", clusterObj.Name)
-	err = deployment.VerifyClusterDeployments(n.client, clusterObj)
-	require.NoError(n.T(), err)
-
-	logrus.Infof("Verifying cluster pods (%s)", clusterObj.Name)
-	err = pods.VerifyClusterPods(n.client, clusterObj)
-	require.NoError(n.T(), err)
-
-	n.cluster = clusterObj
+	n.defaultRegistry = registrySetting.Value
 }
 
 func (n *NeuVectorHardenedTestSuite) TestNeuVectorInstallation() {
-	cluster, err := clusters.NewClusterMeta(n.client, n.cluster.Name)
-	require.NoError(n.T(), err)
-
 	n.T().Logf("Fetching Project [%s]", actionsCharts.SystemProject)
-	project, err := projects.GetProjectByName(n.client, cluster.ID, actionsCharts.SystemProject)
+	project, err := projects.GetProjectByName(n.client, n.cluster.ID, actionsCharts.SystemProject)
 	require.NoError(n.T(), err)
 	require.Equal(n.T(), actionsCharts.SystemProject, project.Name)
 
@@ -151,35 +165,36 @@ func (n *NeuVectorHardenedTestSuite) TestNeuVectorInstallation() {
 		Namespace: actionsCharts.NeuVectorNamespace,
 		Host:      n.client.RancherConfig.Host,
 		InstallOptions: actionsCharts.InstallOptions{
-			Cluster:   cluster,
+			Cluster:   n.cluster,
 			Version:   latestVersions[0],
 			ProjectID: project.ID,
 		},
-		K3s:      strings.Contains(n.cfg.CustomCluster.KubernetesVersion, "k3s"),
-		Hardened: true,
+		DefaultRegistry: n.defaultRegistry,
+		K3s:             n.cluster.Provider == clusters.KubernetesProviderK3S,
+		Hardened:        true,
 	}
 
-	n.T().Logf("Installing NeuVector %s on cluster %s", latestVersions[0], cluster.Name)
+	n.T().Logf("Installing NeuVector %s on cluster %s", latestVersions[0], n.cluster.Name)
 	err = actionsCharts.InstallNeuVectorChart(n.client, payload)
 	require.NoError(n.T(), err)
 
 	n.T().Log("Waiting for NeuVector chart to become active")
-	catalogClient, err := n.client.GetClusterCatalogClient(cluster.ID)
+	catalogClient, err := n.client.GetClusterCatalogClient(n.cluster.ID)
 	require.NoError(n.T(), err)
 	err = charts.WaitChartInstall(catalogClient, payload.Namespace, actionsCharts.NeuVectorChartName)
 	require.NoError(n.T(), err)
 
 	n.T().Log("Waiting for resources to become active")
-	err = charts.WatchAndWaitDeployments(n.client, cluster.ID, payload.Namespace, metav1.ListOptions{})
+	err = charts.WatchAndWaitDeployments(n.client, n.cluster.ID, payload.Namespace, metav1.ListOptions{})
 	require.NoError(n.T(), err)
 
-	err = charts.WatchAndWaitDaemonSets(n.client, cluster.ID, payload.Namespace, metav1.ListOptions{})
+	err = charts.WatchAndWaitDaemonSets(n.client, n.cluster.ID, payload.Namespace, metav1.ListOptions{})
 	require.NoError(n.T(), err)
 
 	n.T().Log("Verifying NeuVector manager UI is reachable via service proxy")
 	uiProxyPath := fmt.Sprintf(
 		"k8s/clusters/%s/api/v1/namespaces/%s/services/https:neuvector-service-webui:8443/proxy/",
-		cluster.ID,
+		n.cluster.ID,
 		actionsCharts.NeuVectorNamespace,
 	)
 	_, err = ingresses.GetExternalIngressResponse(n.client, n.client.RancherConfig.Host, uiProxyPath, true)

--- a/validation/neuvector/neuvector_hardened_test.go
+++ b/validation/neuvector/neuvector_hardened_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	actionsCharts "github.com/rancher/tests/actions/charts"
+	"github.com/rancher/tests/actions/neuvector"
 	"github.com/rancher/tests/actions/projects"
 	"github.com/rancher/tests/actions/provisioning"
 	"github.com/rancher/tests/actions/uiplugins"
@@ -38,8 +39,6 @@ import (
 
 const (
 	uiPluginChartsRepoName = "rancher-ui-plugins"
-	uiPluginChartsURL      = "https://github.com/rancher/ui-plugin-charts"
-	uiPluginChartsBranch   = "main"
 )
 
 type NeuVectorHardenedTestSuite struct {
@@ -71,19 +70,30 @@ func (n *NeuVectorHardenedTestSuite) SetupSuite() {
 	require.NotNil(n.T(), n.cfg.CustomCluster, "customCluster config is required under qaInfraAutomation.customCluster")
 	n.cfg.CustomCluster.Harden = true
 
-	_, err = n.client.Catalog.ClusterRepos().Get(context.TODO(), uiPluginChartsRepoName, metav1.GetOptions{})
-	if k8sErrors.IsNotFound(err) {
-		logrus.Infof("UI plugin repo %q not found, creating it", uiPluginChartsRepoName)
-		err = uiplugins.CreateExtensionsRepo(n.client, uiPluginChartsRepoName, uiPluginChartsURL, uiPluginChartsBranch)
+	neuvectorConfig := new(neuvector.NeuVectorTestConfig)
+	operations.LoadObjectFromMap(neuvector.ConfigurationFileKey, cattleConfig, neuvectorConfig)
+	if neuvectorConfig.UIPluginChartsURL == "" {
+		neuvectorConfig.UIPluginChartsURL = neuvector.DefaultUIPluginChartsURL
 	}
-
-	require.NoError(n.T(), err)
+	if neuvectorConfig.UIPluginChartsBranch == "" {
+		neuvectorConfig.UIPluginChartsBranch = neuvector.DefaultUIPluginChartsBranch
+	}
 
 	n.T().Logf("Checking if NeuVector UI extension [%s] is already installed", interoperablecharts.NeuVectorUIExtensionName)
 	uiExtensionObj, err := charts.GetChartStatus(n.client, "local", interoperablecharts.ExtensionNamespace, interoperablecharts.NeuVectorUIExtensionName)
 	require.NoError(n.T(), err)
 
-	if !uiExtensionObj.IsAlreadyInstalled {
+	if neuvectorConfig.SkipUIExtension || uiExtensionObj.IsAlreadyInstalled {
+		n.T().Logf("Skipping UI plugin repo creation and extension install (skipUIExtension=%t, alreadyInstalled=%t)", neuvectorConfig.SkipUIExtension, uiExtensionObj.IsAlreadyInstalled)
+	} else {
+		_, err = n.client.Catalog.ClusterRepos().Get(context.TODO(), uiPluginChartsRepoName, metav1.GetOptions{})
+		if k8sErrors.IsNotFound(err) {
+			logrus.Infof("UI plugin repo %q not found, creating it from %q", uiPluginChartsRepoName, neuvectorConfig.UIPluginChartsURL)
+			err = uiplugins.CreateExtensionsRepo(n.client, uiPluginChartsRepoName, neuvectorConfig.UIPluginChartsURL, neuvectorConfig.UIPluginChartsBranch)
+		}
+
+		require.NoError(n.T(), err)
+
 		n.T().Logf("Getting the latest chart version for [%s]", interoperablecharts.NeuVectorUIExtensionName)
 		latestVersion, err := n.client.Catalog.GetLatestChartVersion(interoperablecharts.NeuVectorUIExtensionName, uiPluginChartsRepoName)
 		require.NoError(n.T(), err)


### PR DESCRIPTION
## Summary

Closes #805 (Slice 2 of #803 — Make NeuVector Validation Tests Airgap-Compatible).

Replaces the hardcoded `github.com` URL for the UI plugin charts repo in `validation/neuvector/neuvector_hardened_test.go` with a config-driven value, and skips `ClusterRepo` creation when the extension is already installed or explicitly skipped. This unblocks `SetupSuite` in airgap environments where the Rancher server cannot reach `github.com`.

## Changes

- **`actions/neuvector/config.go`** (new): `NeuVectorTestConfig` struct loaded from the new top-level `neuvectorTest` config key, with `uiPluginChartsURL`, `uiPluginChartsBranch`, and `skipUIExtension` fields. Defaults (`https://github.com/rancher/ui-plugin-charts`, `main`) preserve existing behavior when no override is configured.
- **`validation/neuvector/neuvector_hardened_test.go`**: `SetupSuite` loads the config and applies defaults. The `IsAlreadyInstalled` check now runs first; when `skipUIExtension: true` **or** the extension is already installed, `CreateExtensionsRepo` is never called — no `ClusterRepo` creation, no outbound `git clone`. A configured mirror URL is passed through to `CreateExtensionsRepo`, which still waits on `RepoDownloaded`.
- **`validation/neuvector/README.md`**: documents the `neuvectorTest` config key with airgap examples (internal mirror and pre-installed extension).

## Config examples

Internal git mirror:
```yaml
neuvectorTest:
  uiPluginChartsURL: "https://internal-git.example.com/rancher/ui-plugin-charts"
  uiPluginChartsBranch: "main"
  skipUIExtension: false
```

Airgap with pre-installed extension:
```yaml
neuvectorTest:
  skipUIExtension: true
```

## Testing

- `go build -tags=validation ./validation/neuvector/...` ✅
- `go vet -tags=validation ./validation/neuvector/...` and `go vet ./neuvector/...` (actions module) ✅
- Runtime airgap/non-airgap verification requires live environments (per issue acceptance criteria)

## Related

- #803 (Parent PRD)
- #788 (Source issue)
- #804 (Slice 1 — registry propagation, independent)