### PR TITLE
Port sanity testing workflows from rancher/tfp-automation to rancher/tests

### DIFF
--- a/.github/actions/check-rancher-tag-result/action.yaml
+++ b/.github/actions/check-rancher-tag-result/action.yaml
@@ -67,8 +67,11 @@ runs:
           local release_line=""
 
           case "$TAG" in
+            v2.11*)
+              release_line="v2.11"
+              ;;
             v2.12*)
-              return 1
+              release_line="v2.12"
               ;;
             v2.13*)
               release_line="v2.13"
@@ -98,7 +101,7 @@ runs:
           fi
 
           if [[ "$TAG" == *-rc* ]]; then
-            workflow_contains "$workflow_path" "&& contains(github.event.inputs.rancher_version, '-rc')" || workflow_contains "$workflow_path" "&& (contains(github.event.inputs.rancher_version, '-rc')" || workflow_contains "$workflow_path" "&& contains(inputs.rancher_version, '-rc')" || workflow_contains "$workflow_path" "&& (contains(inputs.rancher_version, '-rc')"
+            workflow_contains "$workflow_path" "&& contains(github.event.inputs.rancher_version, '-rc')" || workflow_contains "$workflow_path" "&& (contains(github.event.inputs.rancher_version, '-rc')" || workflow_contains "$workflow_path" "&& contains(inputs.rancher_version, '-rc')" || workflow_contains "$workflow_path" "&& (contains(inputs.rancher_version, '-rc')" || workflow_contains "$workflow_path" "|| contains(github.event.inputs.rancher_version, '-rc')" || workflow_contains "$workflow_path" "|| contains(inputs.rancher_version, '-rc')"
             return $?
           fi
 

--- a/.github/actions/get-latest-rancher-tag/action.yaml
+++ b/.github/actions/get-latest-rancher-tag/action.yaml
@@ -69,13 +69,14 @@ runs:
             if [ "$ASSET_COUNT" -lt 17 ]; then
               echo "Asset count: $ASSET_COUNT. Expected at least 17 assets..."
               LATEST_VERSION=""
-            else
-              echo "Checking for Prime artifacts for $LATEST_VERSION..."
-              curl -sf ${{ inputs.prime_artifacts_path }}/$LATEST_VERSION/rancher-images.txt > /dev/null
-              if [[ $? -ne 0 ]]; then
-                echo "Unable to reach: ${{ inputs.prime_artifacts_path }}/$LATEST_VERSION/rancher-images.txt"
-                LATEST_VERSION=""
-              fi
+            # Uncomment once v2.15 prime artifacts are available
+            # else
+            #   echo "Checking for Prime artifacts for $LATEST_VERSION..."
+            #   curl -sf ${{ inputs.prime_artifacts_path }}/$LATEST_VERSION/rancher-images.txt > /dev/null
+            #   if [[ $? -ne 0 ]]; then
+            #     echo "Unable to reach: ${{ inputs.prime_artifacts_path }}/$LATEST_VERSION/rancher-images.txt"
+            #     LATEST_VERSION=""
+            #   fi
             fi
           else
             RELEASE_JSON=$(curl -s ${{ inputs.prime_artifacts_path }}/$RELEASE_LINE/rancher-images.txt)

--- a/.github/config/dispatch-workflows.txt
+++ b/.github/config/dispatch-workflows.txt
@@ -4,7 +4,10 @@ day2-ops-rancher.yml
 day2-ops-rancher-prime.yml
 day2-ops-upgraded-rancher.yml
 cluster-provisioning.yml
+hb-sanity.yml
+hb-sanity-upgrade.yml
 post-release-prime.yml
 rancher-upgrade-cluster-provisioning.yml
 rancher-upgrade-airgap-cluster-provisioning.yml
 registries-cluster-provisioning.yml
+turtles-feature-off-cluster-provisioning.yml

--- a/.github/workflows/airgap-cluster-provisioning.yml
+++ b/.github/workflows/airgap-cluster-provisioning.yml
@@ -8,11 +8,6 @@ on:
         description: "Rancher tag version"
       rancher_chart_version:
         description: "Rancher chart version"
-      run_all_versions:
-        description: "Run all supported versions if manually triggered"
-        required: false
-        default: false
-        type: boolean
       reporting:
         description: "Enable reporting to Qase and Slack"
         required: false
@@ -52,7 +47,6 @@ env:
 jobs:
   v2-15:
     if: |
-      github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && contains(github.event.inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
@@ -141,8 +135,7 @@ jobs:
           value: |
             ${{
               github.event.inputs.rancher_version ||
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
       - name: Set Rancher chart version
@@ -152,8 +145,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
       - name: Set Rancher repo
@@ -260,6 +252,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -375,7 +368,6 @@ jobs:
 
   v2-14:
     if: |
-      github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && contains(github.event.inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
@@ -464,8 +456,7 @@ jobs:
           value: |
             ${{
               github.event.inputs.rancher_version ||
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
       - name: Set Rancher chart version
@@ -475,8 +466,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
       - name: Set Rancher repo
@@ -584,6 +574,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -699,7 +690,6 @@ jobs:
 
   v2-13:
     if: |
-      github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && contains(github.event.inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
@@ -788,8 +778,7 @@ jobs:
           value: |
             ${{
               github.event.inputs.rancher_version ||
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
       - name: Set Rancher chart version
@@ -799,8 +788,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
       - name: Set Rancher repo
@@ -908,6 +896,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"

--- a/.github/workflows/arm64-cluster-provisioning.yml
+++ b/.github/workflows/arm64-cluster-provisioning.yml
@@ -1,9 +1,9 @@
 ---
-name: Upgraded Rancher Proxy Cluster Provisioning
+name: ARM64 Cluster Provisioning
 
 on:
   schedule:
-    - cron: "0 10 * * 5"
+    - cron: "0 7 * * 3"
   workflow_dispatch:
     inputs:
       rancher_version:
@@ -60,10 +60,10 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: upgrade-community-head
+    environment: head
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_16 }}"
-      HOSTNAME_PREFIX: "ghap-up-216"
+      HOSTNAME_PREFIX: "arm64-216"
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
@@ -144,10 +144,10 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
@@ -156,26 +156,25 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_16_HEAD)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) || 
               (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: false
           release-community-version: "2.16"
-          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -185,15 +184,14 @@ jobs:
           qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_16 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_16 }}
 
-      - name: Set upgraded Rancher chart url
+      - name: Set Rancher chart url
         uses: ./.github/actions/set-rancher-chart-url
         with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          rancher-repo: ${{ env.RANCHER_REPO }}
           is-prime: false
           community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
           staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -209,19 +207,18 @@ jobs:
             enableNetworkPolicy: false
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
             awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
+              ami: "${{ secrets.AWS_ARM_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsInstanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
@@ -246,23 +243,18 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_16 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
               registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+              repo: "${{ env.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_16 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
@@ -273,13 +265,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -306,14 +291,16 @@ jobs:
             region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
-              ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              ami: "${{ secrets.AWS_ARM_AMI }}"
+              instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
             region: "${{ vars.AWS_REGION }}"
@@ -321,11 +308,11 @@ jobs:
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsAMI: "${{ secrets.AWS_ARM_AMI }}"
+                instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ vars.AWS_USER }}"
@@ -335,23 +322,14 @@ jobs:
                 awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -376,7 +354,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -388,13 +366,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: sanity
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -441,22 +419,22 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
         if: always() && github.event_name == 'schedule'
         run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-16\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"arm64-cluster-provisioning\", \"job\": \"v2-16\" }" > test-result-arm64-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
         if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          name: test-result-arm64-cluster-provisioning-v2-16-${{ github.run_id }}
+          path: test-result-arm64-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
   
   v2-15:
     if: |
@@ -465,10 +443,10 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: upgrade-community-head
+    environment: head
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
-      HOSTNAME_PREFIX: "ghap-up-215"
+      HOSTNAME_PREFIX: "arm64-215"
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
@@ -549,10 +527,10 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
@@ -561,26 +539,25 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_15_HEAD)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) || 
               (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: false
           release-community-version: "2.15"
-          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -590,15 +567,14 @@ jobs:
           qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_15 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_15 }}
 
-      - name: Set upgraded Rancher chart url
+      - name: Set Rancher chart url
         uses: ./.github/actions/set-rancher-chart-url
         with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          rancher-repo: ${{ env.RANCHER_REPO }}
           is-prime: false
           community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
           staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -614,19 +590,18 @@ jobs:
             enableNetworkPolicy: false
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
             awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
+              ami: "${{ secrets.AWS_ARM_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsInstanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
@@ -651,23 +626,18 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
               registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
+              repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
@@ -678,13 +648,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -711,14 +674,16 @@ jobs:
             region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
-              ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              ami: "${{ secrets.AWS_ARM_AMI }}"
+              instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
             region: "${{ vars.AWS_REGION }}"
@@ -726,11 +691,11 @@ jobs:
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsAMI: "${{ secrets.AWS_ARM_AMI }}"
+                instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ vars.AWS_USER }}"
@@ -740,23 +705,14 @@ jobs:
                 awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -781,7 +737,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -793,13 +749,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: sanity
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -846,34 +802,34 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
         if: always() && github.event_name == 'schedule'
         run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-15\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"arm64-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-arm64-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
         if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-  
+          name: test-result-arm64-cluster-provisioning-v2-15-${{ github.run_id }}
+          path: test-result-arm64-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+
   v2-14:
     if: |
       github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: upgrade-prime-staging
+    environment: staging-latest
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
-      HOSTNAME_PREFIX: "ghap-up-214"
+      HOSTNAME_PREFIX: "arm64-214"
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
@@ -954,10 +910,10 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
@@ -966,26 +922,25 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_14_HEAD)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) || 
               (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_14) ||
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_14)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: true
           release-prime-version: "2.14"
-          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -995,15 +950,14 @@ jobs:
           qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_14 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_14 }}
 
-      - name: Set upgraded Rancher chart url
+      - name: Set Rancher chart url
         uses: ./.github/actions/set-rancher-chart-url
         with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          rancher-repo: ${{ env.RANCHER_REPO }}
           is-prime: true
           community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
           staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -1019,19 +973,18 @@ jobs:
             enableNetworkPolicy: false
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
             awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
+              ami: "${{ secrets.AWS_ARM_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsInstanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
@@ -1056,24 +1009,19 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_14 }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
               registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
+              repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
@@ -1084,13 +1032,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -1117,14 +1058,16 @@ jobs:
             region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
-              ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              ami: "${{ secrets.AWS_ARM_AMI }}"
+              instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
             region: "${{ vars.AWS_REGION }}"
@@ -1132,11 +1075,11 @@ jobs:
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsAMI: "${{ secrets.AWS_ARM_AMI }}"
+                instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ vars.AWS_USER }}"
@@ -1146,23 +1089,14 @@ jobs:
                 awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1187,7 +1121,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -1199,13 +1133,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: sanity
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -1252,424 +1186,19 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
         if: always() && github.event_name == 'schedule'
         run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-14\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"arm64-cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-arm64-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
         if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-
