### PR TITLE
Fix kubeconfig path inconsistency

### DIFF
--- a/interoperability/qainfraautomation/ansible/ansible.go
+++ b/interoperability/qainfraautomation/ansible/ansible.go
@@ -180,6 +180,7 @@ func (c *Client) GenerateInventoryFromNodes(clusterNodesJSON, distro, env string
 	if err != nil {
 		return "", fmt.Errorf("build inventory: %w", err)
 	}
+	logrus.Infof("Showing inventory file content:\n%s", string(inventoryYAML))
 
 	f, err := os.CreateTemp("", "ansible-inventory-*.yml")
 	if err != nil {

--- a/interoperability/qainfraautomation/provisioning.go
+++ b/interoperability/qainfraautomation/provisioning.go
@@ -728,6 +728,11 @@ func provisionHarvesterStandaloneCluster(
 		t.Fatalf("generate inventory: %v", err)
 	}
 
+	// Defaulting to CWD is too inconsistent so we can set clusterCfg.KubeconfigOutputPath to the playbook dir.
+	if clusterCfg.KubeconfigOutputPath == "" {
+		clusterCfg.KubeconfigOutputPath = filepath.Join(repoPath, filepath.Dir(playbookPath), "kubeconfig.yaml")
+	}
+
 	vars := buildStandaloneVars(clusterCfg)
 	if err := ansibleClient.WriteVarsYAML(varsFile, vars); err != nil {
 		t.Fatalf("write vars.yaml: %v", err)
@@ -748,11 +753,7 @@ func provisionHarvesterStandaloneCluster(
 		t.Fatalf("ansible-playbook (%s): %v", clusterType, err)
 	}
 
-	kubeconfigPath := clusterCfg.KubeconfigOutputPath
-	if kubeconfigPath == "" {
-		kubeconfigPath = filepath.Join(repoPath, filepath.Dir(playbookPath), "kubeconfig.yaml")
-	}
-	return kubeconfigPath
+	return clusterCfg.KubeconfigOutputPath
 }
 
 // ProvisionAWSRKE2Cluster provisions a standalone RKE2 cluster on AWS EC2 instances
@@ -911,11 +912,16 @@ func provisionAWSStandaloneCluster(
 	if err != nil {
 		t.Fatalf("tofu output cluster_nodes_json: %v", err)
 	}
+
 	inventoryPath, err := ansibleClient.GenerateInventoryFromNodes(clusterNodesJSON, clusterType, "default")
 	if err != nil {
 		t.Fatalf("generate inventory: %v", err)
 	}
 
+	// Defaulting to CWD is too inconsistent so we can set clusterCfg.KubeconfigOutputPath to the playbook dir.
+	if clusterCfg.KubeconfigOutputPath == "" {
+		clusterCfg.KubeconfigOutputPath = filepath.Join(repoPath, filepath.Dir(playbookPath), "kubeconfig.yaml")
+	}
 	vars := buildStandaloneVars(clusterCfg)
 	if clusterCfg.ServerFlags != "" {
 		vars["server_flags"] = clusterCfg.ServerFlags
@@ -957,13 +963,8 @@ func provisionAWSStandaloneCluster(
 		logrus.Infof("[qainfraautomation] Route53 FQDN: %s", fqdn)
 	}
 
-	kubeconfigPath := clusterCfg.KubeconfigOutputPath
-	if kubeconfigPath == "" {
-		kubeconfigPath = filepath.Join(repoPath, filepath.Dir(playbookPath), "kubeconfig.yaml")
-	}
-
 	return StandaloneClusterResult{
-		KubeconfigPath: kubeconfigPath,
+		KubeconfigPath: clusterCfg.KubeconfigOutputPath,
 		FQDN:           fqdn,
 	}
 }

--- a/interoperability/qainfraautomation/provisioning.go
+++ b/interoperability/qainfraautomation/provisioning.go
@@ -1278,6 +1278,7 @@ func buildStandaloneVars(clusterCfg *config.StandaloneClusterConfig) map[string]
 			absPath = "kubeconfig.yaml"
 		}
 		vars["kubeconfig_file"] = absPath
+		clusterCfg.KubeconfigOutputPath = absPath
 	}
 	return vars
 }

--- a/validation/pipeline/rancherha/install/rancher_ha_install_test.go
+++ b/validation/pipeline/rancherha/install/rancher_ha_install_test.go
@@ -74,32 +74,24 @@ func (s *RancherHAInstallTestSuite) provisionCluster() qainfraautomation.Standal
 	k8sVersion := s.infraCfg.StandaloneCluster.KubernetesVersion
 	require.NotEmpty(s.T(), k8sVersion, "qaInfraAutomation.standaloneCluster.kubernetesVersion is required")
 
-	var clusterType string
+	var provisionFunction func(t *testing.T, cfg *qaconfig.Config, clusterCfg *qaconfig.StandaloneClusterConfig) qainfraautomation.StandaloneClusterResult
 	switch {
 	case strings.Contains(k8sVersion, "+k3s"):
-		clusterType = "k3s"
+		logrus.Info("[rancherha] provisioning AWS K3s standalone cluster")
+		provisionFunction = qainfraautomation.ProvisionAWSK3SCluster
 	case strings.Contains(k8sVersion, "+rke2"):
-		clusterType = "rke2"
+		logrus.Info("[rancherha] provisioning AWS RKE2 standalone cluster")
+		provisionFunction = qainfraautomation.ProvisionAWSRKE2Cluster
 	default:
 		s.T().Fatalf("cannot determine cluster type from kubernetesVersion %q: must contain +k3s or +rke2", k8sVersion)
 	}
 
-	switch clusterType {
-	case "rke2":
-		logrus.Info("[rancherha] provisioning AWS RKE2 standalone cluster")
-		return qainfraautomation.ProvisionAWSRKE2Cluster(
-			s.T(),
-			s.infraCfg,
-			s.infraCfg.StandaloneCluster,
-		)
-	default:
-		logrus.Info("[rancherha] provisioning AWS K3s standalone cluster")
-		return qainfraautomation.ProvisionAWSK3SCluster(
-			s.T(),
-			s.infraCfg,
-			s.infraCfg.StandaloneCluster,
-		)
-	}
+	logrus.Info("[rancherha] provisioning AWS RKE2 standalone cluster")
+	return provisionFunction(
+		s.T(),
+		s.infraCfg,
+		s.infraCfg.StandaloneCluster,
+	)
 }
 
 func (s *RancherHAInstallTestSuite) TestInstallRancherHA() {


### PR DESCRIPTION
This has the main goal of fixing an issue where the kubeconfig path was inconsistent depending on the CWD of the running test process, as `absPath, err := filepath.Abs("kubeconfig.yaml")` in https://github.com/rancher/tests/blob/main/interoperability/qainfraautomation/provisioning.go#L1275 doesn't always align with `filepath.Join(repoPath, filepath.Dir(playbookPath), "kubeconfig.yaml")` in https://github.com/rancher/tests/blob/main/interoperability/qainfraautomation/provisioning.go#L753

To fix this, this introduces the philosophy that `clusterCfg.KubernetesVersion` should reflect the current kubeconfig location even if it wasn't set by the user initially and using it to enforce a consistent location throughout the execution of `provisionAWSStandaloneCluster` and `provisionHarvesterStandaloneCluster`.