### PR TITLE
Bump default instanceType in defaults.yaml files and update VerifyClusterReady function

### DIFF
--- a/actions/provisioning/verify.go
+++ b/actions/provisioning/verify.go
@@ -58,6 +58,12 @@ const (
 // VerifyClusterReady validates that a non-rke1 cluster and its resources are in a good state, matching a given config.
 func VerifyClusterReady(client *rancher.Client, cluster *steveV1.SteveAPIObject) error {
 	var lastErr error
+	if cluster == nil {
+		return fmt.Errorf("cluster is nil")
+	}
+
+	clusterID := cluster.ID
+	clusterName := cluster.Name
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaults.ThirtyMinuteTimeout)
 	defer cancel()
@@ -65,19 +71,24 @@ func VerifyClusterReady(client *rancher.Client, cluster *steveV1.SteveAPIObject)
 	err := kwait.PollUntilContextTimeout(ctx, 10*time.Second, defaults.ThirtyMinuteTimeout, false, func(context.Context) (done bool, err error) {
 		client, err = client.ReLogin()
 		if err != nil {
-			logrus.Debugf("Unable to fetch cluster client (%s), retrying", cluster.Name)
+			logrus.Debugf("Unable to fetch cluster client (%s), retrying", clusterName)
 			return false, nil
 		}
 
-		cluster, err = client.Steve.SteveType(stevetypes.Provisioning).ByID(cluster.ID)
+		latestCluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 		if err != nil {
+			lastErr = err
+			logrus.Debugf("Unable to fetch provisioning cluster by id (%s/%s), retrying: %v", clusterName, clusterID, err)
 			return false, nil
 		}
+
+		cluster = latestCluster
 
 		clusterStatus := &provv1.ClusterStatus{}
 		err = steveV1.ConvertToK8sType(cluster.Status, clusterStatus)
 		if err != nil {
-			logrus.Debugf("Unable to fetch cluster kube client (%s), retrying", cluster.Name)
+			lastErr = err
+			logrus.Debugf("Unable to fetch cluster kube client (%s), retrying", clusterName)
 			return false, nil
 		}
 
@@ -92,11 +103,11 @@ func VerifyClusterReady(client *rancher.Client, cluster *steveV1.SteveAPIObject)
 		return err
 	}
 
-	logrus.Debugf("Waiting for all machines to be ready on cluster (%s)", cluster.Name)
-	err = nodestat.AllMachineReady(client, cluster.ID, defaults.FiveMinuteTimeout)
+	logrus.Debugf("Waiting for all machines to be ready on cluster (%s)", clusterName)
+	err = nodestat.AllMachineReady(client, clusterID, defaults.FiveMinuteTimeout)
 	if err != nil {
-		logrus.Errorf("Cluster (%s) failed to become ready: %v", cluster.Name, err)
-		dumpProvisioningClusterState(ctx, client, cluster.Name, lastErr)
+		logrus.Errorf("Cluster (%s) failed to become ready: %v", clusterName, err)
+		dumpProvisioningClusterState(ctx, client, clusterName, lastErr)
 		return err
 	}
 

--- a/validation/certificates/defaults/defaults.yaml
+++ b/validation/certificates/defaults/defaults.yaml
@@ -40,7 +40,7 @@ awsMachineConfigs:
   awsMachineConfig:
   - roles: ["etcd","controlplane","worker"]
     ami: "<required>"
-    instanceType: "t3a.medium"
+    instanceType: "t3.xlarge"
     sshUser: "<required>"
     vpcId: "<required>"
     retries: "5"

--- a/validation/deleting/defaults/defaults.yaml
+++ b/validation/deleting/defaults/defaults.yaml
@@ -40,7 +40,7 @@ awsMachineConfigs:
   awsMachineConfig:
   - roles: ["etcd","controlplane","worker"]
     ami: "<required>"
-    instanceType: "t3a.medium"
+    instanceType: "t3.xlarge"
     sshUser: "<required>"
     vpcId: "<required>"
     retries: "5"

--- a/validation/encryptionkeyrotation/defaults/defaults.yaml
+++ b/validation/encryptionkeyrotation/defaults/defaults.yaml
@@ -40,7 +40,7 @@ awsMachineConfigs:
   awsMachineConfig:
   - roles: ["etcd","controlplane","worker"]
     ami: "<required>"
-    instanceType: "t3a.medium"
+    instanceType: "t3.xlarge"
     sshUser: "<required>"
     vpcId: "<required>"
     retries: "5"

--- a/validation/provisioning/airgap/README.md
+++ b/validation/provisioning/airgap/README.md
@@ -126,7 +126,7 @@ Custom clusters are only supported on AWS.
     awsSecretAccessKey: ""
     awsAccessKeyID: ""
     awsEC2Config:
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]
@@ -137,7 +137,7 @@ Custom clusters are only supported on AWS.
         awsUser: "ubuntu"
         volumeSize: 50
         roles: ["etcd", "controlplane"]
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]