-  v2-13:
-    if: |
-      github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13'))
-    name: ${{ github.event.inputs.rancher_version }}
-    runs-on: ubuntu-latest
-    environment: upgrade-prime-staging
-    env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_13 }}"
-      HOSTNAME_PREFIX: "ghap-up-213"
-      REPORTING_ENABLED: >-
-        ${{
-          github.event_name == 'schedule' ||
-          github.event_name == 'workflow_call' ||
-          github.actor == 'github-actions[bot]' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
-        }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          submodules: recursive
-
-      - name: Checkout tfp-automation repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: rancher/tfp-automation
-          path: tfp-automation
-
-      - name: Set up local rancher2 Terraform provider
-        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
-        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
-        with:
-          version: "latest"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: "Fetch and Set DockerHub Credentials"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
-
-      - name: Mask Dockerhub Credentials
-        run: |
-          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
-          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Set up certificates
-        id: setup-certs
-        uses: ./.github/actions/setup-certs
-        with:
-          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
-          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
-          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
-          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
-              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_13_HEAD) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_13_HEAD)
-            }}
-
-      - name: Set upgraded Rancher chart version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_CHART_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_13) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_13)
-            }}
-
-      - name: Set upgraded Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          is-prime: true
-          release-prime-version: "2.13"
-          env-var-name: UPGRADED_RANCHER_REPO
-
-      - name: Get Qase ID
-        id: get-qase-id
-        uses: ./.github/actions/get-qase-id
-        with:
-          triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
-          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
-
-      - name: Set upgraded Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
-          is-prime: true
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-            cleanup: true
-          terraform:
-            cni: "${{ vars.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
-            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
-            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ vars.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
-              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
-              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
-              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
-              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
-              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_13 }}"
-              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
-              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ vars.CNI }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
-            registries:
-              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
-              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
-              rke2Registries:
-                mirrors:
-                  "docker.io":
-                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
-                configs:
-                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
-                    "auth":
-                      username: "${{ env.DOCKERHUB_USERNAME }}"
-                      password: "${{ env.DOCKERHUB_PASSWORD }}"
-                    insecureSkipVerify: true
-
-          logging:
-            level: "${{ vars.LOGGING_LEVEL }}"
-          
-          awsCredentials:
-            secretKey: "$AWS_SECRET_KEY"
-            accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ vars.AWS_REGION }}"
-
-          awsMachineConfigs:
-            region: "${{ vars.AWS_REGION }}"
-            awsMachineConfig:
-            - roles: ["etcd", "controlplane", "worker"]
-              ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              sshUser: "${{ vars.AWS_USER }}"
-              vpcId: "${{ secrets.AWS_VPC_ID }}"
-              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              zone: "${{ vars.AWS_ZONE_LETTER }}"
-              retries: "5"
-              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-
-          awsEC2Configs:
-            region: "${{ vars.AWS_REGION }}"
-            awsSecretAccessKey: "$AWS_SECRET_KEY"
-            awsAccessKeyID: "$AWS_ACCESS_KEY"
-            awsEC2Config:
-              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ vars.AWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["etcd", "controlplane", "worker"]
-              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["windows"]
-          sshPath: 
-            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/go-build.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
-
-      - name: Run Provisioning tests
-        env:
-          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-provisioning
-        with:
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
-          run_ace: "false"
-          run_template: "false"
-
-      - name: Cleanup Infrastructure
-        if: always()
-        working-directory: tfp-automation/modules/proxy/aws
-        run: terraform destroy -auto-approve > /dev/null 2>&1
-
-      - name: Refresh AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: AWS Custodian Infrastructure Cleanup
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: AWS Custodian Downstream Cleanup - Node driver
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: AWS Custodian Downstream Cleanup - Custom
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set job status output
-        if: always()
-        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
-        id: set-job-status
-
-      - name: Reporting Results to Slack
-        if: always() && env.REPORTING_ENABLED == 'true'
-        uses: ./.github/actions/report-to-slack
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          job-status: ${{ steps.set-job-status.outputs.job_status }}
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Save test result as artifact for weekly summary
-        if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-13\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
-        with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          name: test-result-arm64-cluster-provisioning-v2-14-${{ github.run_id }}
+          path: test-result-arm64-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json

--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -174,7 +174,7 @@ jobs:
           rancher-version: ${{ env.RANCHER_VERSION }}
           fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: false
-          release-community-version: "2.15"
+          release-community-version: "2.16"
 
       - name: Get Qase ID
         id: get-qase-id
@@ -292,6 +292,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -308,6 +309,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -681,6 +683,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -697,6 +700,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1071,6 +1075,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1087,6 +1092,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1460,6 +1466,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1476,6 +1483,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"

--- a/.github/workflows/day2-ops-capi-pnp.yml
+++ b/.github/workflows/day2-ops-capi-pnp.yml
@@ -268,6 +268,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -619,6 +620,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"

--- a/.github/workflows/day2-ops-ipv6-rancher.yml
+++ b/.github/workflows/day2-ops-ipv6-rancher.yml
@@ -292,6 +292,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -666,6 +667,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1040,6 +1042,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1414,6 +1417,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"

--- a/.github/workflows/day2-ops-proxy-rancher.yml
+++ b/.github/workflows/day2-ops-proxy-rancher.yml
@@ -287,6 +287,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -303,6 +304,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -313,6 +315,7 @@ jobs:
                 roles: ["etcd", "controlplane", "worker"]
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
@@ -672,6 +675,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -688,6 +692,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -698,6 +703,7 @@ jobs:
                 roles: ["etcd", "controlplane", "worker"]
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1058,6 +1064,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1074,6 +1081,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1084,6 +1092,7 @@ jobs:
                 roles: ["etcd", "controlplane", "worker"]
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1443,6 +1452,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1459,6 +1469,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1469,6 +1480,7 @@ jobs:
                 roles: ["etcd", "controlplane", "worker"]
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"

--- a/.github/workflows/day2-ops-rancher.yml
+++ b/.github/workflows/day2-ops-rancher.yml
@@ -278,6 +278,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -294,6 +295,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -304,6 +306,7 @@ jobs:
                 roles: ["etcd", "controlplane", "worker"]
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
@@ -655,6 +658,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -671,6 +675,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -681,6 +686,7 @@ jobs:
                 roles: ["etcd", "controlplane", "worker"]
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1033,6 +1039,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1049,6 +1056,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1059,6 +1067,7 @@ jobs:
                 roles: ["etcd", "controlplane", "worker"]
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1410,6 +1419,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1426,6 +1436,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1436,6 +1447,7 @@ jobs:
                 roles: ["etcd", "controlplane", "worker"]
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"

--- a/.github/workflows/day2-ops-upgraded-rancher.yml
+++ b/.github/workflows/day2-ops-upgraded-rancher.yml
@@ -295,6 +295,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -311,6 +312,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -321,6 +323,7 @@ jobs:
                 roles: ["etcd", "controlplane", "worker"]
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
@@ -688,6 +691,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -704,6 +708,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -714,6 +719,7 @@ jobs:
                 roles: ["etcd", "controlplane", "worker"]
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1083,6 +1089,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1099,6 +1106,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1109,6 +1117,7 @@ jobs:
                 roles: ["etcd", "controlplane", "worker"]
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1477,6 +1486,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1493,6 +1503,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1503,6 +1514,7 @@ jobs:
                 roles: ["etcd", "controlplane", "worker"]
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -306,6 +306,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -675,6 +676,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1044,6 +1046,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1413,6 +1416,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -291,6 +291,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -307,6 +308,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -661,6 +663,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -677,6 +680,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1029,6 +1033,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1045,6 +1050,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1397,6 +1403,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1413,6 +1420,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"

--- a/.github/workflows/hb-sanity-upgrade.yml
+++ b/.github/workflows/hb-sanity-upgrade.yml
@@ -1,20 +1,13 @@
 ---
-name: Upgraded Rancher Proxy Cluster Provisioning
+name: Hostbusters Sanity - Upgraded Rancher Cluster Provisioning
 
 on:
-  schedule:
-    - cron: "0 10 * * 5"
   workflow_dispatch:
     inputs:
       rancher_version:
         description: "Rancher tag version"
       rancher_chart_version:
         description: "Rancher chart version"
-      run_all_versions:
-        description: "Run all supported versions if manually triggered"
-        required: false
-        default: false
-        type: boolean
       reporting:
         description: "Enable reporting to Qase and Slack"
         required: false
@@ -52,426 +45,19 @@ env:
     }}
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
 
-jobs:
-  v2-16:
-    if: |
-      github.event_name == 'schedule' ||
-      github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
-    name: ${{ github.event.inputs.rancher_version }}
-    runs-on: ubuntu-latest
-    environment: upgrade-community-head
-    env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_16 }}"
-      HOSTNAME_PREFIX: "ghap-up-216"
-      REPORTING_ENABLED: >-
-        ${{
-          github.event_name == 'schedule' ||
-          github.event_name == 'workflow_call' ||
-          github.actor == 'github-actions[bot]' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
-        }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          submodules: recursive
-
-      - name: Checkout tfp-automation repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: rancher/tfp-automation
-          path: tfp-automation
-
-      - name: Set up local rancher2 Terraform provider
-        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
-        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
-        with:
-          version: "latest"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: "Fetch and Set DockerHub Credentials"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
-
-      - name: Mask Dockerhub Credentials
-        run: |
-          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
-          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Set up certificates
-        id: setup-certs
-        uses: ./.github/actions/setup-certs
-        with:
-          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
-          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
-          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
-          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
-              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_16_HEAD) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_16_HEAD)
-            }}
-
-      - name: Set upgraded Rancher chart version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_CHART_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
-            }}
-
-      - name: Set upgraded Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          is-prime: false
-          release-community-version: "2.16"
-          env-var-name: UPGRADED_RANCHER_REPO
-
-      - name: Get Qase ID
-        id: get-qase-id
-        uses: ./.github/actions/get-qase-id
-        with:
-          triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_16 }}
-          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_16 }}
-
-      - name: Set upgraded Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
-          is-prime: false
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-            cleanup: true
-          terraform:
-            cni: "${{ vars.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
-            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
-            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ vars.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
-              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
-              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
-              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
-              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
-              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
-              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
-              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ vars.CNI }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
-            registries:
-              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
-              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
-              rke2Registries:
-                mirrors:
-                  "docker.io":
-                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
-                configs:
-                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
-                    "auth":
-                      username: "${{ env.DOCKERHUB_USERNAME }}"
-                      password: "${{ env.DOCKERHUB_PASSWORD }}"
-                    insecureSkipVerify: true
-
-          logging:
-            level: "${{ vars.LOGGING_LEVEL }}"
-          
-          awsCredentials:
-            secretKey: "$AWS_SECRET_KEY"
-            accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ vars.AWS_REGION }}"
-
-          awsMachineConfigs:
-            region: "${{ vars.AWS_REGION }}"
-            awsMachineConfig:
-            - roles: ["etcd", "controlplane", "worker"]
-              ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              sshUser: "${{ vars.AWS_USER }}"
-              vpcId: "${{ secrets.AWS_VPC_ID }}"
-              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              zone: "${{ vars.AWS_ZONE_LETTER }}"
-              retries: "5"
-              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-
-          awsEC2Configs:
-            region: "${{ vars.AWS_REGION }}"
-            awsSecretAccessKey: "$AWS_SECRET_KEY"
-            awsAccessKeyID: "$AWS_ACCESS_KEY"
-            awsEC2Config:
-              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ vars.AWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["etcd", "controlplane", "worker"]
-              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["windows"]
-          sshPath: 
-            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/go-build.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
-
-      - name: Run Provisioning tests
-        env:
-          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-provisioning
-        with:
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
-          run_ace: "false"
-          run_template: "false"
-
-      - name: Cleanup Infrastructure
-        if: always()
-        working-directory: tfp-automation/modules/proxy/aws
-        run: terraform destroy -auto-approve > /dev/null 2>&1
-
-      - name: Refresh AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: AWS Custodian Infrastructure Cleanup
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: AWS Custodian Downstream Cleanup - Node driver
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: AWS Custodian Downstream Cleanup - Custom
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set job status output
-        if: always()
-        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
-        id: set-job-status
-
-      - name: Reporting Results to Slack
-        if: always() && env.REPORTING_ENABLED == 'true'
-        uses: ./.github/actions/report-to-slack
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          job-status: ${{ steps.set-job-status.outputs.job_status }}
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Save test result as artifact for weekly summary
-        if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-16\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
-        with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-  
+jobs: 
   v2-15:
     if: |
-      github.event_name == 'schedule' ||
-      github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15-head'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && (contains(github.event.inputs.rancher_version, '-rc')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && (contains(inputs.rancher_version, '-rc'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: upgrade-community-head
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
-      HOSTNAME_PREFIX: "ghap-up-215"
+      HOSTNAME_PREFIX: "san-up-215"
       REPORTING_ENABLED: >-
         ${{
-          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -556,9 +142,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
-              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_15_HEAD) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_15_HEAD)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
       - name: Set upgraded Rancher chart version
@@ -568,9 +152,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
       - name: Set upgraded Rancher repo
@@ -614,12 +196,11 @@ jobs:
             enableNetworkPolicy: false
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -659,8 +240,8 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
-              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
-              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
               upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
@@ -678,13 +259,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -748,15 +322,6 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -781,7 +346,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -793,13 +358,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: sanity
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -850,33 +415,18 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
-        if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-15\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
-        with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-  
   v2-14:
     if: |
-      github.event_name == 'schedule' ||
-      github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && (contains(github.event.inputs.rancher_version, '-rc')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && (contains(inputs.rancher_version, '-rc'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
-      HOSTNAME_PREFIX: "ghap-up-214"
+      HOSTNAME_PREFIX: "san-up-214"
       REPORTING_ENABLED: >-
         ${{
-          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -961,9 +511,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
-              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_14_HEAD) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_14_HEAD)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
       - name: Set upgraded Rancher chart version
@@ -973,9 +521,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_14) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_14)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
       - name: Set upgraded Rancher repo
@@ -1019,12 +565,11 @@ jobs:
             enableNetworkPolicy: false
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -1064,8 +609,8 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_14 }}"
-              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
-              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
@@ -1084,13 +629,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -1154,15 +692,6 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1187,7 +716,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -1199,13 +728,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: sanity
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -1255,33 +784,19 @@ jobs:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Save test result as artifact for weekly summary
-        if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-14\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
-        with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-
+  
   v2-13:
     if: |
