### PR TITLE
Remove IPv6 cluster provisioning scheduled run for v2.14 release line

### DIFF
--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -795,7 +795,6 @@ jobs:
   
   v2-14:
     if: |
-      github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
     name: ${{ github.event.inputs.rancher_version }}


### PR DESCRIPTION
## Summary
This PR removes the scheduled IPv6 cluster provisioning run for the v2.14 release line.
## Details
It updates the relevant release-line scheduling configuration so this IPv6 cluster provisioning run is no longer included for v2.14.