### PR TITLE
Fix NeuVector test cleanup hang and error spam

### DIFF
--- a/actions/charts/neuvector.go
+++ b/actions/charts/neuvector.go
@@ -42,6 +42,10 @@ func uninstallChartIfPresent(catalogClient *catalog.Client, namespace, chartName
 		return err
 	}
 	if err := catalogClient.UninstallChart(chartName, namespace, NewChartUninstallAction()); err != nil {
+		if k8sErrors.IsNotFound(err) {
+			// Chart was removed between the Get and the uninstall call — treat as success.
+			return nil
+		}
 		return err
 	}
 	return waitChartGone(catalogClient, namespace, chartName)

--- a/actions/uiplugins/constants.go
+++ b/actions/uiplugins/constants.go
@@ -1,16 +1,8 @@
 package uiplugins
 
-import (
-	"github.com/rancher/shepherd/extensions/defaults"
-)
-
 const (
 	harvesterExtensionsName  = "harvester"
 	stackstateExtensionsName = "observability"
 	stackstatePluginName     = "rancher-ui-plugins"
 	local                    = "local"
-)
-
-var (
-	timeoutSeconds = int64(defaults.TwoMinuteTimeout)
 )

--- a/actions/uiplugins/uiplugins.go
+++ b/actions/uiplugins/uiplugins.go
@@ -2,7 +2,7 @@ package uiplugins
 
 import (
 	"context"
-	"fmt"
+	"time"
 
 	v1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
 	"github.com/rancher/shepherd/clients/rancher"
@@ -11,12 +11,16 @@ import (
 	"github.com/rancher/shepherd/pkg/api/steve/catalog/types"
 	"github.com/rancher/shepherd/pkg/wait"
 	"github.com/sirupsen/logrus"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
 const (
 	extensionNamespace = "cattle-ui-plugin-system"
+	pollInterval       = 5 * time.Second
+	pollTimeout        = 2 * time.Minute
 )
 
 // newUIPluginInstallAction is a private helper function that returns chart install action with the extension payload options.
@@ -47,32 +51,24 @@ func InstallUIPlugin(client *rancher.Client, installExtensionOptions *ExtensionO
 
 		err := catalogClient.UninstallChart(installExtensionOptions.ChartName, extensionNamespace, defaultChartUninstallAction)
 		if err != nil {
+			if k8sErrors.IsNotFound(err) {
+				// Extension was already removed — nothing to clean up.
+				return nil
+			}
 			return err
 		}
 
-		watchAppInterface, err := catalogClient.Apps(extensionNamespace).Watch(context.TODO(), metav1.ListOptions{
-			FieldSelector:  "metadata.name=" + installExtensionOptions.ChartName,
-			TimeoutSeconds: &timeoutSeconds,
-		})
-		if err != nil {
-			return err
-		}
-
-		err = wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
-			chart := event.Object.(*v1.App)
-			if event.Type == watch.Error {
-				return false, fmt.Errorf("there was an error uninstalling %s extension", installExtensionOptions.ChartName)
-			} else if event.Type == watch.Deleted {
-				logrus.Infof("Uninstalled %s extension successfully.", installExtensionOptions)
-				return true, nil
-			} else if chart == nil {
+		// Poll until the extension App is gone. A watch started after
+		// UninstallChart can miss the Deleted event when the uninstall
+		// completes quickly (same race as the repo-delete cleanup).
+		return kwait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
+			_, getErr := catalogClient.Apps(extensionNamespace).Get(ctx, installExtensionOptions.ChartName, metav1.GetOptions{})
+			if k8sErrors.IsNotFound(getErr) {
+				logrus.Infof("Uninstalled %s extension successfully.", installExtensionOptions.ChartName)
 				return true, nil
 			}
-			return false, nil
-
+			return false, getErr
 		})
-
-		return err
 
 	})
 	err = catalogClient.InstallChart(extensionInstallAction, chartRepoName)