-      github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && (contains(github.event.inputs.rancher_version, '-rc')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && (contains(inputs.rancher_version, '-rc'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_13 }}"
-      HOSTNAME_PREFIX: "ghap-up-213"
+      HOSTNAME_PREFIX: "san-up-213"
       REPORTING_ENABLED: >-
         ${{
-          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -1366,9 +881,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
-              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_13_HEAD) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_13_HEAD)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
       - name: Set upgraded Rancher chart version
@@ -1378,9 +891,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_13) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_13)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
       - name: Set upgraded Rancher repo
@@ -1422,14 +933,14 @@ jobs:
             cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            generateV3Token: true
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -1469,8 +980,8 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_13 }}"
-              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
-              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
@@ -1489,13 +1000,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -1559,15 +1063,6 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1592,7 +1087,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -1604,13 +1099,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: sanity
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -1661,15 +1156,742 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
-        if: always() && github.event_name == 'schedule'
+  v2-12:
+    if: |
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && (contains(github.event.inputs.rancher_version, '-rc')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12')) && (contains(inputs.rancher_version, '-rc'))
+    name: ${{ github.event.inputs.rancher_version }}
+    runs-on: ubuntu-latest
+    environment: upgrade-prime-staging
+    env:
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_12 }}"
+      HOSTNAME_PREFIX: "san-up-212"
+      REPORTING_ENABLED: >-
+        ${{
+          github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
+        }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          submodules: recursive
+
+      - name: Checkout tfp-automation repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          repository: rancher/tfp-automation
+          path: tfp-automation
+
+      - name: Set up local rancher2 Terraform provider
+        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
+        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
+        with:
+          version: "latest"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: "Fetch and Set DockerHub Credentials"
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Mask Dockerhub Credentials
         run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-13\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
+          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Set up certificates
+        id: setup-certs
+        uses: ./.github/actions/setup-certs
+        with:
+          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
+          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
+          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
+          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set upgraded Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
+            }}
+
+      - name: Set upgraded Rancher chart version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_CHART_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
+            }}
+
+      - name: Set upgraded Rancher repo
+        uses: ./.github/actions/set-rancher-repo
+        with:
+          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          is-prime: true
+          release-prime-version: "2.12"
+          env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_12 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_12 }}
+
+      - name: Set upgraded Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          is-prime: true
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
+          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+            cleanup: true
+          terraform:
+            cni: "${{ vars.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
+            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
+            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ vars.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ vars.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
+              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
+              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
+              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
+              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_12 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_12 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_12 }}"
+              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_12 }}"
+              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
+              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
+
+          clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            nodeProvider: "ec2"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+
+          awsEC2Configs:
+            region: "${{ vars.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsCICDInstanceTag: "rancher-validation"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
+                awsUser: "${{ vars.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsCICDInstanceTag: "rancher-validation"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["windows"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
         shell: bash
 
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+      - name: Set up Go environment
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/go-build.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/standard/main.go
+
+      - name: Run Provisioning tests
+        env:
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
+          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
+          QASE_CUSTOM_FIELD_FILTER: Hostbusters
+          QASE_SCHEMA_PREFIX: hostbusters
+          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        uses: ./.github/actions/run-hostbusters-provisioning
+        with:
+          reporting: ${{ env.REPORTING_ENABLED }}
+          tags: sanity
+          run_ace: "false"
+          run_template: "false"
+
+      - name: Cleanup Infrastructure
+        if: always()
+        working-directory: tfp-automation/modules/sanity/aws
+        run: terraform destroy -auto-approve > /dev/null 2>&1
+
+      - name: Refresh AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: AWS Custodian Infrastructure Cleanup
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set job status output
+        if: always()
+        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
+        id: set-job-status
+
+      - name: Reporting Results to Slack
+        if: always() && env.REPORTING_ENABLED == 'true'
+        uses: ./.github/actions/report-to-slack
+        with:
+          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          job-status: ${{ steps.set-job-status.outputs.job_status }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  v2-11:
+    if: |
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && (contains(github.event.inputs.rancher_version, '-rc')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11')) && (contains(inputs.rancher_version, '-rc'))
+    name: ${{ github.event.inputs.rancher_version }}
+    runs-on: ubuntu-latest
+    environment: upgrade-prime-staging
+    env:
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
+      HOSTNAME_PREFIX: "san-up-211"
+      REPORTING_ENABLED: >-
+        ${{
+          github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
+        }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          submodules: recursive
+
+      - name: Checkout tfp-automation repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          repository: rancher/tfp-automation
+          path: tfp-automation
+
+      - name: Set up local rancher2 Terraform provider
+        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
+        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
+        with:
+          version: "latest"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: "Fetch and Set DockerHub Credentials"
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Mask Dockerhub Credentials
+        run: |
+          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
+          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Set up certificates
+        id: setup-certs
+        uses: ./.github/actions/setup-certs
+        with:
+          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
+          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
+          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
+          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set upgraded Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
+            }}
+
+      - name: Set upgraded Rancher chart version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_CHART_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
+            }}
+
+      - name: Set upgraded Rancher repo
+        uses: ./.github/actions/set-rancher-repo
+        with:
+          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          is-prime: true
+          release-prime-version: "2.11"
+          env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_11 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_11 }}
+
+      - name: Set upgraded Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          is-prime: true
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
+          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+            cleanup: true
+          terraform:
+            cni: "${{ vars.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
+            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
+            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ vars.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ vars.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
+              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
+              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
+              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
+              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_11 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_11 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_11 }}"
+              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
+              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
+              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
+
+          clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            nodeProvider: "ec2"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+
+          awsEC2Configs:
+            region: "${{ vars.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsCICDInstanceTag: "rancher-validation"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
+                awsUser: "${{ vars.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsCICDInstanceTag: "rancher-validation"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["windows"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/go-build.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/standard/main.go
+
+      - name: Run Provisioning tests
+        env:
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
+          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
+          QASE_CUSTOM_FIELD_FILTER: Hostbusters
+          QASE_SCHEMA_PREFIX: hostbusters
+          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        uses: ./.github/actions/run-hostbusters-provisioning
+        with:
+          reporting: ${{ env.REPORTING_ENABLED }}
+          tags: sanity
+          run_ace: "false"
+          run_template: "false"
+
+      - name: Cleanup Infrastructure
+        if: always()
+        working-directory: tfp-automation/modules/sanity/aws
+        run: terraform destroy -auto-approve > /dev/null 2>&1
+
+      - name: Refresh AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: AWS Custodian Infrastructure Cleanup
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set job status output
+        if: always()
+        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
+        id: set-job-status
+
+      - name: Reporting Results to Slack
+        if: always() && env.REPORTING_ENABLED == 'true'
+        uses: ./.github/actions/report-to-slack
+        with:
+          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          job-status: ${{ steps.set-job-status.outputs.job_status }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/hb-sanity.yml
+++ b/.github/workflows/hb-sanity.yml
@@ -1,20 +1,13 @@
 ---
-name: Upgraded Rancher Proxy Cluster Provisioning
+name: Hostbusters Sanity - Cluster Provisioning
 
 on:
-  schedule:
-    - cron: "0 10 * * 5"
   workflow_dispatch:
     inputs:
       rancher_version:
         description: "Rancher tag version"
       rancher_chart_version:
         description: "Rancher chart version"
-      run_all_versions:
-        description: "Run all supported versions if manually triggered"
-        required: false
-        default: false
-        type: boolean
       reporting:
         description: "Enable reporting to Qase and Slack"
         required: false
@@ -52,426 +45,19 @@ env:
     }}
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
 
-jobs:
-  v2-16:
-    if: |
-      github.event_name == 'schedule' ||
-      github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
-    name: ${{ github.event.inputs.rancher_version }}
-    runs-on: ubuntu-latest
-    environment: upgrade-community-head
-    env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_16 }}"
-      HOSTNAME_PREFIX: "ghap-up-216"
-      REPORTING_ENABLED: >-
-        ${{
-          github.event_name == 'schedule' ||
-          github.event_name == 'workflow_call' ||
-          github.actor == 'github-actions[bot]' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
-        }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          submodules: recursive
-
-      - name: Checkout tfp-automation repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: rancher/tfp-automation
-          path: tfp-automation
-
-      - name: Set up local rancher2 Terraform provider
-        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
-        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
-        with:
-          version: "latest"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: "Fetch and Set DockerHub Credentials"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
-
-      - name: Mask Dockerhub Credentials
-        run: |
-          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
-          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Set up certificates
-        id: setup-certs
-        uses: ./.github/actions/setup-certs
-        with:
-          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
-          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
-          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
-          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
-              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_16_HEAD) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_16_HEAD)
-            }}
-
-      - name: Set upgraded Rancher chart version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_CHART_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
-            }}
-
-      - name: Set upgraded Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          is-prime: false
-          release-community-version: "2.16"
-          env-var-name: UPGRADED_RANCHER_REPO
-
-      - name: Get Qase ID
-        id: get-qase-id
-        uses: ./.github/actions/get-qase-id
-        with:
-          triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_16 }}
-          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_16 }}
-
-      - name: Set upgraded Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
-          is-prime: false
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-            cleanup: true
-          terraform:
-            cni: "${{ vars.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
-            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
-            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ vars.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
-              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
-              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
-              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
-              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
-              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
-              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
-              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ vars.CNI }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
-            registries:
-              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
-              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
-              rke2Registries:
-                mirrors:
-                  "docker.io":
-                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
-                configs:
-                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
-                    "auth":
-                      username: "${{ env.DOCKERHUB_USERNAME }}"
-                      password: "${{ env.DOCKERHUB_PASSWORD }}"
-                    insecureSkipVerify: true
-
-          logging:
-            level: "${{ vars.LOGGING_LEVEL }}"
-          
-          awsCredentials:
-            secretKey: "$AWS_SECRET_KEY"
-            accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ vars.AWS_REGION }}"
-
-          awsMachineConfigs:
-            region: "${{ vars.AWS_REGION }}"
-            awsMachineConfig:
-            - roles: ["etcd", "controlplane", "worker"]
-              ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              sshUser: "${{ vars.AWS_USER }}"
-              vpcId: "${{ secrets.AWS_VPC_ID }}"
-              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              zone: "${{ vars.AWS_ZONE_LETTER }}"
-              retries: "5"
-              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-
-          awsEC2Configs:
-            region: "${{ vars.AWS_REGION }}"
-            awsSecretAccessKey: "$AWS_SECRET_KEY"
-            awsAccessKeyID: "$AWS_ACCESS_KEY"
-            awsEC2Config:
-              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ vars.AWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["etcd", "controlplane", "worker"]
-              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["windows"]
-          sshPath: 
-            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/go-build.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
-
-      - name: Run Provisioning tests
-        env:
-          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-provisioning
-        with:
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
-          run_ace: "false"
-          run_template: "false"
-
-      - name: Cleanup Infrastructure
-        if: always()
-        working-directory: tfp-automation/modules/proxy/aws
-        run: terraform destroy -auto-approve > /dev/null 2>&1
-
-      - name: Refresh AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: AWS Custodian Infrastructure Cleanup
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: AWS Custodian Downstream Cleanup - Node driver
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: AWS Custodian Downstream Cleanup - Custom
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set job status output
-        if: always()
-        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
-        id: set-job-status
-
-      - name: Reporting Results to Slack
-        if: always() && env.REPORTING_ENABLED == 'true'
-        uses: ./.github/actions/report-to-slack
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          job-status: ${{ steps.set-job-status.outputs.job_status }}
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Save test result as artifact for weekly summary
-        if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-16\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
-        with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-  
+jobs:  
   v2-15:
     if: |
-      github.event_name == 'schedule' ||
-      github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15-head'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && (contains(github.event.inputs.rancher_version, '-rc')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && (contains(inputs.rancher_version, '-rc'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: upgrade-community-head
+    environment: head
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
-      HOSTNAME_PREFIX: "ghap-up-215"
+      HOSTNAME_PREFIX: "san-215"
       REPORTING_ENABLED: >-
         ${{
-          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -549,38 +135,33 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
-              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_15_HEAD) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_15_HEAD)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: false
           release-community-version: "2.15"
-          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -590,15 +171,14 @@ jobs:
           qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_15 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_15 }}
 
-      - name: Set upgraded Rancher chart url
+      - name: Set Rancher chart url
         uses: ./.github/actions/set-rancher-chart-url
         with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          rancher-repo: ${{ env.RANCHER_REPO }}
           is-prime: false
           community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
           staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -614,12 +194,11 @@ jobs:
             enableNetworkPolicy: false
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -651,23 +230,18 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
               registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
