### PR TITLE
docs(neuvector): document airgap cluster prerequisites (#806)

### DIFF
--- a/actions/registries/registries.go
+++ b/actions/registries/registries.go
@@ -12,9 +12,30 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// CheckAllClusterPodsForRegistryPrefix checks the pods of a cluster and checks to see if they're coming from the
-// expected registry fqdn.
+// CheckAllClusterPodsForRegistryPrefix checks every pod in a cluster and reports whether
+// all pod images that carry a registry FQDN start with the expected registry prefix.
+//
+// Note: on airgap clusters, RKE2/Rancher system pods (kube-system, calico-system,
+// tigera-operator, ...) are mirrored at the containerd level, so their image strings keep
+// the original registry (e.g. docker.io) even though they are pulled from the private
+// registry. To verify a specific application's pods without tripping on those system pods,
+// use CheckNamespacedPodsForRegistryPrefix instead.
 func CheckAllClusterPodsForRegistryPrefix(client *rancher.Client, clusterID, registryPrefix string) (bool, error) {
+	return checkPodsForRegistryPrefix(client, clusterID, "", registryPrefix)
+}
+
+// CheckNamespacedPodsForRegistryPrefix is like CheckAllClusterPodsForRegistryPrefix but
+// scoped to a single namespace. Use it to verify a specific application's pods (e.g.
+// NeuVector in cattle-neuvector-system) without false-failing on containerd-mirrored
+// system pods whose image strings are not rewritten.
+func CheckNamespacedPodsForRegistryPrefix(client *rancher.Client, clusterID, namespace, registryPrefix string) (bool, error) {
+	return checkPodsForRegistryPrefix(client, clusterID, namespace, registryPrefix)
+}
+
+// checkPodsForRegistryPrefix lists pods (cluster-wide when namespace is empty, otherwise
+// restricted to namespace) and reports false if any pod image that carries a registry FQDN
+// does not start with registryPrefix.
+func checkPodsForRegistryPrefix(client *rancher.Client, clusterID, namespace, registryPrefix string) (bool, error) {
 	if strings.Contains(registryPrefix, "registry-1.docker.io") {
 		logrus.Infof("Skipping registry prefix check for public docker registry: %s", registryPrefix)
 		return true, nil
@@ -26,7 +47,12 @@ func CheckAllClusterPodsForRegistryPrefix(client *rancher.Client, clusterID, reg
 	}
 
 	steveClient := downstreamClient.SteveType(pods.PodResourceSteveType)
-	podsList, err := steveClient.List(nil)
+	var podsList *v1.SteveCollection
+	if namespace == "" {
+		podsList, err = steveClient.List(nil)
+	} else {
+		podsList, err = steveClient.NamespacedSteveClient(namespace).List(nil)
+	}
 	if err != nil {
 		return false, err
 	}

--- a/actions/registries/registries.go
+++ b/actions/registries/registries.go
@@ -57,6 +57,13 @@ func checkPodsForRegistryPrefix(client *rancher.Client, clusterID, namespace, re
 		return false, err
 	}
 
+	if len(podsList.Data) == 0 {
+		if namespace == "" {
+			return false, fmt.Errorf("no pods found in cluster %s", clusterID)
+		}
+		return false, fmt.Errorf("no pods found in namespace %s of cluster %s", namespace, clusterID)
+	}
+
 	for _, pod := range podsList.Data {
 		podSpec := &corev1.PodSpec{}
 		err := v1.ConvertToK8sType(pod.Spec, podSpec)

--- a/validation/charts/neuvector_test.go
+++ b/validation/charts/neuvector_test.go
@@ -113,7 +113,7 @@ func (n *NeuVectorTestSuite) TestNeuVectorInstallation() {
 
 	if n.chartInstallOptions.DefaultRegistry != "" {
 		n.T().Logf("Verifying NeuVector pods use registry prefix %q", n.chartInstallOptions.DefaultRegistry)
-		isUsingRegistry, err := registries.CheckAllClusterPodsForRegistryPrefix(client, n.cluster.ID, n.chartInstallOptions.DefaultRegistry)
+		isUsingRegistry, err := registries.CheckNamespacedPodsForRegistryPrefix(client, n.cluster.ID, actionsCharts.NeuVectorNamespace, n.chartInstallOptions.DefaultRegistry)
 		require.NoError(n.T(), err)
 		require.True(n.T(), isUsingRegistry, "NeuVector pods are not using the expected registry prefix %q", n.chartInstallOptions.DefaultRegistry)
 	}

--- a/validation/neuvector/AIRGAP.md
+++ b/validation/neuvector/AIRGAP.md
@@ -1,0 +1,235 @@
+# Airgap Cluster Prerequisites for NeuVector Tests
+
+This document lists everything the pipeline-provisioned cluster must provide before the NeuVector hardened test suite (`TestNeuVectorHardenedTestSuite`) can run in an airgap environment.
+
+The test itself does **not** provision clusters — it targets an existing cluster via `rancher.clusterName` (see [Architecture Decision in #803](https://github.com/rancher/tests/issues/803#user-content-architecture-decision-target-existing-cluster-2026-08-10)). All infrastructure setup is the airgap pipeline's responsibility (Slice 4, [#807](https://github.com/rancher/tests/issues/807)).
+
+---
+
+## 1. Private Registry Configured
+
+The downstream cluster nodes must have an RKE2/K3s `registries.yaml` pointing at the airgap private registry. This is configured by the pipeline's "Deploy Cluster" and "Deploy Registry" stages.
+
+**RKE2** — `/etc/rancher/rke2/registries.yaml`:
+
+```yaml
+configs:
+  "{}":
+    auth:
+      username: registry-user
+      password: <PRIVATE_REGISTRY_PASSWORD>
+    tls:
+      insecure_skip_verify: true
+```
+
+**K3s** — `/etc/rancher/k3s/registries.yaml` (same format).
+
+This ensures all container runtime image pulls (system images + workload images) resolve against the private registry.
+
+---
+
+## 2. `system-default-registry` Rancher Setting
+
+The Rancher management cluster must have the `system-default-registry` setting configured so the NeuVector chart install propagates it into chart values.
+
+```bash
+# Set via Rancher API or UI
+kubectl patch setting system-default-registry \
+  --namespace cattle-system \
+  --type merge \
+  -p '{"value":"<REGISTRY_HOST>:<PORT>"}'
+```
+
+The test reads this setting in `SetupSuite` (`neuvector_hardened_test.go:150`) and passes it as `DefaultRegistry` in the chart payload (`actions/charts/neuvector.go`). When non-empty, the test additionally verifies that all NeuVector pods use the registry prefix (`neuvector_hardened_test.go:198-203`).
+
+In non-airgap environments this setting exists but is empty — no change to current behavior.
+
+---
+
+## 3. Mirrored NeuVector Images
+
+The private registry must contain all NeuVector component images. The exact tag depends on the chart version (the test installs the latest from `rancher-charts`).
+
+### Core images
+
+| Component   | Image Repository (upstream)     | Tag Source                         | Chart Path                          |
+|-------------|---------------------------------|------------------------------------|-------------------------------------|
+| Controller  | `neuvector/controller`          | top-level `tag` (e.g. `5.6.0`)     | `controller.image.repository`       |
+| Manager     | `neuvector/manager`             | top-level `tag`                    | `manager.image.repository`          |
+| Enforcer    | `neuvector/enforcer`            | top-level `tag`                    | `enforcer.image.repository`         |
+| Scanner     | `neuvector/scanner`             | `cve.scanner.image.tag` (e.g. `6`) | `cve.scanner.image.repository`      |
+| Updater     | `neuvector/updater`             | `cve.updater.image.tag` (e.g. `0.0.13`) | `cve.updater.image.repository` |
+
+### Optional images (enabled by chart config)
+
+| Component             | Image Repository (upstream)        | When needed                                    |
+|-----------------------|------------------------------------|------------------------------------------------|
+| Compliance config     | `neuvector/compliance-config`      | `controller.prime.enabled: true`               |
+| CVE registry adapter  | `neuvector/registry-adapter`       | `cve.adapter.enabled: true`                    |
+
+### How to extract the exact image list for a specific chart version
+
+```bash
+# Pull the chart and inspect values for image tags
+helm pull rancher-charts/neuvector --version <CHART_VERSION> --untar
+grep -A2 'repository:' neuvector/values.yaml | grep 'neuvector/'
+```
+
+### Mirroring command
+
+```bash
+# Example: mirror NeuVector 5.6.0 images to a private registry
+REGISTRY="<REGISTRY_HOST>:<PORT>"
+TAG="5.6.0"
+
+for img in controller manager enforcer; do
+  docker pull "docker.io/neuvector/${img}:${TAG}"
+  docker tag  "docker.io/neuvector/${img}:${TAG}" "${REGISTRY}/neuvector/${img}:${TAG}"
+  docker push "${REGISTRY}/neuvector/${img}:${TAG}"
+done
+
+# Scanner and updater have their own tags
+docker pull docker.io/neuvector/scanner:6
+docker tag  docker.io/neuvector/scanner:6 "${REGISTRY}/neuvector/scanner:6"
+docker push "${REGISTRY}/neuvector/scanner:6"
+
+docker pull docker.io/neuvector/updater:0.0.13
+docker tag  docker.io/neuvector/updater:0.0.13 "${REGISTRY}/neuvector/updater:0.0.13"
+docker push "${REGISTRY}/neuvector/updater:0.0.13"
+```
+
+> **Note:** The Rancher-packaged chart (`rancher-charts/neuvector`) may use Rancher-mirrored image names (e.g. `rancher/mirrored-neuvector-controller`). Inspect the chart values to confirm exact repository paths for your version.
+
+---
+
+## 4. `rancher-charts` Repo Mirrored
+
+The airgap Rancher must have the NeuVector chart available in its local `rancher-charts` mirror. This is part of the standard airgap Rancher setup — the Rancher airgap installation tooling mirrors the charts catalog.
+
+The test fetches chart versions via:
+
+```go
+latestVersions, err := n.client.Catalog.GetListChartVersions(actionsCharts.NeuVectorChartName, catalog.RancherChartRepo)
+```
+
+If the chart is not in the local `rancher-charts`, this call returns an empty list and the test fails.
+
+Verify:
+
+```bash
+# Check that the NeuVector chart is available in rancher-charts
+kubectl get clusterrepo rancher-charts -o jsonpath='{.status.conditions}'
+```
+
+---
+
+## 5. NeuVector UI Extension (optional)
+
+The NeuVector UI extension (`neuvector-ui-ext`) runs on the **local** Rancher cluster, not the downstream cluster. In airgap, choose one:
+
+### Option A: Pre-install the extension
+
+If the extension is already installed, the test auto-detects it via chart status and skips the install:
+
+```go
+uiExtensionObj, err := charts.GetChartStatus(n.client, "local", ...)
+if uiExtensionObj.IsAlreadyInstalled { /* skip */ }
+```
+
+No configuration needed — the test handles it.
+
+### Option B: Internal git mirror
+
+Point the UI plugin charts ClusterRepo at an internal mirror reachable from the Rancher server:
+
+```yaml
+neuvectorTest:
+  uiPluginChartsURL: "https://internal-git.example.com/rancher/ui-plugin-charts"
+  uiPluginChartsBranch: "main"
+```
+
+### Option C: Skip the extension entirely
+
+When the Rancher server cannot reach `github.com` **and** no internal mirror is configured:
+
+```yaml
+neuvectorTest:
+  skipUIExtension: true
+```
+
+The suite still installs and validates the NeuVector backend chart and reaches the manager UI through the Kubernetes service proxy, so the test remains meaningful without the Rancher UI extension.
+
+---
+
+## Cattle-Config for Airgap
+
+```yaml
+rancher:
+  host: "https://<RANCHER_HOST>"
+  adminToken: "<RANCHER_ADMIN_TOKEN>"
+  clusterName: "<PIPELINE_PROVISIONED_CLUSTER_NAME>"  # targets existing cluster
+  insecure: true
+  cleanup: true
+
+neuvectorTest:
+  skipUIExtension: true    # Option C (adjust per your airgap setup)
+  # OR:
+  # uiPluginChartsURL: "https://internal-git.example.com/rancher/ui-plugin-charts"
+  # uiPluginChartsBranch: "main"
+```
+
+Key differences from non-airgap config:
+- `rancher.clusterName` is set (no `qaInfraAutomation.customCluster` provisioning section)
+- `neuvectorTest.skipUIExtension` or `neuvectorTest.uiPluginChartsURL` is configured
+- The `system-default-registry` setting is configured on Rancher by the pipeline, not by the test
+
+---
+
+## Verification
+
+After the pipeline provisions the cluster and before running tests, verify:
+
+```bash
+# 1. system-default-registry is set on Rancher
+kubectl get setting system-default-registry -o jsonpath='{.value}'
+# Expected: <REGISTRY_HOST>:<PORT> (non-empty)
+
+# 2. NeuVector chart is available in rancher-charts
+# (verify via Rancher UI or API)
+
+# 3. Images are present in the private registry
+# (verify via registry API or docker pull from an airgap node)
+```
+
+After the test run, verify:
+
+```bash
+# 4. NeuVector pods use the private registry prefix (no ImagePullBackOff)
+kubectl get pods -n cattle-neuvector-system -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.spec.containers[*].image}{"\n"}{end}'
+# All images should start with <REGISTRY_HOST>:<PORT>/
+```
+
+---
+
+## Pipeline Reference (Slice 4, #807)
+
+The airgap pipeline (`Jenkinsfile.neuvector.airgap-rke2`) is responsible for provisioning all prerequisites listed above:
+
+| Pipeline Stage           | Prerequisite Satisfied                     |
+|--------------------------|--------------------------------------------|
+| Deploy Cluster           | RKE2/K3s nodes with `registries.yaml` (#1) |
+| Deploy Registry          | Private registry with mirrored images (#3) |
+| Deploy Rancher           | Rancher with `system-default-registry` (#2) and `rancher-charts` mirror (#4) |
+| (pre-install or config)  | NeuVector UI extension (#5, if applicable) |
+
+The pipeline generates a cattle-config with `rancher.clusterName` targeting the provisioned cluster — no `qaInfraAutomation` provisioning section is needed.
+
+---
+
+## Related
+
+- [#803](https://github.com/rancher/tests/issues/803) — Parent PRD
+- [#804](https://github.com/rancher/tests/issues/804) — Slice 1: Registry propagation
+- [#806](https://github.com/rancher/tests/issues/806) — Slice 3: This document
+- [#807](https://github.com/rancher/tests/issues/807) — Slice 4: Airgap pipeline
+- [#808](https://github.com/rancher/tests/issues/808) — Slice 5: Build-tag policy

--- a/validation/neuvector/README.md
+++ b/validation/neuvector/README.md
@@ -1,22 +1,39 @@
 # NeuVector Validation Tests
 
 Tests in this directory verify NeuVector installation on Rancher-managed downstream clusters.
-Infrastructure is provisioned via the `interoperability/qainfraautomation` package.
+
+The test supports two modes:
+
+- **Existing cluster** (default for airgap): set `rancher.clusterName` to target a pre-provisioned cluster. No provisioning tooling required.
+- **Self-provisioned cluster**: when `rancher.clusterName` is empty, the test provisions a hardened custom cluster via the `interoperability/qainfraautomation` package.
 
 ## Prerequisites
 
 - A running Rancher instance reachable by the test binary
-- OpenTofu installed and in `$PATH`
-- Ansible installed and in `$PATH`
-- provider defined in qaInfraAutomation for use in a custom cluster (custom cluster required for hardening)
+- **Existing cluster mode**: a downstream cluster already imported/created in Rancher, with `rancher.clusterName` set in the config
+- **Self-provisioned cluster mode**: OpenTofu and Ansible in `$PATH`, plus a provider defined in `qaInfraAutomation` for a custom cluster (custom cluster required for hardening)
+
+> **Airgap?** See [AIRGAP.md](./AIRGAP.md) for the full list of cluster prerequisites (private registry, mirrored images, `system-default-registry`, etc.).
 
 ## Config
 
 The test reads configuration from a YAML file pointed to by `$CATTLE_TEST_CONFIG`.
 
+### Existing cluster (recommended for airgap)
+
+Set `rancher.clusterName` to target a cluster already present in Rancher. The test skips all provisioning and runs directly against the named cluster:
+
+```yaml
+rancher:
+  clusterName: "my-existing-cluster"
+```
+
+### Self-provisioned custom cluster (Ansible-registered nodes)
+
+When `rancher.clusterName` is empty, the test provisions its own cluster. Requires `qaInfraAutomation` config:
+
 Top-level key: `qaInfraAutomation`
 
-### Custom cluster (Ansible-registered nodes)
 
 Set exactly one supported provider alongside `customCluster`:
 

--- a/validation/neuvector/neuvector_hardened_test.go
+++ b/validation/neuvector/neuvector_hardened_test.go
@@ -197,7 +197,7 @@ func (n *NeuVectorHardenedTestSuite) TestNeuVectorInstallation() {
 
 	if registrySetting.Value != "" {
 		n.T().Logf("Verifying NeuVector pods use registry prefix %q", registrySetting.Value)
-		isUsingRegistry, err := registries.CheckAllClusterPodsForRegistryPrefix(n.client, n.cluster.ID, registrySetting.Value)
+		isUsingRegistry, err := registries.CheckNamespacedPodsForRegistryPrefix(n.client, n.cluster.ID, actionsCharts.NeuVectorNamespace, registrySetting.Value)
 		require.NoError(n.T(), err)
 		require.True(n.T(), isUsingRegistry, "NeuVector pods are not using the expected registry prefix %q", registrySetting.Value)
 	}

--- a/validation/neuvector/schemas/pit_schemas.yaml
+++ b/validation/neuvector/schemas/pit_schemas.yaml
@@ -2,52 +2,60 @@
   suite: Charts
   cases:
   - title: "NeuVector Hardened Chart Installation"
-    description: "Verify NeuVector chart installs successfully on a hardened custom cluster with UI extension and service proxy accessibility"
+    description: "Verify NeuVector chart installs successfully on a hardened cluster with UI extension, registry propagation, and service proxy accessibility"
     automation: 2
     steps:
-    - action: "Provision a hardened custom cluster via QA infra automation"
-      data: "Harden: true, KubernetesVersion: as configured"
-      expectedresult: "Hardened custom cluster is active and ready to receive workloads"
+    - action: "Target an existing cluster via rancher.clusterName, or provision a hardened custom cluster via QA infra automation when clusterName is empty"
+      data: "Harden: true (self-provisioned path only), KubernetesVersion: as configured"
+      expectedresult: "Cluster is targeted or provisioned, active, and ready to receive workloads"
       position: 1
     - action: "Ensure NeuVector UI extension repo is registered"
-      data: "Repo name: rancher-ui-plugins, URL: https://github.com/rancher/ui-plugin-charts, Branch: main"
+      data: "Repo name: rancher-ui-plugins, URL: from neuvectorTest.uiPluginChartsURL or default https://github.com/rancher/ui-plugin-charts, Branch: main. Skipped when neuvectorTest.skipUIExtension=true or extension already installed"
       expectedresult: "UI plugin chart repo is present in the local cluster"
       position: 2
     - action: "Install NeuVector UI extension on local cluster if not already installed"
       data: "Chart: neuvector-ui-ext, Version: latest from rancher-ui-plugins repo"
       expectedresult: "NeuVector UI extension is installed successfully"
       position: 3
-    - action: "Verify cluster deployments and pods are healthy"
+    - action: "Verify cluster deployments and pods are healthy (self-provisioned path only)"
       data: "Cluster: provisioned hardened cluster"
       expectedresult: "All cluster deployments and pods are in a healthy state"
       position: 4
+    - action: "Retrieve system-default-registry setting from Rancher"
+      data: "Setting: system-default-registry. Empty in non-airgap; set to private registry host:port in airgap"
+      expectedresult: "system-default-registry value is retrieved and stored for chart payload propagation"
+      position: 5
     - action: "Retrieve System project from the cluster"
       data: "Project name: System"
       expectedresult: "System project is found successfully"
-      position: 5
-    - action: "Fetch latest NeuVector chart version"
-      data: "Chart: neuvector, Repo: rancher chart repository"
-      expectedresult: "Latest NeuVector chart version is retrieved"
       position: 6
-    - action: "Install NeuVector chart with hardened configuration"
-      data: "Namespace: neuvector-system, Hardened: true, K3s: based on cluster Kubernetes version"
-      expectedresult: "NeuVector chart installation starts successfully"
+    - action: "Fetch latest NeuVector chart version"
+      data: "Chart: neuvector, Repo: rancher-charts"
+      expectedresult: "Latest NeuVector chart version is retrieved"
       position: 7
-    - action: "Wait for NeuVector chart installation to complete"
-      data: "Namespace: neuvector-system"
-      expectedresult: "NeuVector chart reports successful installation"
+    - action: "Install NeuVector chart and NeuVector CRD chart with hardened configuration"
+      data: "Namespace: cattle-neuvector-system, Hardened: true (enforcer apparmor annotation, securityContext with SYS_ADMIN/NET_ADMIN/SYS_PTRACE/IPC_LOCK capabilities and Unconfined seccomp), K3s: derived from cluster.Provider, DefaultRegistry: from system-default-registry setting"
+      expectedresult: "NeuVector and NeuVector CRD chart installation starts successfully"
       position: 8
-    - action: "Verify NeuVector deployments readiness"
-      data: "Watch and wait for all deployments in neuvector-system namespace"
-      expectedresult: "All NeuVector deployments are in Ready state"
+    - action: "Wait for NeuVector chart installation to complete"
+      data: "Namespace: cattle-neuvector-system"
+      expectedresult: "NeuVector chart reports successful installation"
       position: 9
-    - action: "Verify NeuVector daemonsets readiness"
-      data: "Watch and wait for all daemonsets in neuvector-system namespace"
-      expectedresult: "All NeuVector daemonsets are in Ready state"
+    - action: "Verify NeuVector deployments readiness"
+      data: "Watch and wait for all deployments in cattle-neuvector-system namespace"
+      expectedresult: "All NeuVector deployments are in Ready state"
       position: 10
-    - action: "Verify NeuVector manager UI is reachable via service proxy"
-      data: "Service: neuvector-service-webui, Port: 8443, Namespace: neuvector-system"
-      expectedresult: "NeuVector manager UI returns a successful response via the Rancher service proxy"
+    - action: "Verify NeuVector daemonsets readiness"
+      data: "Watch and wait for all daemonsets in cattle-neuvector-system namespace"
+      expectedresult: "All NeuVector daemonsets are in Ready state"
       position: 11
+    - action: "Verify NeuVector pods use private registry prefix when system-default-registry is set"
+      data: "Registry prefix: system-default-registry value. Skipped when registry is empty (non-airgap)"
+      expectedresult: "All NeuVector pods pull images from the configured private registry, no ImagePullBackOff"
+      position: 12
+    - action: "Verify NeuVector manager UI is reachable via service proxy"
+      data: "Service: neuvector-service-webui, Port: 8443, Namespace: cattle-neuvector-system"
+      expectedresult: "NeuVector manager UI returns a successful response via the Rancher service proxy"
+      position: 13
     custom_field:
       "15": "TestNeuVectorInstallation"


### PR DESCRIPTION
## Summary

Closes #806 (Slice 3: Cluster prerequisites documentation).

Creates `validation/neuvector/AIRGAP.md` documenting everything the pipeline-provisioned cluster must provide before the NeuVector hardened test suite can run in airgap.

## What Changed

### New: `validation/neuvector/AIRGAP.md`

Documents the five required cluster prerequisites:

1. **Private registry configured** — RKE2/K3s `registries.yaml` on all nodes
2. **`system-default-registry` setting** — read by the test in `SetupSuite`, propagated into chart values, verified against pod images
3. **Mirrored NeuVector images** — detailed table with exact chart value paths:
   | Component  | Image                       | Tag Source              |
   |------------|-----------------------------|-------------------------|
   | Controller | `neuvector/controller`      | top-level `tag`         |
   | Manager    | `neuvector/manager`         | top-level `tag`         |
   | Enforcer   | `neuvector/enforcer`        | top-level `tag`         |
   | Scanner    | `neuvector/scanner`         | `cve.scanner.image.tag` |
   | Updater    | `neuvector/updater`         | `cve.updater.image.tag` |

   Includes mirroring commands and a method to extract exact image lists for any chart version.

4. **`rancher-charts` repo mirrored** — NeuVector chart must be available in the airgap Rancher's local charts catalog
5. **NeuVector UI extension** (optional) — three options: pre-install, internal git mirror, or skip entirely

Also includes: airgap cattle-config example, verification commands, and a pipeline-reference table mapping Slice 4 (#807) pipeline stages to the prerequisites they satisfy.

### Updated: `validation/neuvector/README.md`

- Documents the **existing-cluster mode** (`rancher.clusterName`) alongside the self-provisioned mode
- Splits prerequisites by mode
- Links to `AIRGAP.md` for airgap-specific requirements

## Acceptance Criteria (from #806)

- [x] Documentation exists listing all required cluster prerequisites for airgap NeuVector tests
- [x] Documentation lists the specific NeuVector images that must be mirrored
- [x] The airgap pipeline (#807) can reference this documentation for its cluster provisioning stages (Pipeline Reference section)

## Test plan

- [x] Markdown renders correctly
- [x] Image names verified against the upstream NeuVector helm chart `values.yaml` ([source](https://github.com/neuvector/neuvector-helm/blob/master/charts/core/values.yaml))
- [x] Chart value paths verified against `actions/charts/neuvector.go` and `actions/charts/payloads.go`
- [x] Test code references (`neuvector_hardened_test.go` line numbers) verified against current source

## Related

- #803 (Parent PRD)
- #804 (Slice 1: Registry propagation)
- #806 (This issue)
- #807 (Slice 4: Airgap pipeline — references this doc)
- #808 (Slice 5: Build-tag policy)