--- a/validation/provisioning/airgap/defaults/defaults.yaml
+++ b/validation/provisioning/airgap/defaults/defaults.yaml
@@ -38,7 +38,7 @@ awsEC2Configs:
   awsSecretAccessKey: "<required>"
   awsAccessKeyID: "<required>"
   awsEC2Config:
-    - instanceType: "t3a.medium"
+    - instanceType: "t3.xlarge"
       awsRegionAZ: ""
       awsSSHKeyName: "<required>"
       awsAMI: "<required>"

--- a/validation/provisioning/defaults/defaults.yaml
+++ b/validation/provisioning/defaults/defaults.yaml
@@ -43,7 +43,7 @@ awsMachineConfigs:
   awsMachineConfig:
   - roles: ["etcd","controlplane","worker"]
     ami: "<required>"
-    instanceType: "t3a.medium"
+    instanceType: "t3.xlarge"
     volumeType: "<required>"
     rootSize: "<required>"
     sshUser: "<required>"
@@ -85,7 +85,7 @@ terraform:
     awsSecurityGroupNames: ["<required>", "<required>"]
     awsSubnetID: "<required>"
     awsVpcID: "<required>"
-    awsInstanceType: "t3a.medium"
+    awsinstanceType: "t3.xlarge"
     awsZoneLetter: "a"
     awsRootSize: 100
     awsRoute53Zone: "<required>"
@@ -105,7 +105,7 @@ awsEC2Configs:
   awsSecretAccessKey: "<required>"
   awsAccessKeyID: "<required>"
   awsEC2Config:
-    - instanceType: "t3a.medium"
+    - instanceType: "t3.xlarge"
       awsRegionAZ: ""
       awsAMI: "<required>"
       awsSecurityGroups: ["<required>"]

--- a/validation/provisioning/dualstack/README.md
+++ b/validation/provisioning/dualstack/README.md
@@ -233,7 +233,7 @@ awsMachineConfigs:                            #default
   awsMachineConfig:
   - roles: ["etcd","controlplane","worker"]
     ami: ""                                   #required
-    instanceType: "t3a.medium"
+    instanceType: "t3.xlarge"
     sshUser: "ubuntu"                         #required
     vpcId: ""                                 #required
     volumeType: "gp3"                         
@@ -364,7 +364,7 @@ Custom clusters are only supported on AWS.
     awsSecretAccessKey: ""
     awsAccessKeyID: ""
     awsEC2Config:
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]
@@ -374,7 +374,7 @@ Custom clusters are only supported on AWS.
         awsUser: "ubuntu"
         volumeSize: 50
         roles: ["etcd", "controlplane"]
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]

--- a/validation/provisioning/ipv6/README.md
+++ b/validation/provisioning/ipv6/README.md
@@ -229,7 +229,7 @@ awsMachineConfigs:                            #default
     httpProtocolIpv6: "enabled"
     ipv6AddressOnly: true
     ipv6AddressCount: "1"
-    instanceType: "t3a.medium"
+    instanceType: "t3.xlarge"
     sshUser: "ubuntu"                         #required
     vpcId: ""                                 #required
     volumeType: "gp3"                         