+              repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
@@ -678,13 +252,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -715,10 +282,12 @@ jobs:
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
             region: "${{ vars.AWS_REGION }}"
@@ -729,8 +298,8 @@ jobs:
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ vars.AWS_USER }}"
@@ -740,23 +309,14 @@ jobs:
                 awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -781,7 +341,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -793,13 +353,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: sanity
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -846,37 +406,22 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
-        if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-15\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
-        with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-  
   v2-14:
     if: |
-      github.event_name == 'schedule' ||
-      github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && (contains(github.event.inputs.rancher_version, '-rc')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && (contains(inputs.rancher_version, '-rc'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: upgrade-prime-staging
+    environment: staging-latest
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
-      HOSTNAME_PREFIX: "ghap-up-214"
+      HOSTNAME_PREFIX: "san-214"
       REPORTING_ENABLED: >-
         ${{
-          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -954,38 +499,33 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
-              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_14_HEAD) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_14_HEAD)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_14) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_14)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: true
           release-prime-version: "2.14"
-          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -995,15 +535,14 @@ jobs:
           qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_14 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_14 }}
 
-      - name: Set upgraded Rancher chart url
+      - name: Set Rancher chart url
         uses: ./.github/actions/set-rancher-chart-url
         with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          rancher-repo: ${{ env.RANCHER_REPO }}
           is-prime: true
           community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
           staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -1019,12 +558,11 @@ jobs:
             enableNetworkPolicy: false
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -1056,24 +594,19 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_14 }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
               registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
+              repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
@@ -1084,13 +617,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -1121,10 +647,12 @@ jobs:
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
             region: "${{ vars.AWS_REGION }}"
@@ -1135,8 +663,8 @@ jobs:
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ vars.AWS_USER }}"
@@ -1146,23 +674,14 @@ jobs:
                 awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1187,7 +706,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -1199,13 +718,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: sanity
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -1252,36 +771,22 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Save test result as artifact for weekly summary
-        if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-14\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
-        with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-
+  
   v2-13:
     if: |
-      github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && (contains(github.event.inputs.rancher_version, '-rc')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && (contains(inputs.rancher_version, '-rc'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: upgrade-prime-staging
+    environment: staging-latest
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_13 }}"
-      HOSTNAME_PREFIX: "ghap-up-213"
+      HOSTNAME_PREFIX: "san-213"
       REPORTING_ENABLED: >-
         ${{
-          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -1359,38 +864,33 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
-              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_13_HEAD) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_13_HEAD)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_13) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_13)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: true
           release-prime-version: "2.13"
-          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -1400,15 +900,14 @@ jobs:
           qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
 
-      - name: Set upgraded Rancher chart url
+      - name: Set Rancher chart url
         uses: ./.github/actions/set-rancher-chart-url
         with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          rancher-repo: ${{ env.RANCHER_REPO }}
           is-prime: true
           community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
           staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -1422,14 +921,14 @@ jobs:
             cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            generateV3Token: true
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -1461,24 +960,19 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_13 }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
               registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
+              repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
@@ -1489,13 +983,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -1526,10 +1013,12 @@ jobs:
               instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
 
           awsEC2Configs:
             region: "${{ vars.AWS_REGION }}"
@@ -1540,8 +1029,8 @@ jobs:
                 awsAMI: "${{ secrets.AWS_AMI }}"
                 instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
                 awsUser: "${{ vars.AWS_USER }}"
@@ -1551,23 +1040,14 @@ jobs:
                 awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
                 awsCICDInstanceTag: "rancher-validation"
                 awsUser: "${{ vars.AWS_WINDOWS_USER }}"
                 volumeSize: ${{ vars.AWS_ROOT_SIZE }}
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1592,7 +1072,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -1604,13 +1084,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: sanity
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -1657,19 +1137,736 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
-        if: always() && github.event_name == 'schedule'
+  v2-12:
+    if: |
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && (contains(github.event.inputs.rancher_version, '-rc')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12')) && (contains(inputs.rancher_version, '-rc'))
+    name: ${{ github.event.inputs.rancher_version }}
+    runs-on: ubuntu-latest
+    environment: staging-latest
+    env:
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_12 }}"
+      HOSTNAME_PREFIX: "san-212"
+      REPORTING_ENABLED: >-
+        ${{
+          github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
+        }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          submodules: recursive
+
+      - name: Checkout tfp-automation repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          repository: rancher/tfp-automation
+          path: tfp-automation
+
+      - name: Set up local rancher2 Terraform provider
+        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
+        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
+        with:
+          version: "latest"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: "Fetch and Set DockerHub Credentials"
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Mask Dockerhub Credentials
         run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-13\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
+          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Set up certificates
+        id: setup-certs
+        uses: ./.github/actions/setup-certs
+        with:
+          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
+          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
+          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
+          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
+            }}
+
+      - name: Set Rancher chart version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_CHART_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
+            }}
+
+      - name: Set Rancher repo
+        uses: ./.github/actions/set-rancher-repo
+        with:
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
+          is-prime: true
+          release-prime-version: "2.12"
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_12 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_12 }}
+
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          is-prime: true
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+            cleanup: true
+          terraform:
+            cni: "${{ vars.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
+            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
+            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ vars.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ vars.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
+              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
+              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
+              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
+              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_12 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ env.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_12 }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
+
+          clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            nodeProvider: "ec2"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
+
+          awsEC2Configs:
+            region: "${{ vars.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
+                awsUser: "${{ vars.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["windows"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
         shell: bash
 
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+      - name: Set up Go environment
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/go-build.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
+
+      - name: Run Provisioning tests
+        env:
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
+          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
+          QASE_CUSTOM_FIELD_FILTER: Hostbusters
+          QASE_SCHEMA_PREFIX: hostbusters
+          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        uses: ./.github/actions/run-hostbusters-provisioning
+        with:
+          reporting: ${{ env.REPORTING_ENABLED }}
+          tags: sanity
+          run_ace: "false"
+          run_template: "false"
+
+      - name: Cleanup Infrastructure
+        if: always()
+        working-directory: tfp-automation/modules/sanity/aws
+        run: terraform destroy -auto-approve > /dev/null 2>&1
+
+      - name: Refresh AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: AWS Custodian Infrastructure Cleanup
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set job status output
+        if: always()
+        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
+        id: set-job-status
+
+      - name: Reporting Results to Slack
+        if: always() && env.REPORTING_ENABLED == 'true'
+        uses: ./.github/actions/report-to-slack
+        with:
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          job-status: ${{ steps.set-job-status.outputs.job_status }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  v2-11:
+    if: |
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && (contains(github.event.inputs.rancher_version, '-rc')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11')) && (contains(inputs.rancher_version, '-rc'))
+    name: ${{ github.event.inputs.rancher_version }}
+    runs-on: ubuntu-latest
+    environment: staging-latest
+    env:
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
+      HOSTNAME_PREFIX: "san-211"
+      REPORTING_ENABLED: >-
+        ${{
+          github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
+        }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          submodules: recursive
+
+      - name: Checkout tfp-automation repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          repository: rancher/tfp-automation
+          path: tfp-automation
+
+      - name: Set up local rancher2 Terraform provider
+        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
+        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
+        with:
+          version: "latest"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: "Fetch and Set DockerHub Credentials"
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Mask Dockerhub Credentials
+        run: |
+          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
+          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Set up certificates
+        id: setup-certs
+        uses: ./.github/actions/setup-certs
+        with:
+          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
+          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
+          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
+          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
+            }}
+
+      - name: Set Rancher chart version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_CHART_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
+            }}
+
+      - name: Set Rancher repo
+        uses: ./.github/actions/set-rancher-repo
+        with:
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
+          is-prime: true
+          release-prime-version: "2.11"
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_11 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_11 }}
+
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          is-prime: true
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+            cleanup: true
+          terraform:
+            cni: "${{ vars.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
+            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
+            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ vars.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ vars.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
+              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
+              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
+              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
+              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_11 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ env.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
+
+          clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            nodeProvider: "ec2"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
+
+          awsEC2Configs:
+            region: "${{ vars.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
+                awsUser: "${{ vars.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["windows"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/go-build.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
+
+      - name: Run Provisioning tests
+        env:
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
+          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
+          QASE_CUSTOM_FIELD_FILTER: Hostbusters
+          QASE_SCHEMA_PREFIX: hostbusters
+          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        uses: ./.github/actions/run-hostbusters-provisioning
+        with:
+          reporting: ${{ env.REPORTING_ENABLED }}
+          tags: sanity
+          run_ace: "false"
+          run_template: "false"
+
+      - name: Cleanup Infrastructure
+        if: always()
+        working-directory: tfp-automation/modules/sanity/aws
+        run: terraform destroy -auto-approve > /dev/null 2>&1
+
+      - name: Refresh AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: AWS Custodian Infrastructure Cleanup
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set job status output
+        if: always()
+        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
+        id: set-job-status
+
+      - name: Reporting Results to Slack
+        if: always() && env.REPORTING_ENABLED == 'true'
+        uses: ./.github/actions/report-to-slack
+        with:
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          job-status: ${{ steps.set-job-status.outputs.job_status }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -291,6 +291,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -307,6 +308,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -661,6 +663,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -677,6 +680,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1030,6 +1034,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1046,6 +1051,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1400,6 +1406,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1416,6 +1423,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"

--- a/.github/workflows/mixed-arch-cluster-provisioning.yml
+++ b/.github/workflows/mixed-arch-cluster-provisioning.yml
@@ -1,9 +1,9 @@
 ---
-name: Upgraded Rancher Proxy Cluster Provisioning
+name: Mixed Architecture Cluster Provisioning
 
 on:
   schedule:
-    - cron: "0 10 * * 5"
+    - cron: "0 7 * * 2"
   workflow_dispatch:
     inputs:
       rancher_version:
@@ -52,7 +52,7 @@ env:
     }}
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
 
-jobs:
+jobs:  
   v2-16:
     if: |
       github.event_name == 'schedule' ||
@@ -60,10 +60,10 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: upgrade-community-head
+    environment: head
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_16 }}"
-      HOSTNAME_PREFIX: "ghap-up-216"
+      HOSTNAME_PREFIX: "mix-arch-216"
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
@@ -144,10 +144,10 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
@@ -156,26 +156,25 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_16_HEAD)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) || 
               (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: false
           release-community-version: "2.16"
-          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -185,15 +184,14 @@ jobs:
           qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_16 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_16 }}
 
-      - name: Set upgraded Rancher chart url
+      - name: Set Rancher chart url
         uses: ./.github/actions/set-rancher-chart-url
         with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          rancher-repo: ${{ env.RANCHER_REPO }}
           is-prime: false
           community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
           staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -208,13 +206,13 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
+            mixedArchitecture: true
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -222,6 +220,8 @@ jobs:
               ami: "${{ secrets.AWS_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              armAMI: "${{ secrets.AWS_ARM_AMI }}"
+              armInstanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
@@ -246,23 +246,18 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_16 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
               registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+              repo: "${{ env.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_16 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
@@ -270,16 +265,10 @@ jobs:
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             cni: "${{ vars.CNI }}"
+            mixedArchitecture: true
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -305,53 +294,31 @@ jobs:
           awsMachineConfigs:
             region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
-            - roles: ["etcd", "controlplane", "worker"]
+            - roles: ["etcd", "controlplane"]
               ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE }}"
+            - roles: ["worker"]
+              ami: "${{ secrets.AWS_ARM_AMI }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE }}"
 
-          awsEC2Configs:
-            region: "${{ vars.AWS_REGION }}"
-            awsSecretAccessKey: "$AWS_SECRET_KEY"
-            awsAccessKeyID: "$AWS_ACCESS_KEY"
-            awsEC2Config:
-              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ vars.AWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["etcd", "controlplane", "worker"]
-              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -376,7 +343,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -388,13 +355,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: mixed
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -441,22 +408,22 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
         if: always() && github.event_name == 'schedule'
         run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-16\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"mixed-arch-cluster-provisioning\", \"job\": \"v2-16\" }" > test-result-mixed-arch-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
         if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          name: test-result-mixed-arch-cluster-provisioning-v2-16-${{ github.run_id }}
+          path: test-result-mixed-arch-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
   
   v2-15:
     if: |
@@ -465,13 +432,12 @@ jobs:
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: upgrade-community-head
+    environment: head
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
-      HOSTNAME_PREFIX: "ghap-up-215"
+      HOSTNAME_PREFIX: "mix-arch-215"
       REPORTING_ENABLED: >-
         ${{
-          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -549,22 +515,22 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) ||
               (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_15_HEAD) ||
               (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_15_HEAD)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
@@ -573,14 +539,13 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: false
           release-community-version: "2.15"
-          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -590,15 +555,14 @@ jobs:
           qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_15 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_15 }}
 