@@ -130,28 +126,24 @@ func CreateExtensionsRepo(client *rancher.Client, rancherUiPluginsName, uiExtens
 	client.Session.RegisterCleanupFunc(func() error {
 		err := client.Catalog.ClusterRepos().Delete(context.TODO(), repoObject.Name, metav1.DeleteOptions{})
 		if err != nil {
+			if k8sErrors.IsNotFound(err) {
+				// Repo was already removed — nothing to clean up.
+				return nil
+			}
 			return err
 		}
 
-		watchAppInterface, err := client.Catalog.ClusterRepos().Watch(context.TODO(), metav1.ListOptions{
-			FieldSelector:  "metadata.name=" + repoObject.Name,
-			TimeoutSeconds: &defaults.WatchTimeoutSeconds,
-		})
-		if err != nil {
-			return err
-		}
-
-		err = wait.WatchWait(watchAppInterface, func(event watch.Event) (ready bool, err error) {
-			if event.Type == watch.Error {
-				return false, fmt.Errorf("there was an error deleting the cluster repo")
-			} else if event.Type == watch.Deleted {
+		// Poll until the repo is gone. A watch started after Delete can miss the
+		// Deleted event because the resource is removed synchronously before the
+		// watch connects, causing it to block until the 30-minute watch timeout.
+		return kwait.PollUntilContextTimeout(context.Background(), pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
+			_, getErr := client.Catalog.ClusterRepos().Get(ctx, repoObject.Name, metav1.GetOptions{})
+			if k8sErrors.IsNotFound(getErr) {
 				logrus.Info("Removed extensions repo successfully.")
 				return true, nil
 			}
-			return false, nil
+			return false, getErr
 		})
-
-		return err
 	})
 
 	watchAppInterface, err := client.Catalog.ClusterRepos().Watch(context.TODO(), metav1.ListOptions{


### PR DESCRIPTION
## Summary

The NeuVector hardened test suite (`TestNeuVectorHardenedTestSuite`) passed but exhibited two problems during `session.Cleanup()`:
1. **35+ minute runtime** (actual test logic ~5 min, cleanup ~30 min)
2. **`level=error` messages** about failed resource cleanup

## Root Causes

### 1. `timeoutSeconds` type conversion bug (`actions/uiplugins/constants.go`)

```go
// BUG: time.Duration is nanoseconds — int64() gives 120,000,000,000
timeoutSeconds = int64(defaults.TwoMinuteTimeout)
```

Used as `metav1.ListOptions.TimeoutSeconds` (which expects **seconds**), this caused the `InstallUIPlugin` cleanup watch to stay open for ~3,800 years in theory — practically ~30 minutes until the server/proxy severed the connection. **Removed** the variable entirely (no longer needed after fix #2).

### 2. Delete-then-Watch race condition (`actions/uiplugins/uiplugins.go`)

Both `InstallUIPlugin` and `CreateExtensionsRepo` cleanup functions used:
```
1. Delete/Uninstall resource  → gone immediately (synchronous)
2. Start Watch for Deleted    → event already fired, missed!
3. WatchWait blocks           → 30 min (defaults.WatchTimeoutSeconds)
```

A Kubernetes watch only sees events **after** it connects. For `ClusterRepos().Delete()`, the resource is removed synchronously — the `Deleted` event fires before the watch starts, so `WatchWait` blocks until the 30-minute timeout.

**Fix:** Replaced both watches with `kwait.PollUntilContextTimeout` polling `Get` until `NotFound` — the same pattern `waitChartGone` already uses in `neuvector.go`:

```go
return kwait.PollUntilContextTimeout(ctx, pollInterval, pollTimeout, true, func(ctx context.Context) (bool, error) {
    _, getErr := client.Catalog.ClusterRepos().Get(ctx, repoObject.Name, metav1.GetOptions{})
    if k8sErrors.IsNotFound(getErr) {
        return true, nil
    }
    return false, getErr
})
```

### 3. Non-idempotent cleanups (`uiplugins.go`, `neuvector.go`)

Cleanup functions returned errors when resources were already gone (`NotFound`), triggering `session.Cleanup()`'s 5-step `ExponentialBackoff` retries and `level=error` logs. All three cleanup paths now treat `NotFound` as success:
- `CreateExtensionsRepo` cleanup → `Delete` returns `IsNotFound` → `return nil`
- `InstallUIPlugin` cleanup → `UninstallChart` returns `IsNotFound` → `return nil`
- `uninstallChartIfPresent` → `UninstallChart` returns `IsNotFound` → `return nil`

## Before / After

| Metric | Before | After |
|---|---|---|
| Suite runtime | ~35 min | ~6 min |
| `level=error` lines | 2 | 0 |
| Test result | PASS | PASS |

## Test plan

- [x] `go build` + `go vet` pass for `actions/uiplugins`, `actions/charts`, and `validation/neuvector`
- [x] `gofmt` clean
- [x] Full `TestNeuVectorHardenedTestSuite` run (CI)