@@ -361,7 +361,7 @@ Custom clusters are only supported on AWS.
     awsSecretAccessKey: ""
     awsAccessKeyID: ""
     awsEC2Config:
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]
@@ -372,7 +372,7 @@ Custom clusters are only supported on AWS.
         awsUser: "ubuntu"
         volumeSize: 50
         roles: ["etcd", "controlplane"]
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]

--- a/validation/provisioning/k3s/README.md
+++ b/validation/provisioning/k3s/README.md
@@ -414,7 +414,7 @@ awsMachineConfigs:                            #default
   awsMachineConfig:
   - roles: ["etcd","controlplane","worker"]
     ami: ""                                   #required
-    instanceType: "t3a.medium"
+    instanceType: "t3.xlarge"
     sshUser: "ubuntu"                         #required
     vpcId: ""                                 #required
     volumeType: "gp3"                         
@@ -547,7 +547,7 @@ Custom clusters are only supported on AWS.
     awsSecretAccessKey: ""
     awsAccessKeyID: ""
     awsEC2Config:
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]
@@ -558,7 +558,7 @@ Custom clusters are only supported on AWS.
         awsUser: "ubuntu"
         volumeSize: 50
         roles: ["etcd", "controlplane"]
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]

--- a/validation/provisioning/proxy/README.md
+++ b/validation/provisioning/proxy/README.md
@@ -218,7 +218,7 @@ awsMachineConfigs:                            #default
   awsMachineConfig:
   - roles: ["etcd","controlplane","worker"]
     ami: ""                                   #required
-    instanceType: "t3a.medium"
+    instanceType: "t3.xlarge"
     sshUser: "ubuntu"                         #required
     vpcId: ""                                 #required
     volumeType: "gp3"                         
@@ -350,7 +350,7 @@ Custom clusters are only supported on AWS.
     awsSecretAccessKey: ""
     awsAccessKeyID: ""
     awsEC2Config:
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]
@@ -361,7 +361,7 @@ Custom clusters are only supported on AWS.
         awsUser: "ubuntu"
         volumeSize: 50
         roles: ["etcd", "controlplane"]
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]

--- a/validation/provisioning/proxy/defaults/defaults.yaml
+++ b/validation/provisioning/proxy/defaults/defaults.yaml
@@ -63,7 +63,7 @@ awsEC2Configs:
   awsSecretAccessKey: "<required>"
   awsAccessKeyID: "<required>"
   awsEC2Config:
-    - instanceType: "t3a.medium"
+    - instanceType: "t3.xlarge"
       awsRegionAZ: ""
       awsSSHKeyName: "<required>"
       awsAMI: "<required>"

--- a/validation/provisioning/registries/README.md
+++ b/validation/provisioning/registries/README.md
@@ -151,7 +151,7 @@ awsMachineConfigs:                            #default
     httpProtocolIpv6: "enabled"
     ipv6AddressOnly: true
     ipv6AddressCount: "1"
-    instanceType: "t3a.medium"
+    instanceType: "t3.xlarge"
     sshUser: "ubuntu"                         #required
     vpcId: ""                                 #required
     volumeType: "gp3"                         
@@ -169,7 +169,7 @@ Custom clusters are only supported on AWS.
     awsSecretAccessKey: ""
     awsAccessKeyID: ""
     awsEC2Config:
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]
@@ -180,7 +180,7 @@ Custom clusters are only supported on AWS.
         awsUser: "ubuntu"
         volumeSize: 50
         roles: ["etcd", "controlplane"]
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]

--- a/validation/provisioning/registries/defaults/defaults.yaml
+++ b/validation/provisioning/registries/defaults/defaults.yaml
@@ -69,7 +69,7 @@ awsEC2Configs:
   awsSecretAccessKey: "<required>"
   awsAccessKeyID: "<required>"
   awsEC2Config:
-    - instanceType: "t3a.medium"
+    - instanceType: "t3.xlarge"
       awsRegionAZ: ""
       awsSSHKeyName: "<required>"
       awsAMI: "<required>"

--- a/validation/provisioning/rke2/README.md
+++ b/validation/provisioning/rke2/README.md
@@ -499,7 +499,7 @@ awsMachineConfigs:                            #default
   awsMachineConfig:
   - roles: ["etcd","controlplane","worker"]
     ami: ""                                   #required