-      - name: Set upgraded Rancher chart url
+      - name: Set Rancher chart url
         uses: ./.github/actions/set-rancher-chart-url
         with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          rancher-repo: ${{ env.RANCHER_REPO }}
           is-prime: false
           community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
           staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -613,13 +577,13 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
+            mixedArchitecture: true
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -627,6 +591,8 @@ jobs:
               ami: "${{ secrets.AWS_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              armAMI: "${{ secrets.AWS_ARM_AMI }}"
+              armInstanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
@@ -651,23 +617,18 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
               registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
+              repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
@@ -675,16 +636,10 @@ jobs:
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             cni: "${{ vars.CNI }}"
+            mixedArchitecture: true
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -710,53 +665,31 @@ jobs:
           awsMachineConfigs:
             region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
-            - roles: ["etcd", "controlplane", "worker"]
+            - roles: ["etcd", "controlplane"]
               ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE }}"
+            - roles: ["worker"]
+              ami: "${{ secrets.AWS_ARM_AMI }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE }}"
 
-          awsEC2Configs:
-            region: "${{ vars.AWS_REGION }}"
-            awsSecretAccessKey: "$AWS_SECRET_KEY"
-            awsAccessKeyID: "$AWS_ACCESS_KEY"
-            awsEC2Config:
-              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ vars.AWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["etcd", "controlplane", "worker"]
-              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -781,7 +714,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -793,13 +726,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: mixed
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -846,37 +779,36 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
         if: always() && github.event_name == 'schedule'
         run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-15\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"mixed-arch-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-mixed-arch-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
         if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-  
+          name: test-result-mixed-arch-cluster-provisioning-v2-15-${{ github.run_id }}
+          path: test-result-mixed-arch-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+
   v2-14:
     if: |
       github.event_name == 'schedule' ||
       github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: upgrade-prime-staging
+    environment: staging-latest
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
-      HOSTNAME_PREFIX: "ghap-up-214"
+      HOSTNAME_PREFIX: "mix-arch-214"
       REPORTING_ENABLED: >-
         ${{
-          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -954,22 +886,22 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) ||
               (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_14_HEAD) ||
               (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_14_HEAD)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
@@ -978,14 +910,13 @@ jobs:
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_14)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: true
           release-prime-version: "2.14"
-          env-var-name: UPGRADED_RANCHER_REPO
 
       - name: Get Qase ID
         id: get-qase-id
@@ -995,15 +926,14 @@ jobs:
           qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_14 }}
           qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_14 }}
 
-      - name: Set upgraded Rancher chart url
+      - name: Set Rancher chart url
         uses: ./.github/actions/set-rancher-chart-url
         with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          rancher-repo: ${{ env.RANCHER_REPO }}
           is-prime: true
           community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
           staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -1018,13 +948,13 @@ jobs:
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
+            mixedArchitecture: true
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
@@ -1032,6 +962,8 @@ jobs:
               ami: "${{ secrets.AWS_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              armAMI: "${{ secrets.AWS_ARM_AMI }}"
+              armInstanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
@@ -1056,24 +988,19 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_14 }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
               registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
               registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
+              repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
@@ -1081,16 +1008,10 @@ jobs:
           clusterConfig:
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
             cni: "${{ vars.CNI }}"
+            mixedArchitecture: true
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -1116,53 +1037,31 @@ jobs:
           awsMachineConfigs:
             region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
-            - roles: ["etcd", "controlplane", "worker"]
+            - roles: ["etcd", "controlplane"]
               ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               zone: "${{ vars.AWS_ZONE_LETTER }}"
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE }}"
+            - roles: ["worker"]
+              ami: "${{ secrets.AWS_ARM_AMI }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE }}"
 
-          awsEC2Configs:
-            region: "${{ vars.AWS_REGION }}"
-            awsSecretAccessKey: "$AWS_SECRET_KEY"
-            awsAccessKeyID: "$AWS_ACCESS_KEY"
-            awsEC2Config:
-              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ vars.AWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["etcd", "controlplane", "worker"]
-              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1187,7 +1086,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -1199,13 +1098,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: mixed
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -1252,424 +1151,19 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Save test result as artifact for weekly summary
         if: always() && github.event_name == 'schedule'
         run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-14\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"mixed-arch-cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-mixed-arch-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
         if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-
-  v2-13:
-    if: |
-      github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13'))
-    name: ${{ github.event.inputs.rancher_version }}
-    runs-on: ubuntu-latest
-    environment: upgrade-prime-staging
-    env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_13 }}"
-      HOSTNAME_PREFIX: "ghap-up-213"
-      REPORTING_ENABLED: >-
-        ${{
-          github.event_name == 'schedule' ||
-          github.event_name == 'workflow_call' ||
-          github.actor == 'github-actions[bot]' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
-        }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          submodules: recursive
-
-      - name: Checkout tfp-automation repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: rancher/tfp-automation
-          path: tfp-automation
-
-      - name: Set up local rancher2 Terraform provider
-        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
-        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
-        with:
-          version: "latest"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: "Fetch and Set DockerHub Credentials"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
-
-      - name: Mask Dockerhub Credentials
-        run: |
-          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
-          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Set up certificates
-        id: setup-certs
-        uses: ./.github/actions/setup-certs
-        with:
-          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
-          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
-          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
-          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
-              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_13_HEAD) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_13_HEAD)
-            }}
-
-      - name: Set upgraded Rancher chart version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_CHART_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_13) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_13)
-            }}
-
-      - name: Set upgraded Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          is-prime: true
-          release-prime-version: "2.13"
-          env-var-name: UPGRADED_RANCHER_REPO
-
-      - name: Get Qase ID
-        id: get-qase-id
-        uses: ./.github/actions/get-qase-id
-        with:
-          triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
-          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
-
-      - name: Set upgraded Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
-          is-prime: true
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-            cleanup: true
-          terraform:
-            cni: "${{ vars.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
-            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
-            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ vars.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
-              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
-              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
-              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
-              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
-              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_13 }}"
-              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
-              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ vars.CNI }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
-            registries:
-              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
-              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
-              rke2Registries:
-                mirrors:
-                  "docker.io":
-                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
-                configs:
-                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
-                    "auth":
-                      username: "${{ env.DOCKERHUB_USERNAME }}"
-                      password: "${{ env.DOCKERHUB_PASSWORD }}"
-                    insecureSkipVerify: true
-
-          logging:
-            level: "${{ vars.LOGGING_LEVEL }}"
-          
-          awsCredentials:
-            secretKey: "$AWS_SECRET_KEY"
-            accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ vars.AWS_REGION }}"
-
-          awsMachineConfigs:
-            region: "${{ vars.AWS_REGION }}"
-            awsMachineConfig:
-            - roles: ["etcd", "controlplane", "worker"]
-              ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              sshUser: "${{ vars.AWS_USER }}"
-              vpcId: "${{ secrets.AWS_VPC_ID }}"
-              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              zone: "${{ vars.AWS_ZONE_LETTER }}"
-              retries: "5"
-              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-
-          awsEC2Configs:
-            region: "${{ vars.AWS_REGION }}"
-            awsSecretAccessKey: "$AWS_SECRET_KEY"
-            awsAccessKeyID: "$AWS_ACCESS_KEY"
-            awsEC2Config:
-              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ vars.AWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["etcd", "controlplane", "worker"]
-              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["windows"]
-          sshPath: 
-            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/go-build.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
-
-      - name: Run Provisioning tests
-        env:
-          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-provisioning
-        with:
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
-          run_ace: "false"
-          run_template: "false"
-
-      - name: Cleanup Infrastructure
-        if: always()
-        working-directory: tfp-automation/modules/proxy/aws
-        run: terraform destroy -auto-approve > /dev/null 2>&1
-
-      - name: Refresh AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: AWS Custodian Infrastructure Cleanup
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: AWS Custodian Downstream Cleanup - Node driver
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: AWS Custodian Downstream Cleanup - Custom
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set job status output
-        if: always()
-        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
-        id: set-job-status
-
-      - name: Reporting Results to Slack
-        if: always() && env.REPORTING_ENABLED == 'true'
-        uses: ./.github/actions/report-to-slack
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          job-status: ${{ steps.set-job-status.outputs.job_status }}
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Save test result as artifact for weekly summary
-        if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-13\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
-        with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          name: test-result-mixed-arch-cluster-provisioning-v2-14-${{ github.run_id }}
+          path: test-result-mixed-arch-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json

--- a/.github/workflows/proxy-cluster-provisioning.yml
+++ b/.github/workflows/proxy-cluster-provisioning.yml
@@ -300,6 +300,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -316,6 +317,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -698,6 +700,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -714,6 +717,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1097,6 +1101,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1113,6 +1118,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -1495,6 +1501,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1511,6 +1518,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"

--- a/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-airgap-cluster-provisioning.yml
@@ -8,11 +8,6 @@ on:
         description: "Rancher tag version"
       rancher_chart_version:
         description: "Rancher chart version"
-      run_all_versions:
-        description: "Run all supported versions if manually triggered"
-        required: false
-        default: false
-        type: boolean
       reporting:
         description: "Enable reporting to Qase and Slack"
         required: false
@@ -52,7 +47,6 @@ env:
 jobs:
   v2-15:
     if: |
-      github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && contains(github.event.inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
@@ -141,8 +135,7 @@ jobs:
           value: | 
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
       - name: Set upgraded Rancher chart version
@@ -152,8 +145,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
       - name: Set upgraded Rancher repo
@@ -267,6 +259,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
@@ -382,7 +375,6 @@ jobs:
   
   v2-14:
     if: |
-      github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && contains(github.event.inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
@@ -471,8 +463,7 @@ jobs:
           value: | 
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
       - name: Set upgraded Rancher chart version
@@ -482,8 +473,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
       - name: Set upgraded Rancher repo
@@ -599,6 +589,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"
@@ -714,7 +705,6 @@ jobs:
 
   v2-13:
     if: |
-      github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && contains(github.event.inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
@@ -803,8 +793,7 @@ jobs:
           value: | 
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
       - name: Set upgraded Rancher chart version
@@ -814,8 +803,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
       - name: Set upgraded Rancher repo
@@ -931,6 +919,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AIRGAP_AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AIRGAP_AWS_SUBNET_ID }}"

--- a/.github/workflows/rancher-upgrade-arm64-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-arm64-cluster-provisioning.yml
@@ -1,9 +1,9 @@
 ---
-name: Upgraded Rancher Proxy Cluster Provisioning
+name: Upgraded Rancher ARM64 Cluster Provisioning
 
 on:
   schedule:
-    - cron: "0 10 * * 5"
+    - cron: "0 8 * * 2"
   workflow_dispatch:
     inputs:
       rancher_version:
@@ -52,7 +52,7 @@ env:
     }}
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
 
-jobs:
+jobs: 
   v2-16:
     if: |
       github.event_name == 'schedule' ||
@@ -63,7 +63,7 @@ jobs:
     environment: upgrade-community-head
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_16 }}"
-      HOSTNAME_PREFIX: "ghap-up-216"
+      HOSTNAME_PREFIX: "arm64-up-216"
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
@@ -151,7 +151,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) ||
               (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_16_HEAD) ||
               (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_16_HEAD)
             }}
@@ -209,19 +209,18 @@ jobs:
             enableNetworkPolicy: false
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
             awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
+              ami: "${{ secrets.AWS_ARM_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsInstanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
@@ -247,17 +246,17 @@ jobs:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_16 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
-              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
-              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_16 }}"
               upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
@@ -273,13 +272,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -306,8 +298,8 @@ jobs:
             region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
-              ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              ami: "${{ secrets.AWS_ARM_AMI }}"
+              instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -321,8 +313,8 @@ jobs:
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsAMI: "${{ secrets.AWS_ARM_AMI }}"
+                instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -343,15 +335,6 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -376,7 +359,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -388,13 +371,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: sanity
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -448,15 +431,15 @@ jobs:
       - name: Save test result as artifact for weekly summary
         if: always() && github.event_name == 'schedule'
         run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-16\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-arm64-cluster-provisioning\", \"job\": \"v2-16\" }" > test-result-rancher-upgrade-arm64-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
         if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          name: test-result-rancher-upgrade-arm64-cluster-provisioning-v2-16-${{ github.run_id }}
+          path: test-result-rancher-upgrade-arm64-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
   
   v2-15:
     if: |
@@ -468,7 +451,7 @@ jobs:
     environment: upgrade-community-head
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
-      HOSTNAME_PREFIX: "ghap-up-215"
+      HOSTNAME_PREFIX: "arm64-up-215"
       REPORTING_ENABLED: >-
         ${{
           github.event_name == 'schedule' ||
@@ -556,7 +539,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) ||
               (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_15_HEAD) ||
               (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_15_HEAD)
             }}
@@ -614,19 +597,18 @@ jobs:
             enableNetworkPolicy: false
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
             awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
+              ami: "${{ secrets.AWS_ARM_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsInstanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
@@ -659,8 +641,8 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
-              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
-              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
               upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
@@ -678,13 +660,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -711,8 +686,8 @@ jobs:
             region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
-              ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              ami: "${{ secrets.AWS_ARM_AMI }}"
+              instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -726,8 +701,8 @@ jobs:
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsAMI: "${{ secrets.AWS_ARM_AMI }}"
+                instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -748,15 +723,6 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -781,7 +747,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -793,13 +759,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: sanity
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -853,30 +819,28 @@ jobs:
       - name: Save test result as artifact for weekly summary
         if: always() && github.event_name == 'schedule'
         run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-15\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-arm64-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-rancher-upgrade-arm64-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
         if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-  
+          name: test-result-rancher-upgrade-arm64-cluster-provisioning-v2-15-${{ github.run_id }}
+          path: test-result-rancher-upgrade-arm64-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+
   v2-14:
     if: |
-      github.event_name == 'schedule' ||
-      github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14'))
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && (contains(github.event.inputs.rancher_version, '-rc')) ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && (contains(inputs.rancher_version, '-rc'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
     environment: upgrade-prime-staging
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
-      HOSTNAME_PREFIX: "ghap-up-214"
+      HOSTNAME_PREFIX: "san-up-214"
       REPORTING_ENABLED: >-
         ${{
-          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -961,9 +925,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
-              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_14_HEAD) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_14_HEAD)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
       - name: Set upgraded Rancher chart version
@@ -973,9 +935,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_14) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_14)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
       - name: Set upgraded Rancher repo
@@ -1019,19 +979,18 @@ jobs:
             enableNetworkPolicy: false
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
             awsCredentials:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
             awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
+              ami: "${{ secrets.AWS_ARM_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsInstanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
               region: "${{ vars.AWS_REGION }}"
               awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
@@ -1064,8 +1023,8 @@ jobs:
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_14 }}"
-              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
-              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
+              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
@@ -1084,13 +1043,6 @@ jobs:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
             registries:
               rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
               rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
@@ -1117,8 +1069,8 @@ jobs:
             region: "${{ vars.AWS_REGION }}"
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
-              ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              ami: "${{ secrets.AWS_ARM_AMI }}"
+              instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1132,8 +1084,8 @@ jobs:
             awsAccessKeyID: "$AWS_ACCESS_KEY"
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsAMI: "${{ secrets.AWS_ARM_AMI }}"
+                instanceType: "${{ vars.AWS_ARM_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1154,15 +1106,6 @@ jobs:
                 roles: ["windows"]
           sshPath: 
             sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1187,7 +1130,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/standard/main.go
 
       - name: Run Provisioning tests
         env:
@@ -1199,13 +1142,13 @@ jobs:
         uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
+          tags: sanity
           run_ace: "false"
           run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/proxy/aws
+        working-directory: tfp-automation/modules/sanity/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -1259,417 +1202,12 @@ jobs:
       - name: Save test result as artifact for weekly summary
         if: always() && github.event_name == 'schedule'
         run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-14\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-arm64-cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-rancher-upgrade-arm64-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
         shell: bash
 
       - name: Upload test result weekly summary
         if: always() && github.event_name == 'schedule'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-
-  v2-13:
-    if: |
-      github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13'))
-    name: ${{ github.event.inputs.rancher_version }}
-    runs-on: ubuntu-latest
-    environment: upgrade-prime-staging
-    env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_13 }}"
-      HOSTNAME_PREFIX: "ghap-up-213"
-      REPORTING_ENABLED: >-
-        ${{
-          github.event_name == 'schedule' ||
-          github.event_name == 'workflow_call' ||
-          github.actor == 'github-actions[bot]' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
-        }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          submodules: recursive
-
-      - name: Checkout tfp-automation repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: rancher/tfp-automation
-          path: tfp-automation
-
-      - name: Set up local rancher2 Terraform provider
-        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
-        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
-        with:
-          version: "latest"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: "Fetch and Set DockerHub Credentials"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
-
-      - name: Mask Dockerhub Credentials
-        run: |
-          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
-          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Set up certificates
-        id: setup-certs
-        uses: ./.github/actions/setup-certs
-        with:
-          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
-          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
-          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
-          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
-              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_13_HEAD) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_13_HEAD)
-            }}
-
-      - name: Set upgraded Rancher chart version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_CHART_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_13) ||
-              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_13)
-            }}
-
-      - name: Set upgraded Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          is-prime: true
-          release-prime-version: "2.13"
-          env-var-name: UPGRADED_RANCHER_REPO
-
-      - name: Get Qase ID
-        id: get-qase-id
-        uses: ./.github/actions/get-qase-id
-        with:
-          triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
-          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
-
-      - name: Set upgraded Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
-          is-prime: true
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
-          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-            cleanup: true
-          terraform:
-            cni: "${{ vars.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
-            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
-            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            proxy:
-              proxyBastion: ""
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ vars.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
-              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
-              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
-              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
-              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
-              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_13 }}"
-              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
-              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ vars.CNI }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            agentEnvVars:
-            - name: HTTP_PROXY
-              value: http://<replace me>:3228
-            - name: HTTPS_PROXY
-              value: http://<replace me>:3228
-            - name: NO_PROXY
-              value: localhost,127.0.0.0/8,10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,.svc,.cluster.local,cattle-system.svc,169.254.169.254
-            registries:
-              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
-              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
-              rke2Registries:
-                mirrors:
-                  "docker.io":
-                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
-                configs:
-                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
-                    "auth":
-                      username: "${{ env.DOCKERHUB_USERNAME }}"
-                      password: "${{ env.DOCKERHUB_PASSWORD }}"
-                    insecureSkipVerify: true
-
-          logging:
-            level: "${{ vars.LOGGING_LEVEL }}"
-          
-          awsCredentials:
-            secretKey: "$AWS_SECRET_KEY"
-            accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ vars.AWS_REGION }}"
-
-          awsMachineConfigs:
-            region: "${{ vars.AWS_REGION }}"
-            awsMachineConfig:
-            - roles: ["etcd", "controlplane", "worker"]
-              ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              sshUser: "${{ vars.AWS_USER }}"
-              vpcId: "${{ secrets.AWS_VPC_ID }}"
-              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              zone: "${{ vars.AWS_ZONE_LETTER }}"
-              retries: "5"
-              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-
-          awsEC2Configs:
-            region: "${{ vars.AWS_REGION }}"
-            awsSecretAccessKey: "$AWS_SECRET_KEY"
-            awsAccessKeyID: "$AWS_ACCESS_KEY"
-            awsEC2Config:
-              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.AWS_AMI }}"
-                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-                awsUser: "${{ vars.AWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["etcd", "controlplane", "worker"]
-              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
-                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
-                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
-                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
-                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-                awsCICDInstanceTag: "rancher-validation"
-                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
-                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
-                roles: ["windows"]
-          sshPath: 
-            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
-
-          templateTest:
-            repo:
-              spec:
-                gitRepo: "${{ secrets.TEMPLATE_GIT_REPO }}"
-                gitBranch: main
-                insecureSkipTLSVerify: true
-            templateProvider: "aws"
-            templateName: "cluster-template1"
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/go-build.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/proxy/main.go
-
-      - name: Run Provisioning tests
-        env:
-          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-hostbusters-provisioning
-        with:
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tags: proxy
-          run_ace: "false"
-          run_template: "false"
-
-      - name: Cleanup Infrastructure
-        if: always()
-        working-directory: tfp-automation/modules/proxy/aws
-        run: terraform destroy -auto-approve > /dev/null 2>&1
-
-      - name: Refresh AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: AWS Custodian Infrastructure Cleanup
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: AWS Custodian Downstream Cleanup - Node driver
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: AWS Custodian Downstream Cleanup - Custom
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set job status output
-        if: always()
-        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
-        id: set-job-status
-
-      - name: Reporting Results to Slack
-        if: always() && env.REPORTING_ENABLED == 'true'
-        uses: ./.github/actions/report-to-slack
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          job-status: ${{ steps.set-job-status.outputs.job_status }}
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Save test result as artifact for weekly summary
-        if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-13\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
-        with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          name: test-result-rancher-upgrade-arm64-cluster-provisioning-v2-14-${{ github.run_id }}
+          path: test-result-rancher-upgrade-arm64-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -299,6 +299,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -313,6 +314,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -692,6 +694,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -706,6 +709,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1087,6 +1091,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1101,6 +1106,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
@@ -1481,6 +1487,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -1495,6 +1502,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"

--- a/.github/workflows/registries-cluster-provisioning.yml
+++ b/.github/workflows/registries-cluster-provisioning.yml
@@ -8,11 +8,6 @@ on:
         description: "Rancher tag version"
       rancher_chart_version:
         description: "Rancher chart version"
-      run_all_versions:
-        description: "Run all supported versions if manually triggered"
-        required: false
-        default: false
-        type: boolean
       reporting:
         description: "Enable reporting to Qase and Slack"
         required: false
@@ -51,7 +46,6 @@ env:
 jobs:
   v2-15:
     if: |
-      github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && contains(github.event.inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
@@ -140,8 +134,7 @@ jobs:
           value: |
             ${{
               github.event.inputs.rancher_version ||
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
       - name: Set Rancher chart version
@@ -151,8 +144,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
       - name: Set Rancher repo
@@ -264,6 +256,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -280,6 +273,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -395,7 +389,6 @@ jobs:
 
   v2-14:
     if: |
-      github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && contains(github.event.inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
@@ -484,8 +477,7 @@ jobs:
           value: |
             ${{
               github.event.inputs.rancher_version ||
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
       - name: Set Rancher chart version
@@ -495,8 +487,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
       - name: Set Rancher repo
@@ -608,6 +599,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -624,6 +616,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
@@ -739,7 +732,6 @@ jobs:
 
   v2-13:
     if: |
-      github.event.inputs.run_all_versions == 'true' ||
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && contains(github.event.inputs.rancher_version, '-alpha') ||
       (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
@@ -828,8 +820,7 @@ jobs:
           value: |
             ${{
               github.event.inputs.rancher_version ||
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
       - name: Set Rancher chart version
@@ -839,8 +830,7 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
-              (github.event.inputs.run_all_versions == 'true' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
       - name: Set Rancher repo
@@ -952,6 +942,7 @@ jobs:
             awsMachineConfig:
             - roles: ["etcd", "controlplane", "worker"]
               ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               sshUser: "${{ vars.AWS_USER }}"
               vpcId: "${{ secrets.AWS_VPC_ID }}"
               subnetId: "${{ secrets.AWS_SUBNET_ID }}"
@@ -968,6 +959,7 @@ jobs:
             awsEC2Config:
               - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
                 awsAMI: "${{ secrets.AWS_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
                 awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
                 awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
                 awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"

--- a/.github/workflows/turtles-feature-off-cluster-provisioning.yml
+++ b/.github/workflows/turtles-feature-off-cluster-provisioning.yml
@@ -1,7 +1,9 @@
 ---
-name: Day 2 Operations - Rancher Prime
+name: Turtles Feature Off - Cluster Provisioning
 
 on:
+  schedule:
+    - cron: "0 7 * * 2"
   workflow_dispatch:
     inputs:
       rancher_version:
@@ -48,328 +50,9 @@ env:
       (github.event_name == 'workflow_dispatch' && github.event.inputs.local_cluster_type) || 
       (github.event_name == 'schedule' && 'rke2') || 'rke2' 
     }}
+  LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
 
 jobs:
-  v2-14:
-    if: |
-      github.event.inputs.run_all_versions == 'true' ||
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && contains(github.event.inputs.rancher_version, '-alpha') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && contains(inputs.rancher_version, '-alpha')
-    name: ${{ github.event.inputs.rancher_version }}
-    runs-on: ubuntu-latest
-    environment: staging-latest
-    env:
-      HOSTNAME_PREFIX: "pgha-214"
-      REPORTING_ENABLED: >-
-        ${{
-          github.event_name == 'workflow_call' ||
-          github.actor == 'github-actions[bot]' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
-        }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          submodules: recursive
-
-      - name: Checkout tfp-automation repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: rancher/tfp-automation
-          path: tfp-automation
-
-      - name: Set up local rancher2 Terraform provider
-        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
-        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: "Fetch and Set DockerHub Credentials"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
-
-      - name: Mask Dockerhub Credentials
-        run: |
-          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
-          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Set up certificates
-        id: setup-certs
-        uses: ./.github/actions/setup-certs
-        with:
-          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
-          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
-          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
-          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: RANCHER_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
-              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_14_HEAD)
-            }}
-
-      - name: Set Rancher chart version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: RANCHER_CHART_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) || 
-              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_13)
-            }}
-
-      - name: Set Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.RANCHER_REPO }}
-          is-prime: true
-          release-prime-version: "2.14"
-
-      - name: Get Qase ID
-        id: get-qase-id
-        uses: ./.github/actions/get-qase-id
-        with:
-          triggered_tag: ${{ github.event.inputs.rancher_version }}
-          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_14 }}
-          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_14 }}
-
-      - name: Set Rancher chart url
-        uses: ./.github/actions/set-rancher-chart-url
-        with:
-          rancher-repo: ${{ env.RANCHER_REPO }}
-          is-prime: true
-          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
-          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
-          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-            cleanup: true
-          terraform:
-            cni: "${{ vars.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
-            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
-            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ vars.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
-              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
-              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
-              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
-              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
-              repo: "${{ env.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            cni: "${{ vars.CNI }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-            registries:
-              rke2Registries:
-                mirrors:
-                  "docker.io":
-                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
-                configs:
-                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
-                    "auth":
-                      username: "${{ env.DOCKERHUB_USERNAME }}"
-                      password: "${{ env.DOCKERHUB_PASSWORD }}"
-
-          logging:
-            level: "${{ vars.LOGGING_LEVEL }}"
-          
-          awsCredentials:
-            secretKey: "$AWS_SECRET_KEY"
-            accessKey: "$AWS_ACCESS_KEY"
-            defaultRegion: "${{ vars.AWS_REGION }}"
-
-          awsMachineConfigs:
-            region: "${{ vars.AWS_REGION }}"
-            awsMachineConfig:
-            - roles: ["etcd", "controlplane", "worker"]
-              ami: "${{ secrets.AWS_AMI }}"
-              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              sshUser: "${{ vars.AWS_USER }}"
-              vpcId: "${{ secrets.AWS_VPC_ID }}"
-              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
-              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              zone: "${{ vars.AWS_ZONE_LETTER }}"
-              retries: "5"
-              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
-              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/go-build.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Creating Rancher server
-        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
-
-      - name: Run Test Suites
-        env:
-          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        with:
-          reporting: ${{ env.REPORTING_ENABLED }}
-        uses: ./.github/actions/run-hostbusters-prime-test-suites
-
-      - name: Cleanup Infrastructure
-        if: always()
-        working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve > /dev/null 2>&1
-
-      - name: Refresh AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: AWS Custodian Infrastructure Cleanup
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: AWS Custodian Downstream Cleanup - Node driver
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: AWS Custodian Downstream Cleanup - Custom
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set job status output
-        if: always()
-        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
-        id: set-job-status
-
-      - name: Reporting Results to Slack
-        if: always() && env.REPORTING_ENABLED == 'true'
-        uses: ./.github/actions/report-to-slack
-        with:
-          rancher-version: ${{ env.RANCHER_VERSION }}
-          job-status: ${{ steps.set-job-status.outputs.job_status }}
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-  
   v2-13:
     if: |
       github.event.inputs.run_all_versions == 'true' ||
@@ -379,9 +62,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: staging-latest
     env:
-      HOSTNAME_PREFIX: "pgha-213"
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_13 }}"
+      HOSTNAME_PREFIX: "ts-off-213"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -402,6 +87,11 @@ jobs:
       - name: Set up local rancher2 Terraform provider
         if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
         run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