-    instanceType: "t3a.medium"
+    instanceType: "t3.xlarge"
     sshUser: "ubuntu"                         #required
     vpcId: ""                                 #required
     volumeType: "gp3"                         
@@ -632,7 +632,7 @@ Custom clusters are only supported on AWS.
     awsSecretAccessKey: ""
     awsAccessKeyID: ""
     awsEC2Config:
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]
@@ -643,7 +643,7 @@ Custom clusters are only supported on AWS.
         awsUser: "ubuntu"
         volumeSize: 50
         roles: ["etcd", "controlplane"]
-      - instanceType: "t3a.medium"
+      - instanceType: "t3.xlarge"
         awsRegionAZ: ""
         awsAMI: ""
         awsSecurityGroups: [""]

--- a/validation/rbac/clusterandprojectroles/README.md
+++ b/validation/rbac/clusterandprojectroles/README.md
@@ -43,7 +43,7 @@ awsMachineConfigs:
  awsMachineConfig:
  - roles: ["etcd","controlplane","worker"]
    ami: "<ami>"
-   instanceType: "t3a.medium"                
+   instanceType: "t3.xlarge"                
    sshUser: "ubuntu"
    vpcId: "<vpc-id>"
    volumeType: "gp2"                         

--- a/validation/rbac/globalroles/README.md
+++ b/validation/rbac/globalroles/README.md
@@ -59,7 +59,7 @@ awsMachineConfigs:
  awsMachineConfig:
  - roles: ["etcd","controlplane","worker"]
    ami: ""
-   instanceType: "t3a.medium"                
+   instanceType: "t3.xlarge"                
    sshUser: "ubuntu"
    vpcId: ""
    volumeType: "gp2"                         

--- a/validation/remotedialerproxy/defaults/defaults.yaml
+++ b/validation/remotedialerproxy/defaults/defaults.yaml
@@ -43,7 +43,7 @@ awsMachineConfigs:
   awsMachineConfig:
   - roles: ["etcd","controlplane","worker"]
     ami: "<required>"
-    instanceType: "t3a.medium"
+    instanceType: "t3.xlarge"
     volumeType: "<required>"
     rootSize: "<required>"
     sshUser: "<required>"
@@ -66,7 +66,7 @@ awsEC2Configs:
   awsSecretAccessKey: "<required>"
   awsAccessKeyID: "<required>"
   awsEC2Config:
-    - instanceType: "t3a.medium"
+    - instanceType: "t3.xlarge"
       awsRegionAZ: ""
       awsAMI: "<required>"
       awsSecurityGroups: ["<required>"]

--- a/validation/snapshot/defaults/defaults.yaml
+++ b/validation/snapshot/defaults/defaults.yaml
@@ -63,7 +63,7 @@ awsEC2Configs:
   awsSecretAccessKey: "<required>"
   awsAccessKeyID: "<required>"
   awsEC2Config:
-    - instanceType: "t3a.medium"
+    - instanceType: "t3.xlarge"
       awsRegionAZ: ""
       awsSSHKeyName: "<required>"
       awsAMI: "<required>"

--- a/validation/upgrade/defaults/defaults.yaml
+++ b/validation/upgrade/defaults/defaults.yaml
@@ -40,7 +40,7 @@ awsMachineConfigs:
   awsMachineConfig:
   - roles: ["etcd","controlplane","worker"]
     ami: "<required>"
-    instanceType: "t3a.medium"
+    instanceType: "t3.xlarge"
     volumeType: "<required>"
     rootSize: "<required>"
     sshUser: "<required>"
@@ -63,7 +63,7 @@ awsEC2Configs:
   awsSecretAccessKey: "<required>"
   awsAccessKeyID: "<required>"
   awsEC2Config:
-    - instanceType: "t3a.medium"
+    - instanceType: "t3.xlarge"
       awsRegionAZ: ""
       awsSSHKeyName: "<required>"
       awsAMI: "<required>"


### PR DESCRIPTION
This PR updates the default `instanceType` values in the relevant `defaults.yaml` files and adjusts the `VerifyClusterReady` function to align with the updated cluster configuration and readiness checks.