+        with:
+          version: "latest"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
@@ -462,6 +152,7 @@ jobs:
             ${{ 
               github.event.inputs.rancher_version || 
               (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_13_HEAD) ||
               (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_13_HEAD)
             }}
 
@@ -473,6 +164,7 @@ jobs:
             ${{ 
               github.event.inputs.rancher_chart_version || 
               (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) || 
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_13) ||
               (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_13)
             }}
 
@@ -513,8 +205,10 @@ jobs:
             cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            generateV3Token: true
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
             privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
             privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
             privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
@@ -538,6 +232,12 @@ jobs:
               awsUser: "${{ vars.AWS_USER }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
+              windowsAWSUser: "${{ vars.AWS_WINDOWS_USER }}" 
+              windows2019AMI: "${{ secrets.WINDOWS_2019_AMI }}"
+              windows2022AMI: "${{ secrets.WINDOWS_2022_AMI }}"
+              windows2019Password: "${{ secrets.AWS_WINDOWS_2019_PASSWORD }}"
+              windows2022Password: "${{ secrets.AWS_WINDOWS_2022_PASSWORD }}"
+              windowsInstanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
               loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
               targetType: "${{ vars.TARGET_TYPE }}"
@@ -557,6 +257,8 @@ jobs:
               registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
               repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
+              featureFlags:
+                turtles: "false"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
@@ -568,6 +270,8 @@ jobs:
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
             registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
               rke2Registries:
                 mirrors:
                   "docker.io":
@@ -577,6 +281,7 @@ jobs:
                     "auth":
                       username: "${{ env.DOCKERHUB_USERNAME }}"
                       password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
 
           logging:
             level: "${{ vars.LOGGING_LEVEL }}"
@@ -600,6 +305,34 @@ jobs:
               retries: "5"
               rootSize: "${{ vars.AWS_ROOT_SIZE }}"
               iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
+
+          awsEC2Configs:
+            region: "${{ vars.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_AMI }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE}}"
+                awsUser: "${{ vars.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+              - instanceType: "${{ vars.AWS_WINDOWS_INSTANCE_TYPE }}"
+                awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.WINDOWS_2022_AMI }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsUser: "${{ vars.AWS_WINDOWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["windows"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -626,16 +359,19 @@ jobs:
       - name: Creating Rancher server
         run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
 
-      - name: Run Test Suites
+      - name: Run Provisioning tests
         env:
           QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_CUSTOM_FIELD_FILTER: Hostbusters
           QASE_SCHEMA_PREFIX: hostbusters
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        uses: ./.github/actions/run-hostbusters-provisioning
         with:
           reporting: ${{ env.REPORTING_ENABLED }}
-        uses: ./.github/actions/run-hostbusters-prime-test-suites
+          tags: sanity
+          run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
@@ -689,3 +425,16 @@ jobs:
           rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Save test result as artifact for weekly summary
+        if: always() && github.event_name == 'schedule'
+        run: |
+          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"cluster-provisioning\", \"job\": \"v2-13\" }" > test-result-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+        shell: bash
+
+      - name: Upload test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        with:
+          name: test-result-cluster-provisioning-v2-13-${{ github.run_id }}
+          path: test-result-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json

--- a/actions/clusters/clusterconfig.go
+++ b/actions/clusters/clusterconfig.go
@@ -37,6 +37,7 @@ type ClusterConfig struct {
 	ResourcePrefix       string                                   `json:"resourcePrefix" yaml:"resourcePrefix" default:""`
 	BastionUser          string                                   `json:"bastionUser" yaml:"bastionUser" default:""`
 	BastionWindowsUser   string                                   `json:"bastionWindowsUser" yaml:"bastionWindowsUser" default:""`
+	MixedArchitecture    bool                                     `json:"mixedArchitecture" yaml:"mixedArchitecture" default:"false"`
 }
 
 // ConvertConfigToClusterConfig converts the config from (user) provisioning input to a cluster config
@@ -67,6 +68,7 @@ func ConvertConfigToClusterConfig(provisioningConfig *provisioningInput.Config) 
 	newConfig.IPv6Cluster = provisioningConfig.IPv6Cluster
 	newConfig.BastionUser = provisioningConfig.BastionUser
 	newConfig.BastionWindowsUser = provisioningConfig.BastionWindowsUser
+	newConfig.MixedArchitecture = provisioningConfig.MixedArchitecture
 
 	return &newConfig
 }

--- a/actions/provisioning/verify.go
+++ b/actions/provisioning/verify.go
@@ -78,7 +78,6 @@ func VerifyClusterReady(client *rancher.Client, cluster *steveV1.SteveAPIObject)
 		latestCluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(clusterID)
 		if err != nil {
 			lastErr = err
-			logrus.Debugf("Unable to fetch provisioning cluster by id (%s/%s), retrying: %v", clusterName, clusterID, err)
 			return false, nil
 		}
 

--- a/actions/provisioninginput/config.go
+++ b/actions/provisioninginput/config.go
@@ -182,6 +182,7 @@ type Config struct {
 	IPv6Cluster            bool                                     `json:"ipv6Cluster,omitempty" yaml:"ipv6Cluster,omitempty" default:"false"`
 	BastionUser            string                                   `json:"bastionUser,omitempty" yaml:"bastionUser,omitempty" default:""`
 	BastionWindowsUser     string                                   `json:"bastionWindowsUser,omitempty" yaml:"bastionWindowsUser,omitempty" default:""`
+	MixedArchitecture      bool                                     `json:"mixedArchitecture,omitempty" yaml:"mixedArchitecture,omitempty" default:"false"`
 }
 
 type TemplateConfig struct {

--- a/actions/workloads/deployment/verify.go
+++ b/actions/workloads/deployment/verify.go
@@ -527,7 +527,7 @@ func VerifyClusterDeployments(client *rancher.Client, cluster *v1.SteveAPIObject
 		clusterID = "local"
 		requiredDeployments = []string{Rancher, Webhook, Fleet, CapiControllerManager}
 		if ok, err := actionClusters.IsRancherVersionAbove(client, "v2.13.0"); err == nil && ok {
-			logrus.Info("Version is above 2.13 verifying CapiControllerManager")
+			logrus.Debugf("Version is above 2.13 verifying CapiControllerManager")
 			requiredDeployments = append(requiredDeployments, CapiControllerManager)
 		}
 	}

--- a/validation/provisioning/defaults/defaults.yaml
+++ b/validation/provisioning/defaults/defaults.yaml
@@ -43,7 +43,7 @@ awsMachineConfigs:
   awsMachineConfig:
   - roles: ["etcd","controlplane","worker"]
     ami: "<required>"
-    instanceType: "t3.xlarge"
+    instanceType: "<required>"
     volumeType: "<required>"
     rootSize: "<required>"
     sshUser: "<required>"
@@ -85,7 +85,7 @@ terraform:
     awsSecurityGroupNames: ["<required>", "<required>"]
     awsSubnetID: "<required>"
     awsVpcID: "<required>"
-    awsinstanceType: "t3.xlarge"
+    awsInstanceType: "<required>"
     awsZoneLetter: "a"
     awsRootSize: 100
     awsRoute53Zone: "<required>"
@@ -105,7 +105,7 @@ awsEC2Configs:
   awsSecretAccessKey: "<required>"
   awsAccessKeyID: "<required>"
   awsEC2Config:
-    - instanceType: "t3.xlarge"
+    - instanceType: "<required>"
       awsRegionAZ: ""
       awsAMI: "<required>"
       awsSecurityGroups: ["<required>"]

--- a/validation/provisioning/k3s/custom_test.go
+++ b/validation/provisioning/k3s/custom_test.go
@@ -1,4 +1,4 @@
-//go:build validation || recurring
+//go:build validation || recurring || sanity
 
 package k3s
 

--- a/validation/provisioning/k3s/imported_test.go
+++ b/validation/provisioning/k3s/imported_test.go
@@ -1,4 +1,4 @@
-//go:build validation || recurring
+//go:build validation || recurring || sanity
 
 package k3s
 

--- a/validation/provisioning/k3s/node_driver_test.go
+++ b/validation/provisioning/k3s/node_driver_test.go
@@ -1,4 +1,4 @@
-//go:build validation || recurring
+//go:build validation || recurring || sanity || mixed
 
 package k3s
 
@@ -98,7 +98,12 @@ func TestNodeDriver(t *testing.T) {
 			operations.LoadObjectFromMap(defaults.ClusterConfigKey, k.cattleConfig, clusterConfig)
 			clusterConfig.MachinePools = tt.machinePools
 
+			if clusterConfig.MixedArchitecture && len(tt.machinePools) == 1 && tt.machinePools[0].MachinePoolConfig.Worker && tt.machinePools[0].MachinePoolConfig.Etcd {
+				t.Skip("skipping all-roles pool: mixed architecture requires a dedicated worker pool")
+			}
+
 			require.NotNil(t, clusterConfig.Provider)
+
 			provider := provisioning.CreateProvider(clusterConfig.Provider)
 			credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
 			machineConfigSpec := provider.LoadMachineConfigFunc(k.cattleConfig)

--- a/validation/provisioning/k3s/schemas/hostbusters_schemas copy.yaml
+++ b/validation/provisioning/k3s/schemas/hostbusters_schemas copy.yaml
@@ -1,0 +1,816 @@
+- projects:
+  - RRT
+  - RM
+  suite: Go Automation/Provisioning/K3S/NodeDriver
+  cases:
+  - description: Provisions a 1 node all roles node driver cluster
+    title: K3S_Node_Driver|etcd_cp_worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision K3S node driver cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 2 node stacked roles node driver cluster
+    title: K3S_Node_Driver|etcd_cp|worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision K3S node driver cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 3 node split roles node driver cluster
+    title: K3S_Node_Driver|etcd|cp|worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision K3S node driver cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 8 node 3etcd/2cp/3worker node driver cluster
+    title: K3S_Node_Driver|3_etcd|2_cp|3_worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision K3S node driver cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+- projects:
+  - RRT
+  - RM
+  suite: Go Automation/Provisioning/K3S/Custom
+  cases:
+  - description: Provisions a 1 node all roles custom cluster
+    title: K3S_Custom|etcd_cp_worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a K3S custom cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 2 node stacked roles custom cluster
+    title: K3S_Custom|etcd_cp|worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a K3S custom cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 3 node split roles custom cluster
+    title: K3S_Custom|etcd|cp|worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a K3S custom cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 8 node 3etcd/2cp/3worker custom cluster
+    title: K3S_Custom|3_etcd|2_cp|3_worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a K3S custom cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+- projects:
+  - RRT
+  - RM
+  suite: Go Automation/Provisioning/K3S/Imported
+  cases:
+  - description: Provisions a 1 node all roles imported cluster
+    title: K3S_Imported|etcd_cp_worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a K3S imported cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 2 node stacked roles imported cluster
+    title: K3S_Imported|etcd_cp|worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a K3S imported cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 3 node split roles imported cluster
+    title: K3S_Imported|etcd|cp|worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a K3S imported cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 8 node 3etcd/2cp/3worker imported cluster
+    title: K3S_Imported|3_etcd|2_cp|3_worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a K3S imported cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+- projects:
+  - RRT
+  - RM
+  suite: Go Automation/Provisioning/K3S/PSACT
+  cases:
+  - description: Provisions a cluster with psact set to rancher privilaged
+    title: K3S_Rancher_Privileged|3_etcd|2_cp|3_worker
+    priority: 5
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a psact K3S cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a cluster with psact set to rancher restricted
+    title: K3S_Rancher_Restricted|3_etcd|2_cp|3_worker
+    priority: 5
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a psact K3S cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a cluster with psact set to rancher baseline
+    title: K3S_Rancher_Baseline|3_etcd|2_cp|3_worker
+    priority: 5
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a psact k3s cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+- projects:
+  - RRT
+  - RM
+  suite: Go Automation/Provisioning/K3S/Hardened
+  cases:
+  - description: Provisions a hardened 3etcd/2cp/3worker custom cluster
+    title: K3S_Rancher_Compliance
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a k3s custom cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Harden the k3s custom cluster
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 4
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+- projects:
+  - RRT
+  - RM
+  suite: Go Automation/Provisioning/K3S/Template
+  cases:
+  - description: Provisions a 3 node split roles cluster using an K3S template
+    title: K3S_Template|etcd|cp|worker
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a K3S template cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+- projects:
+  - RRT
+  - RM
+  suite: Go Automation/Provisioning/K3S/HostnameTruncation
+  cases:
+  - description: Provisions a 3 node split roles cluster with hostname truncation
+      enabled
+    title: K3S_Hostname_Truncation|10_Characters
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a cluster with hostname limit set to 10
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify that the hostname limit is respected
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+- projects:
+  - RRT
+  - RM
+  suite: Go Automation/Provisioning/K3S/HostnameTruncation
+  cases:
+  - description: Provisions a 3 node split roles cluster with hostname truncation
+      enabled
+    title: K3S_Hostname_Truncation|10_Characters
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a cluster with hostname limit set to 10
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify that the hostname limit is respected
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 3 node split roles cluster with hostname truncation
+      enabled
+    title: K3S_Hostname_Truncation|31_Characters
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a cluster with hostname limit set to 31
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify that the hostname limit is respected
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 3 node split roles cluster with hostname truncation
+      enabled
+    title: K3S_Hostname_Truncation|63_Characters
+    priority: 4
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a cluster with hostname limit set to 63
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify that the hostname limit is respected
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+- projects:
+  - RRT
+  - RM
+  suite: Go Automation/Provisioning/K3S/ACE
+  cases:
+  - description: Provisions a 3etcd/2cp/2worker node driver cluster with ACE enabled
+    title: K3S_ACE
+    priority: 5
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a k3s cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+- projects:
+  - RRT
+  - RM
+  suite: Go Automation/Provisioning/K3S/DataDirectories
+  cases:
+  - description: Provisions a 3 node split roles cluster with custom data directories
+    title: K3S_Split_Data_Directories
+    priority: 5
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a k3s cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    - action: Verify data directories on each node
+      expectedresult: ""
+      data: ""
+      position: 4
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters
+  - description: Provisions a 3 node split roles cluster with custom data directories
+    title: K3S_Grouped_Data_Directories
+    priority: 5
+    type: 8
+    automation: 2
+    attachments: []
+    steps:
+    - action: Create rancher provider credentials
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+      steps: []
+    - action: Provision a k3s cluster
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+      steps: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 3
+      attachments: []
+      steps: []
+    - action: Verify data directories on each node
+      expectedresult: ""
+      data: ""
+      position: 4
+      attachments: []
+      steps: []
+    tags: []
+    params: {}
+    parameters: []
+    customfield:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/provisioning/rke2/custom_test.go
+++ b/validation/provisioning/rke2/custom_test.go
@@ -1,4 +1,4 @@
-//go:build validation || recurring
+//go:build validation || recurring || sanity
 
 package rke2
 

--- a/validation/provisioning/rke2/imported_test.go
+++ b/validation/provisioning/rke2/imported_test.go
@@ -1,4 +1,4 @@
-//go:build validation || recurring
+//go:build validation || recurring || sanity
 
 package rke2
 

--- a/validation/provisioning/rke2/node_driver_test.go
+++ b/validation/provisioning/rke2/node_driver_test.go
@@ -1,4 +1,4 @@
-//go:build validation || recurring || pit.weekly
+//go:build validation || recurring || pit.weekly || sanity || mixed
 
 package rke2
 
@@ -100,6 +100,10 @@ func TestNodeDriver(t *testing.T) {
 			clusterConfig := new(clusters.ClusterConfig)
 			operations.LoadObjectFromMap(defaults.ClusterConfigKey, r.cattleConfig, clusterConfig)
 			clusterConfig.MachinePools = tt.machinePools
+
+			if clusterConfig.MixedArchitecture && len(tt.machinePools) == 1 && tt.machinePools[0].MachinePoolConfig.Worker && tt.machinePools[0].MachinePoolConfig.Etcd {
+				t.Skip("skipping all-roles pool: mixed architecture requires a dedicated worker pool")
+			}
 
 			require.NotNil(t, clusterConfig.Provider)
 

--- a/validation/recurring/infrastructure/upgraderancher/standard/main.go
+++ b/validation/recurring/infrastructure/upgraderancher/standard/main.go
@@ -1,22 +1,33 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 
+	"github.com/rancher/shepherd/clients/ec2"
+	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/pkg/config"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
+	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	infraConfig "github.com/rancher/tests/validation/recurring/infrastructure/config"
+	tfpConfig "github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/keypath"
+	tfpCustom "github.com/rancher/tfp-automation/tests/infrastructure/downstream/custom"
+	tfpImported "github.com/rancher/tfp-automation/tests/infrastructure/downstream/imported"
 	setupstandard "github.com/rancher/tfp-automation/tests/infrastructure/ranchers/setup/standard"
 	upgradestandard "github.com/rancher/tfp-automation/tests/infrastructure/ranchers/upgrade/standard"
 	"github.com/sirupsen/logrus"
@@ -39,6 +50,7 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("Failed to load package defaults: %v", err)
 	}
+
 	testSession := session.NewSession()
 
 	client, serverNodeOne, _, _, cattleConfig := setupstandard.SetupRancher(t, testSession, keypath.SanityKeyPath, cattleConfig)
@@ -61,6 +73,13 @@ func main() {
 	err = pods.VerifyClusterPods(client, cluster)
 	require.NoError(t, err)
 
+	// If awsEC2Configs is present in the cattleConfig, provision clusters before upgrading Rancher.
+	if _, ok := cattleConfig[ec2.ConfigurationFileKey]; !ok {
+		return
+	} else {
+		provisionClustersPreUpgrade(t, client, cattleConfig)
+	}
+
 	client, _, _, _ = upgradestandard.UpgradeRancher(t, client, serverNodeOne, testSession, cattleConfig)
 
 	cattleConfig, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, client.RancherConfig.AdminToken, cattleConfig)
@@ -77,4 +96,96 @@ func main() {
 	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
 	err = pods.VerifyClusterPods(client, cluster)
 	require.NoError(t, err)
+}
+
+func provisionClustersPreUpgrade(t *testing.T, client *rancher.Client, cattleConfig map[string]any) {
+	clusterConfig := new(clusters.ClusterConfig)
+	operations.LoadObjectFromMap(defaults.ClusterConfigKey, cattleConfig, clusterConfig)
+
+	provider := provisioning.CreateProvider(clusterConfig.Provider)
+	machineConfigSpec := provider.LoadMachineConfigFunc(cattleConfig)
+
+	awsEC2Configs := new(ec2.AWSEC2Configs)
+	operations.LoadObjectFromMap(ec2.ConfigurationFileKey, cattleConfig, awsEC2Configs)
+
+	nodeRolesStandard := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMachinePool,
+		provisioninginput.ControlPlaneMachinePool,
+		provisioninginput.WorkerMachinePool,
+	}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
+
+	rancher, terraform, terratest, _ := tfpConfig.LoadTFPConfigs(cattleConfig)
+
+	clusterConfig.MachinePools = nodeRolesStandard
+
+	customNodepoolsRKE2 := []tfpConfig.Nodepool{{Quantity: 1, Etcd: true}, {Quantity: 1, Controlplane: true}, {Quantity: 1, Worker: true}, {Quantity: 1, Windows: true}}
+	customNodepoolsK3S := []tfpConfig.Nodepool{{Quantity: 1, Etcd: true}, {Quantity: 1, Controlplane: true}, {Quantity: 1, Worker: true}}
+	importedNodepools := []tfpConfig.Nodepool{{Quantity: 3, Etcd: true}, {Quantity: 2, Controlplane: true}, {Quantity: 3, Worker: true}}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var errs []error
+
+	addErr := func(err error) {
+		mu.Lock()
+		errs = append(errs, err)
+		mu.Unlock()
+	}
+
+	for _, clusterType := range []string{defaults.RKE2, defaults.K3S} {
+		clusterType := clusterType
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			logrus.Infof("Provisioning %s node driver cluster", clusterType)
+			_, err := resources.ProvisionRKE2K3SCluster(t, client, clusterType, provider, *clusterConfig, machineConfigSpec, nil, true, false)
+			if err != nil {
+				addErr(fmt.Errorf("%s node driver: %w", clusterType, err))
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			terraformCustom := *terraform
+			terratestCustom := *terratest
+
+			if clusterType == defaults.RKE2 {
+				terratestCustom.Nodepools = customNodepoolsRKE2
+			} else {
+				terratestCustom.Nodepools = customNodepoolsK3S
+			}
+
+			logrus.Infof("Provisioning %s custom cluster", clusterType)
+			_, _, _, customCluster := tfpCustom.CreateCustomCluster(t, client, rancher, &terraformCustom, &terratestCustom, clusterType, "validation/provisioning/"+clusterType, false)
+			if err := provisioning.VerifyClusterReady(client, customCluster); err != nil {
+				addErr(fmt.Errorf("%s custom: %w", clusterType, err))
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			terraformImported := *terraform
+			terratestImported := *terratest
+			terratestImported.Nodepools = importedNodepools
+
+			logrus.Infof("Provisioning %s imported cluster", clusterType)
+			_, _, _, importedCluster := tfpImported.CreateImportedCluster(t, client, rancher, &terraformImported, &terratestImported, clusterType, "validation/provisioning/"+clusterType)
+			if err := provisioning.VerifyClusterReadyV3(client, importedCluster.Name); err != nil {
+				addErr(fmt.Errorf("%s imported: %w", clusterType, err))
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
 }


### PR DESCRIPTION
## Summary
Ports the sanity testing workflows from `rancher/tfp-automation` into `rancher/tests`.
## What Changed
- Moved the sanity testing workflow definitions into the `rancher/tests` repository
- Updated the test repository to own and run these workflows directly
- Consolidated sanity test automation so it is maintained alongside the test suite