### PR TITLE
Migrate KDM, MCM feature-disabled, dual-stack, and IPv6 upgrade workflows from rancher/tfp-automation to rancher/tests

### DIFF
--- a/.github/actions/run-test-suite/action.yaml
+++ b/.github/actions/run-test-suite/action.yaml
@@ -13,7 +13,7 @@ inputs:
     required: true
   test-suite:
     description: "Suite to test"
-    required: true
+    required: false
   timeout:
     description: "Timeout"
     required: true
@@ -27,8 +27,23 @@ runs:
       continue-on-error: true
       run: |
         set +e
-        gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/${{ inputs.package }} \
-        --junitfile results.xml --jsonfile results.json -- -timeout=${{ inputs.timeout }} -tags=${{ inputs.tag }} -v -run "${{ inputs.test-suite }}"
+
+        if [[ "${{ inputs.test-suite }}" != "" ]]; then
+          gotestsum --format standard-verbose \
+          --packages=github.com/rancher/tests/validation/${{ inputs.package }} \
+          --junitfile results.xml \
+          --jsonfile results.json \
+          -- -timeout=${{ inputs.timeout }} -tags=${{ inputs.tag }} -v -run "${{ inputs.test-suite }}"
+        else
+          gotestsum --format standard-verbose \
+          --packages=github.com/rancher/tests/validation/kdm/... \
+          --junitfile results.xml \
+          --jsonfile results.json \
+          -- -timeout=2h -tags=${{ inputs.tag }} -v
+        fi
+
+        test_exit_code=$?
+        echo "test_exit_code=$test_exit_code" >> "$GITHUB_ENV"
 
         if [[ "${{ inputs.reporting }}" == "true" ]]; then
           ./validation/pipeline/scripts/build_qase_reporter_v2.sh;
@@ -38,23 +53,13 @@ runs:
     - name: Show failed tests
       shell: bash
       run: |
-        declare -A suites=(
-          [exit]="Test Suite: ${{ inputs.test-suite }}:results.json"
-        )
-
-        failed=0
-
-        for exit_code in "${!suites[@]}"; do
-          IFS=: read suite_name results_file <<< "${suites[$exit_code]}"
-          exit_val="${!exit_code}"
-
-          if [ "$exit_val" != "" ] && [ "$exit_val" -ne 0 ]; then
-            echo "Failed $suite_name tests:"
-            jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' "$results_file"
-            failed=1
+        if [ "${test_exit_code:-}" != "" ] && [ "$test_exit_code" -ne 0 ]; then
+          if [[ "${{ inputs.test-suite }}" != "" ]]; then
+            echo "Failed Test Suite: ${{ inputs.test-suite }}"
+          else
+            echo "Failed Test Suite: ${{ inputs.package }}"
           fi
-        done
 
-        if [ "$failed" -eq 1 ]; then
+          jq -r 'select(.Action=="fail" and .Test != null) | "- " + .Test' results.json
           exit 1
         fi

--- a/.github/actions/save-weekly-summary-result/action.yaml
+++ b/.github/actions/save-weekly-summary-result/action.yaml
@@ -1,0 +1,32 @@
+---
+name: Save Weekly Summary Result
+description: Create and upload weekly summary test result artifact
+inputs:
+  rancher_version:
+    description: Rancher version to include in the summary payload
+    required: true
+  workflow:
+    description: Workflow identifier used in payload and artifact naming
+    required: true
+  job:
+    description: Job identifier used in payload and artifact naming
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - id: save
+      shell: bash
+      run: |
+        artifact_name="test-result-${{ inputs.workflow }}-${{ inputs.job }}-${{ github.run_id }}"
+        artifact_path="${artifact_name}-${{ github.run_attempt }}.json"
+
+        echo "{\"date\": \"$(date -u \"+%B %d, %Y at %I:%M %p\")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ inputs.rancher_version }}\", \"workflow\": \"${{ inputs.workflow }}\", \"job\": \"${{ inputs.job }}\" }" > "$artifact_path"
+
+        echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+        echo "artifact_path=$artifact_path" >> "$GITHUB_OUTPUT"
+
+    - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+      with:
+        name: ${{ steps.save.outputs.artifact_name }}
+        path: ${{ steps.save.outputs.artifact_path }}

--- a/.github/workflows/arm64-cluster-provisioning.yml
+++ b/.github/workflows/arm64-cluster-provisioning.yml
@@ -423,18 +423,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"arm64-cluster-provisioning\", \"job\": \"v2-16\" }" > test-result-arm64-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-arm64-cluster-provisioning-v2-16-${{ github.run_id }}
-          path: test-result-arm64-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: arm64-cluster-provisioning
+          job: v2-16
   
   v2-15:
     if: |
@@ -806,18 +801,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"arm64-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-arm64-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-arm64-cluster-provisioning-v2-15-${{ github.run_id }}
-          path: test-result-arm64-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: arm64-cluster-provisioning
+          job: v2-15
 
   v2-14:
     if: |
@@ -1190,15 +1180,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"arm64-cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-arm64-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-arm64-cluster-provisioning-v2-14-${{ github.run_id }}
-          path: test-result-arm64-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: arm64-cluster-provisioning
+          job: v2-14

--- a/.github/workflows/capi-pnp-cluster-provisioning.yml
+++ b/.github/workflows/capi-pnp-cluster-provisioning.yml
@@ -374,18 +374,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"capi-pnp-cluster-provisioning\", \"job\": \"v2-16\" }" > test-result-capi-pnp-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-capi-pnp-cluster-provisioning-v2-16-${{ github.run_id }}
-          path: test-result-capi-pnp-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: capi-pnp-cluster-provisioning
+          job: v2-16
   
   v2-15:
     if: |
@@ -709,15 +704,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"capi-pnp-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-capi-pnp-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-capi-pnp-cluster-provisioning-v2-15-${{ github.run_id }}
-          path: test-result-capi-pnp-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: capi-pnp-cluster-provisioning
+          job: v2-15

--- a/.github/workflows/cluster-provisioning.yml
+++ b/.github/workflows/cluster-provisioning.yml
@@ -430,18 +430,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"cluster-provisioning\", \"job\": \"v2-16\" }" > test-result-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-cluster-provisioning-v2-16-${{ github.run_id }}
-          path: test-result-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: cluster-provisioning
+          job: v2-16
   
   v2-15:
     if: |
@@ -821,18 +816,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-cluster-provisioning-v2-15-${{ github.run_id }}
-          path: test-result-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: cluster-provisioning
+          job: v2-15
 
   v2-14:
     if: |
@@ -1213,18 +1203,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-cluster-provisioning-v2-14-${{ github.run_id }}
-          path: test-result-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: cluster-provisioning
+          job: v2-14
   
   v2-13:
     if: |
@@ -1604,15 +1589,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"cluster-provisioning\", \"job\": \"v2-13\" }" > test-result-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-cluster-provisioning-v2-13-${{ github.run_id }}
-          path: test-result-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: cluster-provisioning
+          job: v2-13

--- a/.github/workflows/day2-ops-capi-pnp.yml
+++ b/.github/workflows/day2-ops-capi-pnp.yml
@@ -390,19 +390,14 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-capi-pnp\", \"job\": \"v2-16\" }" > test-result-day2-ops-capi-pnp-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-capi-pnp-v2-16-${{ github.run_id }}
-          path: test-result-day2-ops-capi-pnp-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-  
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-capi-pnp
+          job: v2-16
+
   v2-15:
     if: |
       github.event_name == 'schedule' ||
@@ -743,15 +738,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-capi-pnp\", \"job\": \"v2-15\" }" > test-result-day2-ops-capi-pnp-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-capi-pnp-v2-15-${{ github.run_id }}
-          path: test-result-day2-ops-capi-pnp-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-capi-pnp
+          job: v2-15

--- a/.github/workflows/day2-ops-dualstack-rancher.yml
+++ b/.github/workflows/day2-ops-dualstack-rancher.yml
@@ -412,18 +412,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-dualstack-rancher\", \"job\": \"v2-16\" }" > test-result-day2-ops-dualstack-rancher-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-dualstack-rancher-v2-16-${{ github.run_id }}
-          path: test-result-day2-ops-dualstack-rancher-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-dualstack-rancher
+          job: v2-16
   
   v2-15:
     if: |
@@ -785,18 +780,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-dualstack-rancher\", \"job\": \"v2-15\" }" > test-result-day2-ops-dualstack-rancher-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-dualstack-rancher-v2-15-${{ github.run_id }}
-          path: test-result-day2-ops-dualstack-rancher-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-dualstack-rancher
+          job: v2-15
   
   v2-14:
     if: |
@@ -1158,18 +1148,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-dualstack-rancher\", \"job\": \"v2-14\" }" > test-result-day2-ops-dualstack-rancher-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-dualstack-rancher-v2-14-${{ github.run_id }}
-          path: test-result-day2-ops-dualstack-rancher-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-dualstack-rancher
+          job: v2-14
 
   v2-13:
     if: |
@@ -1531,15 +1516,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-dualstack-rancher\", \"job\": \"v2-13\" }" > test-result-day2-ops-dualstack-rancher-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-dualstack-rancher-v2-13-${{ github.run_id }}
-          path: test-result-day2-ops-dualstack-rancher-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-dualstack-rancher
+          job: v2-13

--- a/.github/workflows/day2-ops-ipv6-rancher.yml
+++ b/.github/workflows/day2-ops-ipv6-rancher.yml
@@ -414,18 +414,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-ipv6-rancher\", \"job\": \"v2-15\" }" > test-result-day2-ops-ipv6-rancher-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-ipv6-rancher-v2-15-${{ github.run_id }}
-          path: test-result-day2-ops-ipv6-rancher-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-ipv6-rancher
+          job: v2-16
   
   v2-15:
     if: |
@@ -789,18 +784,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-ipv6-rancher\", \"job\": \"v2-15\" }" > test-result-day2-ops-ipv6-rancher-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-ipv6-rancher-v2-15-${{ github.run_id }}
-          path: test-result-day2-ops-ipv6-rancher-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-ipv6-rancher
+          job: v2-15
   
   v2-14:
     if: |
@@ -1164,18 +1154,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-ipv6-rancher\", \"job\": \"v2-14\" }" > test-result-day2-ops-ipv6-rancher-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-ipv6-rancher-v2-14-${{ github.run_id }}
-          path: test-result-day2-ops-ipv6-rancher-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-ipv6-rancher
+          job: v2-14
 
   v2-13:
     if: |
@@ -1539,15 +1524,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-ipv6-rancher\", \"job\": \"v2-13\" }" > test-result-day2-ops-ipv6-rancher-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-ipv6-rancher-v2-13-${{ github.run_id }}
-          path: test-result-day2-ops-ipv6-rancher-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-ipv6-rancher
+          job: v2-13

--- a/.github/workflows/day2-ops-proxy-rancher.yml
+++ b/.github/workflows/day2-ops-proxy-rancher.yml
@@ -427,18 +427,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-proxy-rancher\", \"job\": \"v2-16\" }" > test-result-day2-ops-proxy-rancher-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-proxy-rancher-v2-16-${{ github.run_id }}
-          path: test-result-day2-ops-proxy-rancher-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-proxy-rancher
+          job: v2-16
   
   v2-15:
     if: |
@@ -815,18 +810,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-proxy-rancher\", \"job\": \"v2-15\" }" > test-result-day2-ops-proxy-rancher-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-proxy-rancher-v2-15-${{ github.run_id }}
-          path: test-result-day2-ops-proxy-rancher-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-proxy-rancher
+          job: v2-15
   
   v2-14:
     if: |
@@ -1204,18 +1194,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-proxy-rancher\", \"job\": \"v2-14\" }" > test-result-day2-ops-proxy-rancher-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-proxy-rancher-v2-14-${{ github.run_id }}
-          path: test-result-day2-ops-proxy-rancher-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-proxy-rancher
+          job: v2-14
 
   v2-13:
     if: |
@@ -1592,15 +1577,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-proxy-rancher\", \"job\": \"v2-13\" }" > test-result-day2-ops-proxy-rancher-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-proxy-rancher-v2-13-${{ github.run_id }}
-          path: test-result-day2-ops-proxy-rancher-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-proxy-rancher
+          job: v2-13

--- a/.github/workflows/day2-ops-rancher.yml
+++ b/.github/workflows/day2-ops-rancher.yml
@@ -418,18 +418,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-rancher\", \"job\": \"v2-16\" }" > test-result-day2-ops-rancher-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-rancher-v2-16-${{ github.run_id }}
-          path: test-result-day2-ops-rancher-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-rancher
+          job: v2-16
   
   v2-15:
     if: |
@@ -798,19 +793,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-rancher\", \"job\": \"v2-15\" }" > test-result-day2-ops-rancher-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-rancher-v2-15-${{ github.run_id }}
-          path: test-result-day2-ops-rancher-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-rancher
+          job: v2-15
   v2-14:
     if: |
       github.event_name == 'schedule' ||
@@ -1179,18 +1168,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-rancher\", \"job\": \"v2-14\" }" > test-result-day2-ops-rancher-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-rancher-v2-14-${{ github.run_id }}
-          path: test-result-day2-ops-rancher-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-rancher
+          job: v2-14
   
   v2-13:
     if: |
@@ -1559,15 +1543,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"day2-ops-rancher\", \"job\": \"v2-13\" }" > test-result-day2-ops-rancher-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-day2-ops-rancher-v2-13-${{ github.run_id }}
-          path: test-result-day2-ops-rancher-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-rancher
+          job: v2-13

--- a/.github/workflows/day2-ops-upgraded-rancher.yml
+++ b/.github/workflows/day2-ops-upgraded-rancher.yml
@@ -435,18 +435,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-cluster-provisioning-test\", \"job\": \"v2-16\" }" > test-result-rancher-upgrade-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-cluster-provisioning-test-v2-16-${{ github.run_id }}
-          path: test-result-rancher-upgrade-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-upgraded-rancher
+          job: v2-16
   
   v2-15:
     if: |
@@ -831,18 +826,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-cluster-provisioning-test\", \"job\": \"v2-15\" }" > test-result-rancher-upgrade-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-cluster-provisioning-test-v2-15-${{ github.run_id }}
-          path: test-result-rancher-upgrade-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-upgraded-rancher
+          job: v2-15
 
   v2-14:
     if: |
@@ -1229,18 +1219,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-cluster-provisioning-test\", \"job\": \"v2-14\" }" > test-result-rancher-upgrade-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-cluster-provisioning-test-v2-14-${{ github.run_id }}
-          path: test-result-rancher-upgrade-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-upgraded-rancher
+          job: v2-14
   
   v2-13:
     if: |
@@ -1626,15 +1611,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-cluster-provisioning-test\", \"job\": \"v2-13\" }" > test-result-rancher-upgrade-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-cluster-provisioning-test-v2-13-${{ github.run_id }}
-          path: test-result-rancher-upgrade-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: day2-ops-upgraded-rancher
+          job: v2-13

--- a/.github/workflows/dualstack-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-cluster-provisioning.yml
@@ -410,18 +410,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-cluster-provisioning\", \"job\": \"v2-16\" }" > test-result-dualstack-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-dualstack-cluster-provisioning-v2-16-${{ github.run_id }}
-          path: test-result-dualstack-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: dualstack-cluster-provisioning
+          job: v2-16
   
   v2-15:
     if: |
@@ -780,18 +775,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-dualstack-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-dualstack-cluster-provisioning-v2-15-${{ github.run_id }}
-          path: test-result-dualstack-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: dualstack-cluster-provisioning
+          job: v2-15
   
   v2-14:
     if: |
@@ -1150,18 +1140,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-dualstack-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-dualstack-cluster-provisioning-v2-14-${{ github.run_id }}
-          path: test-result-dualstack-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: dualstack-cluster-provisioning
+          job: v2-14
 
   v2-13:
     if: |
@@ -1520,15 +1505,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-cluster-provisioning\", \"job\": \"v2-13\" }" > test-result-dualstack-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-dualstack-cluster-provisioning-v2-13-${{ github.run_id }}
-          path: test-result-dualstack-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: dualstack-cluster-provisioning
+          job: v2-13

--- a/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/dualstack-rancher-ipv6-cluster-provisioning.yml
@@ -412,18 +412,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-rancher-ipv6-cluster-provisioning\", \"job\": \"v2-16\" }" > test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-16-${{ github.run_id }}
-          path: test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: dualstack-rancher-ipv6-cluster-provisioning
+          job: v2-16
   
   v2-15:
     if: |
@@ -784,18 +779,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-rancher-ipv6-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-15-${{ github.run_id }}
-          path: test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: dualstack-rancher-ipv6-cluster-provisioning
+          job: v2-15
   
   v2-14:
     if: |
@@ -1154,18 +1144,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-rancher-ipv6-cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-14-${{ github.run_id }}
-          path: test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: dualstack-rancher-ipv6-cluster-provisioning
+          job: v2-14
 
   v2-13:
     if: |
@@ -1524,15 +1509,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"dualstack-rancher-ipv6-cluster-provisioning\", \"job\": \"v2-13\" }" > test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-13-${{ github.run_id }}
-          path: test-result-dualstack-rancher-ipv6-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: dualstack-rancher-ipv6-cluster-provisioning
+          job: v2-13

--- a/.github/workflows/hb-post-release-sanity.yml
+++ b/.github/workflows/hb-post-release-sanity.yml
@@ -1001,6 +1001,7 @@ jobs:
             cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            generateV3Token: true
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
@@ -1270,6 +1271,7 @@ jobs:
             cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
+            generateV3Token: true
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"

--- a/.github/workflows/ipv6-cluster-provisioning.yml
+++ b/.github/workflows/ipv6-cluster-provisioning.yml
@@ -412,18 +412,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"ipv6-cluster-provisioning\", \"job\": \"v2-16\" }" > test-result-ipv6-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-ipv6-cluster-provisioning-v2-16-${{ github.run_id }}
-          path: test-result-ipv6-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: ipv6-cluster-provisioning
+          job: v2-16
   
   v2-15:
     if: |
@@ -784,18 +779,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"ipv6-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-ipv6-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-ipv6-cluster-provisioning-v2-15-${{ github.run_id }}
-          path: test-result-ipv6-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: ipv6-cluster-provisioning
+          job: v2-15
   
   v2-14:
     if: |
@@ -1155,18 +1145,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"ipv6-cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-ipv6-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-ipv6-cluster-provisioning-v2-14-${{ github.run_id }}
-          path: test-result-ipv6-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: ipv6-cluster-provisioning
+          job: v2-14
 
   v2-13:
     if: |
@@ -1527,15 +1512,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"ipv6-cluster-provisioning\", \"job\": \"v2-13\" }" > test-result-ipv6-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-ipv6-cluster-provisioning-v2-13-${{ github.run_id }}
-          path: test-result-ipv6-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: ipv6-cluster-provisioning
+          job: v2-13

--- a/.github/workflows/kdm.yml
+++ b/.github/workflows/kdm.yml
@@ -1,5 +1,5 @@
 ---
-name: Hostbusters Post Release Upgrade Sanity
+name: KDM Post Release Checks
 
 on:
   workflow_dispatch:
@@ -8,6 +8,11 @@ on:
         description: "Rancher tag version"
       rancher_chart_version:
         description: "Rancher chart version"
+      run_all_versions:
+        description: "Run all supported versions if manually triggered"
+        required: false
+        default: false
+        type: boolean
       reporting:
         description: "Enable reporting to Qase and Slack"
         required: false
@@ -44,39 +49,12 @@ env:
       (github.event_name == 'schedule' && 'rke2') || 'rke2' 
     }}
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
-  PACKAGE: "postrelease"
-  TAG: "postrelease"
-  TEST_SUITE: "^TestPostReleaseUpgradeTestSuite$"
+  PACKAGE: "kdm"
+  TAG: "kdm"
   TIMEOUT: "1h"
 
-jobs: 
-  create-qase-run:
-    if: |
-      ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
-      ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-head'))
-    runs-on: ubuntu-latest
-    outputs:
-      run_id: ${{ steps.create-qase-run.outputs.id }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          submodules: recursive
-      
-      - name: Create Qase test run
-        id: create-qase-run
-        uses: ./.github/actions/create-qase-test-run
-        with:
-          test_run_name: "[${{ github.event.inputs.rancher_version || inputs.rancher_version }}] Post Rancher Release Upgrade Validations"
-          qase_project_id: ${{ secrets.HB_QASE_PROJECT_ID }}
-          qase_token: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-  
+jobs:  
   v2-15:
-    needs: [create-qase-run]
     if: |
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && !contains(github.event.inputs.rancher_version, '-rc') &&
@@ -89,9 +67,10 @@ jobs:
     environment: latest
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
-      HOSTNAME_PREFIX: "pr-up-215"
+      HOSTNAME_PREFIX: "kdm-215"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -169,32 +148,39 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
               (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
               (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          env-var-name: UPGRADED_RANCHER_REPO
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_15 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_15 }}
 
       - name: Create config.yaml
         run: |
@@ -240,31 +226,64 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -288,9 +307,12 @@ jobs:
           terraform_version: "${{ vars.TERRAFORM_VERSION }}"
           terraform_wrapper: false
 
-      - name: Run Post Release Upgrade Test Suite
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
+
+      - name: Run KDM Checks
         env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.qase_id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_CUSTOM_FIELD_FILTER: Hostbusters
           QASE_SCHEMA_PREFIX: hostbusters
@@ -300,7 +322,6 @@ jobs:
           package: ${{ env.PACKAGE }}
           reporting: ${{ env.REPORTING_ENABLED }}
           tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
           timeout: ${{ env.TIMEOUT }}
 
       - name: Cleanup Infrastructure
@@ -320,6 +341,13 @@ jobs:
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
           region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
@@ -338,12 +366,11 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   v2-14:
-    needs: [create-qase-run]
     if: |
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && !contains(github.event.inputs.rancher_version, '-rc') &&
@@ -356,9 +383,10 @@ jobs:
     environment: prime
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
-      HOSTNAME_PREFIX: "pr-up-214"
+      HOSTNAME_PREFIX: "kdm-214"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -436,33 +464,40 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
               (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
               (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: true
-          env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_14 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_14 }}
 
       - name: Create config.yaml
         run: |
@@ -476,7 +511,6 @@ jobs:
             cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
-            generateV3Token: true
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
@@ -509,32 +543,65 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_14 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -558,9 +625,12 @@ jobs:
           terraform_version: "${{ vars.TERRAFORM_VERSION }}"
           terraform_wrapper: false
 
-      - name: Run Post Release Upgrade Test Suite
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
+
+      - name: Run KDM Checks
         env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.qase_id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_CUSTOM_FIELD_FILTER: Hostbusters
           QASE_SCHEMA_PREFIX: hostbusters
@@ -570,7 +640,6 @@ jobs:
           package: ${{ env.PACKAGE }}
           reporting: ${{ env.REPORTING_ENABLED }}
           tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
           timeout: ${{ env.TIMEOUT }}
 
       - name: Cleanup Infrastructure
@@ -592,6 +661,13 @@ jobs:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
           region: "${{ vars.AWS_REGION }}"
 
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
@@ -608,12 +684,11 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
   
   v2-13:
-    needs: [create-qase-run]
     if: |
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && !contains(github.event.inputs.rancher_version, '-rc') &&
@@ -626,9 +701,10 @@ jobs:
     environment: prime
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_13 }}"
-      HOSTNAME_PREFIX: "pr-up-213"
+      HOSTNAME_PREFIX: "kdm-213"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -706,33 +782,40 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
               (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
               (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: true
-          env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
 
       - name: Create config.yaml
         run: |
@@ -779,32 +862,65 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_13 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -828,9 +944,12 @@ jobs:
           terraform_version: "${{ vars.TERRAFORM_VERSION }}"
           terraform_wrapper: false
 
-      - name: Run Post Release Upgrade Test Suite
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
+
+      - name: Run KDM Checks
         env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.qase_id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_CUSTOM_FIELD_FILTER: Hostbusters
           QASE_SCHEMA_PREFIX: hostbusters
@@ -840,7 +959,6 @@ jobs:
           package: ${{ env.PACKAGE }}
           reporting: ${{ env.REPORTING_ENABLED }}
           tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
           timeout: ${{ env.TIMEOUT }}
 
       - name: Cleanup Infrastructure
@@ -862,6 +980,13 @@ jobs:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
           region: "${{ vars.AWS_REGION }}"
 
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
@@ -878,12 +1003,11 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   v2-12:
-    needs: [create-qase-run]
     if: |
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
       (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && !contains(github.event.inputs.rancher_version, '-rc') &&
@@ -896,9 +1020,10 @@ jobs:
     environment: prime
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_12 }}"
-      HOSTNAME_PREFIX: "pr-up-212"
+      HOSTNAME_PREFIX: "kdm-212"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -976,33 +1101,40 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
               (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
               (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: true
-          env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_12 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_12 }}
 
       - name: Create config.yaml
         run: |
@@ -1049,301 +1181,65 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_12 }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_12 }}${{ vars.K3S_VERSION_SUFFIX }}"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_12 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_12 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/go-build.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Run Post Release Upgrade Test Suite
-        env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
-        with:
-          package: ${{ env.PACKAGE }}
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
-
-      - name: Cleanup Infrastructure
-        if: always()
-        working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve > /dev/null 2>&1
-
-      - name: Refresh AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: AWS Custodian Infrastructure Cleanup
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set job status output
-        if: always()
-        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
-        id: set-job-status
-
-      - name: Reporting Results to Slack
-        if: always() && env.REPORTING_ENABLED == 'true'
-        uses: ./.github/actions/report-to-slack
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          job-status: ${{ steps.set-job-status.outputs.job_status }}
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  v2-11:
-    needs: [create-qase-run]
-    if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.1')) && !contains(inputs.rancher_version, '-head')
-    name: ${{ github.event.inputs.rancher_version }}
-    runs-on: ubuntu-latest
-    environment: prime
-    env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
-      HOSTNAME_PREFIX: "pr-up-211"
-      REPORTING_ENABLED: >-
-        ${{
-          github.event_name == 'workflow_call' ||
-          github.actor == 'github-actions[bot]' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
-        }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          submodules: recursive
-
-      - name: Checkout tfp-automation repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: rancher/tfp-automation
-          path: tfp-automation
-
-      - name: Set up local rancher2 Terraform provider
-        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
-        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
-        with:
-          version: "latest"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: "Fetch and Set DockerHub Credentials"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
-
-      - name: Mask Dockerhub Credentials
-        run: |
-          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
-          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Set up certificates
-        id: setup-certs
-        uses: ./.github/actions/setup-certs
-        with:
-          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
-          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
-          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
-          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
-            }}
-
-      - name: Set upgraded Rancher chart version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_CHART_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
-            }}
-
-      - name: Set upgraded Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          is-prime: true
-          env-var-name: UPGRADED_RANCHER_REPO
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-            cleanup: true
-          terraform:
-            cni: "${{ vars.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
-            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
-            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ vars.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_11 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_11 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_11 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              iamInstanceProfile: "${{ secrets.AWS_IAM_PROFILE}}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1367,9 +1263,12 @@ jobs:
           terraform_version: "${{ vars.TERRAFORM_VERSION }}"
           terraform_wrapper: false
 
-      - name: Run Post Release Upgrade Test Suite
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
+
+      - name: Run KDM Checks
         env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.qase_id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_CUSTOM_FIELD_FILTER: Hostbusters
           QASE_SCHEMA_PREFIX: hostbusters
@@ -1379,7 +1278,6 @@ jobs:
           package: ${{ env.PACKAGE }}
           reporting: ${{ env.REPORTING_ENABLED }}
           tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
           timeout: ${{ env.TIMEOUT }}
 
       - name: Cleanup Infrastructure
@@ -1401,6 +1299,13 @@ jobs:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
           region: "${{ vars.AWS_REGION }}"
 
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
       - name: Revoke Runner IP
         if: always()
         uses: ./.github/actions/revoke-runner-ip
@@ -1417,30 +1322,6 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  close-qase-run:
-    needs: [create-qase-run, v2-15, v2-14, v2-13, v2-12, v2-11]
-    if: always() && (
-        ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
-        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
-        ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-alpha') &&
-        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-rc') &&
-        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-head'))
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          submodules: recursive
-
-      - name: Close Qase test run
-        uses: ./.github/actions/close-qase-test-run
-        with:
-          qase_run_id: ${{ needs.create-qase-run.outputs.run_id }}
-          qase_project_id: ${{ secrets.HB_QASE_PROJECT_ID }}
-          qase_token: ${{ secrets.QASE_TOKEN }}

--- a/.github/workflows/mcm-feature-off.yml
+++ b/.github/workflows/mcm-feature-off.yml
@@ -1,5 +1,5 @@
 ---
-name: Hostbusters Post Release Upgrade Sanity
+name: MCM Feature Off
 
 on:
   workflow_dispatch:
@@ -8,6 +8,11 @@ on:
         description: "Rancher tag version"
       rancher_chart_version:
         description: "Rancher chart version"
+      run_all_versions:
+        description: "Run all supported versions if manually triggered"
+        required: false
+        default: false
+        type: boolean
       reporting:
         description: "Enable reporting to Qase and Slack"
         required: false
@@ -44,54 +49,22 @@ env:
       (github.event_name == 'schedule' && 'rke2') || 'rke2' 
     }}
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
-  PACKAGE: "postrelease"
-  TAG: "postrelease"
-  TEST_SUITE: "^TestPostReleaseUpgradeTestSuite$"
-  TIMEOUT: "1h"
 
-jobs: 
-  create-qase-run:
+jobs:
+  v2-16:
     if: |
-      ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
-      ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-head'))
-    runs-on: ubuntu-latest
-    outputs:
-      run_id: ${{ steps.create-qase-run.outputs.id }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          submodules: recursive
-      
-      - name: Create Qase test run
-        id: create-qase-run
-        uses: ./.github/actions/create-qase-test-run
-        with:
-          test_run_name: "[${{ github.event.inputs.rancher_version || inputs.rancher_version }}] Post Rancher Release Upgrade Validations"
-          qase_project_id: ${{ secrets.HB_QASE_PROJECT_ID }}
-          qase_token: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-  
-  v2-15:
-    needs: [create-qase-run]
-    if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && !contains(inputs.rancher_version, '-head')
+      github.event_name == 'schedule' ||
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: head
     env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
-      HOSTNAME_PREFIX: "pr-up-215"
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_16 }}"
+      HOSTNAME_PREFIX: "mcm-216"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -169,32 +142,46 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_16_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_16_HEAD)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) || 
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          env-var-name: UPGRADED_RANCHER_REPO
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
+          is-prime: false
+          release-community-version: "2.16"
+
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          is-prime: false
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -240,31 +227,23 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_16 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              featureFlags:
+                mcm: "false"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ env.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_16 }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -288,20 +267,8 @@ jobs:
           terraform_version: "${{ vars.TERRAFORM_VERSION }}"
           terraform_wrapper: false
 
-      - name: Run Post Release Upgrade Test Suite
-        env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
-        with:
-          package: ${{ env.PACKAGE }}
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
 
       - name: Cleanup Infrastructure
         if: always()
@@ -338,27 +305,300 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Save test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: ./.github/actions/save-weekly-summary-result
+        with:
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: mcm-feature-off
+          job: v2-16
+  
+  v2-15:
+    if: |
+      github.event_name == 'schedule' ||
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && contains(inputs.rancher_version, '-alpha')
+    name: ${{ github.event.inputs.rancher_version }}
+    runs-on: ubuntu-latest
+    environment: head
+    env:
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
+      HOSTNAME_PREFIX: "mcm-215"
+      REPORTING_ENABLED: >-
+        ${{
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
+        }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          submodules: recursive
+
+      - name: Checkout tfp-automation repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          repository: rancher/tfp-automation
+          path: tfp-automation
+
+      - name: Set up local rancher2 Terraform provider
+        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
+        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
+        with:
+          version: "latest"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: "Fetch and Set DockerHub Credentials"
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Mask Dockerhub Credentials
+        run: |
+          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
+          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Set up certificates
+        id: setup-certs
+        uses: ./.github/actions/setup-certs
+        with:
+          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
+          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
+          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
+          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_15_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_15_HEAD)
+            }}
+
+      - name: Set Rancher chart version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: RANCHER_CHART_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) || 
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
+            }}
+
+      - name: Set Rancher repo
+        uses: ./.github/actions/set-rancher-repo
+        with:
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
+          is-prime: false
+          release-community-version: "2.15"
+
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          is-prime: false
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+            cleanup: true
+          terraform:
+            cni: "${{ vars.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
+            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
+            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ vars.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ vars.AWS_USER }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              featureFlags:
+                mcm: "false"
+              osUser: "${{ vars.OS_USER }}"
+              osGroup: "${{ vars.OS_GROUP }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ env.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/go-build.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
+
+      - name: Cleanup Infrastructure
+        if: always()
+        working-directory: tfp-automation/modules/sanity/aws
+        run: terraform destroy -auto-approve > /dev/null 2>&1
+
+      - name: Refresh AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: AWS Custodian Infrastructure Cleanup
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set job status output
+        if: always()
+        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
+        id: set-job-status
+
+      - name: Reporting Results to Slack
+        if: always() && env.REPORTING_ENABLED == 'true'
+        uses: ./.github/actions/report-to-slack
+        with:
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          job-status: ${{ steps.set-job-status.outputs.job_status }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Save test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: ./.github/actions/save-weekly-summary-result
+        with:
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: mcm-feature-off
+          job: v2-15
 
   v2-14:
-    needs: [create-qase-run]
     if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && !contains(inputs.rancher_version, '-head')
+      github.event_name == 'schedule' ||
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: prime
+    environment: staging-latest
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
-      HOSTNAME_PREFIX: "pr-up-214"
+      HOSTNAME_PREFIX: "mcm-214"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -436,33 +676,46 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_14_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_14_HEAD)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) || 
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_14) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_14)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: true
-          env-var-name: UPGRADED_RANCHER_REPO
+          release-prime-version: "2.14"
+
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          is-prime: true
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -476,7 +729,6 @@ jobs:
             cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
-            generateV3Token: true
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
@@ -509,32 +761,24 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              featureFlags:
+                mcm: "false"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_14 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -558,20 +802,8 @@ jobs:
           terraform_version: "${{ vars.TERRAFORM_VERSION }}"
           terraform_wrapper: false
 
-      - name: Run Post Release Upgrade Test Suite
-        env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
-        with:
-          package: ${{ env.PACKAGE }}
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
 
       - name: Cleanup Infrastructure
         if: always()
@@ -608,27 +840,32 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Save test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: ./.github/actions/save-weekly-summary-result
+        with:
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: mcm-feature-off
+          job: v2-14
   
   v2-13:
-    needs: [create-qase-run]
     if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && !contains(inputs.rancher_version, '-head')
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && contains(github.event.inputs.rancher_version, '-alpha') ||
+      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && contains(inputs.rancher_version, '-alpha')
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: prime
+    environment: staging-latest
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_13 }}"
-      HOSTNAME_PREFIX: "pr-up-213"
+      HOSTNAME_PREFIX: "mcm-213"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -706,33 +943,46 @@ jobs:
       - name: Uniquify hostname prefix
         uses: ./.github/actions/uniquify-hostname
 
-      - name: Set upgraded Rancher version
+      - name: Set Rancher version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_VERSION
+          key: RANCHER_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_13_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_13_HEAD)
             }}
 
-      - name: Set upgraded Rancher chart version
+      - name: Set Rancher chart version
         uses: ./.github/actions/set-env-var
         with:
-          key: UPGRADED_RANCHER_CHART_VERSION
+          key: RANCHER_CHART_VERSION
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) || 
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_13) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_13)
             }}
 
-      - name: Set upgraded Rancher repo
+      - name: Set Rancher repo
         uses: ./.github/actions/set-rancher-repo
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.RANCHER_REPO }}
           is-prime: true
-          env-var-name: UPGRADED_RANCHER_REPO
+          release-prime-version: "2.13"
+
+      - name: Set Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.RANCHER_REPO }}
+          is-prime: true
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.RANCHER_HELM_CHART_URL }}
 
       - name: Create config.yaml
         run: |
@@ -746,7 +996,6 @@ jobs:
             cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
-            generateV3Token: true
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
@@ -779,32 +1028,24 @@ jobs:
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
+              chartVersion: "${{ env.RANCHER_CHART_VERSION }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              featureFlags:
+                mcm: "false"
               osUser: "${{ vars.OS_USER }}"
               osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherAgentImage: "${{ secrets.RANCHER_AGENT_IMAGE }}"
+              rancherChartRepository: "${{ env.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_13 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
+              rancherTagVersion: "${{ env.RANCHER_VERSION }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ env.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
           terratest:
             pathToRepo: "${{ secrets.PATH_TO_REPO }}"
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -828,20 +1069,8 @@ jobs:
           terraform_version: "${{ vars.TERRAFORM_VERSION }}"
           terraform_wrapper: false
 
-      - name: Run Post Release Upgrade Test Suite
-        env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
-        with:
-          package: ${{ env.PACKAGE }}
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/setuprancher/standard/main.go
 
       - name: Cleanup Infrastructure
         if: always()
@@ -878,569 +1107,14 @@ jobs:
         if: always() && env.REPORTING_ENABLED == 'true'
         uses: ./.github/actions/report-to-slack
         with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          rancher-version: ${{ env.RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  v2-12:
-    needs: [create-qase-run]
-    if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12')) && !contains(inputs.rancher_version, '-head')
-    name: ${{ github.event.inputs.rancher_version }}
-    runs-on: ubuntu-latest
-    environment: prime
-    env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_12 }}"
-      HOSTNAME_PREFIX: "pr-up-212"
-      REPORTING_ENABLED: >-
-        ${{
-          github.event_name == 'workflow_call' ||
-          github.actor == 'github-actions[bot]' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
-        }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+      - name: Save test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          submodules: recursive
-
-      - name: Checkout tfp-automation repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: rancher/tfp-automation
-          path: tfp-automation
-
-      - name: Set up local rancher2 Terraform provider
-        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
-        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
-        with:
-          version: "latest"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: "Fetch and Set DockerHub Credentials"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
-
-      - name: Mask Dockerhub Credentials
-        run: |
-          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
-          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Set up certificates
-        id: setup-certs
-        uses: ./.github/actions/setup-certs
-        with:
-          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
-          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
-          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
-          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
-            }}
-
-      - name: Set upgraded Rancher chart version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_CHART_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
-            }}
-
-      - name: Set upgraded Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          is-prime: true
-          env-var-name: UPGRADED_RANCHER_REPO
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-            cleanup: true
-          terraform:
-            cni: "${{ vars.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            generateV3Token: true
-            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
-            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
-            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ vars.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_12 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_12 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_12 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_12 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/go-build.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Run Post Release Upgrade Test Suite
-        env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
-        with:
-          package: ${{ env.PACKAGE }}
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
-
-      - name: Cleanup Infrastructure
-        if: always()
-        working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve > /dev/null 2>&1
-
-      - name: Refresh AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: AWS Custodian Infrastructure Cleanup
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set job status output
-        if: always()
-        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
-        id: set-job-status
-
-      - name: Reporting Results to Slack
-        if: always() && env.REPORTING_ENABLED == 'true'
-        uses: ./.github/actions/report-to-slack
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          job-status: ${{ steps.set-job-status.outputs.job_status }}
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  v2-11:
-    needs: [create-qase-run]
-    if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.1')) && !contains(inputs.rancher_version, '-head')
-    name: ${{ github.event.inputs.rancher_version }}
-    runs-on: ubuntu-latest
-    environment: prime
-    env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
-      HOSTNAME_PREFIX: "pr-up-211"
-      REPORTING_ENABLED: >-
-        ${{
-          github.event_name == 'workflow_call' ||
-          github.actor == 'github-actions[bot]' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
-        }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          submodules: recursive
-
-      - name: Checkout tfp-automation repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: rancher/tfp-automation
-          path: tfp-automation
-
-      - name: Set up local rancher2 Terraform provider
-        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
-        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
-        with:
-          version: "latest"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: "Fetch and Set DockerHub Credentials"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
-
-      - name: Mask Dockerhub Credentials
-        run: |
-          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
-          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Set up certificates
-        id: setup-certs
-        uses: ./.github/actions/setup-certs
-        with:
-          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
-          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
-          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
-          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
-            }}
-
-      - name: Set upgraded Rancher chart version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_CHART_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
-            }}
-
-      - name: Set upgraded Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          is-prime: true
-          env-var-name: UPGRADED_RANCHER_REPO
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-            cleanup: true
-          terraform:
-            cni: "${{ vars.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
-            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
-            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ vars.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_11 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_11 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_11 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/go-build.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Run Post Release Upgrade Test Suite
-        env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
-        with:
-          package: ${{ env.PACKAGE }}
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
-
-      - name: Cleanup Infrastructure
-        if: always()
-        working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve > /dev/null 2>&1
-
-      - name: Refresh AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: AWS Custodian Infrastructure Cleanup
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set job status output
-        if: always()
-        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
-        id: set-job-status
-
-      - name: Reporting Results to Slack
-        if: always() && env.REPORTING_ENABLED == 'true'
-        uses: ./.github/actions/report-to-slack
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          job-status: ${{ steps.set-job-status.outputs.job_status }}
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  close-qase-run:
-    needs: [create-qase-run, v2-15, v2-14, v2-13, v2-12, v2-11]
-    if: always() && (
-        ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
-        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
-        ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-alpha') &&
-        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-rc') &&
-        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-head'))
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          submodules: recursive
-
-      - name: Close Qase test run
-        uses: ./.github/actions/close-qase-test-run
-        with:
-          qase_run_id: ${{ needs.create-qase-run.outputs.run_id }}
-          qase_project_id: ${{ secrets.HB_QASE_PROJECT_ID }}
-          qase_token: ${{ secrets.QASE_TOKEN }}
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: mcm-feature-off
+          job: v2-13

--- a/.github/workflows/mixed-arch-cluster-provisioning.yml
+++ b/.github/workflows/mixed-arch-cluster-provisioning.yml
@@ -412,18 +412,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"mixed-arch-cluster-provisioning\", \"job\": \"v2-16\" }" > test-result-mixed-arch-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-mixed-arch-cluster-provisioning-v2-16-${{ github.run_id }}
-          path: test-result-mixed-arch-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: mixed-arch-cluster-provisioning
+          job: v2-16
   
   v2-15:
     if: |
@@ -783,18 +778,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"mixed-arch-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-mixed-arch-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-mixed-arch-cluster-provisioning-v2-15-${{ github.run_id }}
-          path: test-result-mixed-arch-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: mixed-arch-cluster-provisioning
+          job: v2-15
 
   v2-14:
     if: |
@@ -1155,15 +1145,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"mixed-arch-cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-mixed-arch-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-mixed-arch-cluster-provisioning-v2-14-${{ github.run_id }}
-          path: test-result-mixed-arch-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: mixed-arch-cluster-provisioning
+          job: v2-14

--- a/.github/workflows/proxy-cluster-provisioning.yml
+++ b/.github/workflows/proxy-cluster-provisioning.yml
@@ -440,18 +440,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"proxy-cluster-provisioning\", \"job\": \"v2-16\" }" > test-result-proxy-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-proxy-cluster-provisioning-v2-16-${{ github.run_id }}
-          path: test-result-proxy-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: proxy-cluster-provisioning
+          job: v2-16
   
   v2-15:
     if: |
@@ -840,18 +835,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"proxy-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-proxy-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-proxy-cluster-provisioning-v2-15-${{ github.run_id }}
-          path: test-result-proxy-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: proxy-cluster-provisioning
+          job: v2-15
 
   v2-14:
     if: |
@@ -1241,18 +1231,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"proxy-cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-proxy-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-proxy-cluster-provisioning-v2-14-${{ github.run_id }}
-          path: test-result-proxy-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: proxy-cluster-provisioning
+          job: v2-14
 
   v2-13:
     if: |
@@ -1641,15 +1626,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"proxy-cluster-provisioning\", \"job\": \"v2-13\" }" > test-result-proxy-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-proxy-cluster-provisioning-v2-13-${{ github.run_id }}
-          path: test-result-proxy-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: proxy-cluster-provisioning
+          job: v2-13

--- a/.github/workflows/rancher-upgrade-arm64-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-arm64-cluster-provisioning.yml
@@ -428,18 +428,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-arm64-cluster-provisioning\", \"job\": \"v2-16\" }" > test-result-rancher-upgrade-arm64-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-arm64-cluster-provisioning-v2-16-${{ github.run_id }}
-          path: test-result-rancher-upgrade-arm64-cluster-provisioning-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-arm64-cluster-provisioning
+          job: v2-16
   
   v2-15:
     if: |
@@ -816,18 +811,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-arm64-cluster-provisioning\", \"job\": \"v2-15\" }" > test-result-rancher-upgrade-arm64-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-arm64-cluster-provisioning-v2-15-${{ github.run_id }}
-          path: test-result-rancher-upgrade-arm64-cluster-provisioning-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-arm64-cluster-provisioning
+          job: v2-15
 
   v2-14:
     if: |
@@ -1199,15 +1189,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-arm64-cluster-provisioning\", \"job\": \"v2-14\" }" > test-result-rancher-upgrade-arm64-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-arm64-cluster-provisioning-v2-14-${{ github.run_id }}
-          path: test-result-rancher-upgrade-arm64-cluster-provisioning-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-arm64-cluster-provisioning
+          job: v2-14

--- a/.github/workflows/rancher-upgrade-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-cluster-provisioning.yml
@@ -435,18 +435,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-cluster-provisioning-test\", \"job\": \"v2-16\" }" > test-result-rancher-upgrade-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-cluster-provisioning-test-v2-16-${{ github.run_id }}
-          path: test-result-rancher-upgrade-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-cluster-provisioning
+          job: v2-16
   
   v2-15:
     if: |
@@ -830,18 +825,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-cluster-provisioning-test\", \"job\": \"v2-15\" }" > test-result-rancher-upgrade-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-cluster-provisioning-test-v2-15-${{ github.run_id }}
-          path: test-result-rancher-upgrade-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-cluster-provisioning
+          job: v2-15
 
   v2-14:
     if: |
@@ -1227,18 +1217,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-cluster-provisioning-test\", \"job\": \"v2-14\" }" > test-result-rancher-upgrade-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-cluster-provisioning-test-v2-14-${{ github.run_id }}
-          path: test-result-rancher-upgrade-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-cluster-provisioning
+          job: v2-14
   
   v2-13:
     if: |
@@ -1623,15 +1608,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-cluster-provisioning-test\", \"job\": \"v2-13\" }" > test-result-rancher-upgrade-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-cluster-provisioning-test-v2-13-${{ github.run_id }}
-          path: test-result-rancher-upgrade-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-cluster-provisioning
+          job: v2-13

--- a/.github/workflows/rancher-upgrade-dualstack-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-dualstack-cluster-provisioning.yml
@@ -1,13 +1,20 @@
 ---
-name: Hostbusters Post Release Upgrade Sanity
+name: Upgraded Dualstack Rancher Cluster Provisioning
 
 on:
+  schedule:
+    - cron: "0 8 * * 2"
   workflow_dispatch:
     inputs:
       rancher_version:
         description: "Rancher tag version"
       rancher_chart_version:
         description: "Rancher chart version"
+      run_all_versions:
+        description: "Run all supported versions if manually triggered"
+        required: false
+        default: false
+        type: boolean
       reporting:
         description: "Enable reporting to Qase and Slack"
         required: false
@@ -44,54 +51,22 @@ env:
       (github.event_name == 'schedule' && 'rke2') || 'rke2' 
     }}
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
-  PACKAGE: "postrelease"
-  TAG: "postrelease"
-  TEST_SUITE: "^TestPostReleaseUpgradeTestSuite$"
-  TIMEOUT: "1h"
 
-jobs: 
-  create-qase-run:
+jobs:
+  v2-16:
     if: |
-      ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
-      ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-head'))
-    runs-on: ubuntu-latest
-    outputs:
-      run_id: ${{ steps.create-qase-run.outputs.id }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          submodules: recursive
-      
-      - name: Create Qase test run
-        id: create-qase-run
-        uses: ./.github/actions/create-qase-test-run
-        with:
-          test_run_name: "[${{ github.event.inputs.rancher_version || inputs.rancher_version }}] Post Rancher Release Upgrade Validations"
-          qase_project_id: ${{ secrets.HB_QASE_PROJECT_ID }}
-          qase_token: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-  
-  v2-15:
-    needs: [create-qase-run]
-    if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && !contains(inputs.rancher_version, '-head')
+      github.event_name == 'schedule' ||
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: upgrade-community-head
     env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
-      HOSTNAME_PREFIX: "pr-up-215"
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_16 }}"
+      HOSTNAME_PREFIX: "ds-up-216"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -176,7 +151,9 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_16_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_16_HEAD)
             }}
 
       - name: Set upgraded Rancher chart version
@@ -186,7 +163,9 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
       - name: Set upgraded Rancher repo
@@ -194,7 +173,27 @@ jobs:
         with:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          is-prime: false
+          release-community-version: "2.16"
           env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_16 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_16 }}
+
+      - name: Set upgraded Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          is-prime: false
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
+          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
 
       - name: Create config.yaml
         run: |
@@ -219,7 +218,7 @@ jobs:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
             awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
+              ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -231,28 +230,30 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
+              awsUser: "${{ vars.DUAL_STACK_AWS_USER }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_DUALSTACK_TYPE }}"
               targetType: "${{ vars.TARGET_TYPE }}"
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
+              osUser: "${{ vars.DUAL_STACK_OS_USER }}"
+              osGroup: "${{ vars.DUAL_STACK_OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
@@ -262,9 +263,73 @@ jobs:
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            networking:
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
+              stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
+            advanced:
+              machineGlobalConfig:
+                flannel-ipv6-masq: true
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+
+          awsEC2Configs:
+            region: "${{ vars.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
+                awsUser: "${{ vars.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -288,24 +353,26 @@ jobs:
           terraform_version: "${{ vars.TERRAFORM_VERSION }}"
           terraform_wrapper: false
 
-      - name: Run Post Release Upgrade Test Suite
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/dualstack/main.go
+
+      - name: Run Dualstack Provisioning tests
         env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_CUSTOM_FIELD_FILTER: Hostbusters
           QASE_SCHEMA_PREFIX: hostbusters
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
+        uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          package: ${{ env.PACKAGE }}
           reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
+          tags: dualstack
+          run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/sanity/aws
+        working-directory: tfp-automation/modules/dualstack/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -320,6 +387,20 @@ jobs:
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
           region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
@@ -342,23 +423,405 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  v2-14:
-    needs: [create-qase-run]
+      - name: Save test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: ./.github/actions/save-weekly-summary-result
+        with:
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-dualstack-cluster-provisioning
+          job: v2-16
+  
+  v2-15:
     if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && !contains(inputs.rancher_version, '-head')
+      github.event_name == 'schedule' ||
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: prime
+    environment: upgrade-community-head
     env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
-      HOSTNAME_PREFIX: "pr-up-214"
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
+      HOSTNAME_PREFIX: "ds-up-215"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
+        }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          submodules: recursive
+
+      - name: Checkout tfp-automation repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          repository: rancher/tfp-automation
+          path: tfp-automation
+
+      - name: Set up local rancher2 Terraform provider
+        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
+        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
+        with:
+          version: "latest"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: "Fetch and Set DockerHub Credentials"
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Mask Dockerhub Credentials
+        run: |
+          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
+          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Set up certificates
+        id: setup-certs
+        uses: ./.github/actions/setup-certs
+        with:
+          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
+          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
+          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
+          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set upgraded Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_15_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_15_HEAD)
+            }}
+
+      - name: Set upgraded Rancher chart version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_CHART_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
+            }}
+
+      - name: Set upgraded Rancher repo
+        uses: ./.github/actions/set-rancher-repo
+        with:
+          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          is-prime: false
+          release-community-version: "2.15"
+          env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_15 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_15 }}
+
+      - name: Set upgraded Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          is-prime: false
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
+          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+            cleanup: true
+          terraform:
+            cni: "${{ vars.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
+            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
+            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ vars.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ vars.DUAL_STACK_AWS_USER }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_DUALSTACK_TYPE }}"
+              targetType: "${{ vars.TARGET_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              osUser: "${{ vars.DUAL_STACK_OS_USER }}"
+              osGroup: "${{ vars.DUAL_STACK_OS_GROUP }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
+              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
+
+          clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            nodeProvider: "ec2"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            networking:
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
+              stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
+            advanced:
+              machineGlobalConfig:
+                flannel-ipv6-masq: true
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+
+          awsEC2Configs:
+            region: "${{ vars.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
+                awsUser: "${{ vars.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/go-build.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/dualstack/main.go
+
+      - name: Run Dualstack Provisioning tests
+        env:
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
+          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
+          QASE_CUSTOM_FIELD_FILTER: Hostbusters
+          QASE_SCHEMA_PREFIX: hostbusters
+          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        uses: ./.github/actions/run-hostbusters-provisioning
+        with:
+          reporting: ${{ env.REPORTING_ENABLED }}
+          tags: dualstack
+          run_ace: "false"
+          run_template: "false"
+
+      - name: Cleanup Infrastructure
+        if: always()
+        working-directory: tfp-automation/modules/dualstack/aws
+        run: terraform destroy -auto-approve > /dev/null 2>&1
+
+      - name: Refresh AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: AWS Custodian Infrastructure Cleanup
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set job status output
+        if: always()
+        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
+        id: set-job-status
+
+      - name: Reporting Results to Slack
+        if: always() && env.REPORTING_ENABLED == 'true'
+        uses: ./.github/actions/report-to-slack
+        with:
+          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          job-status: ${{ steps.set-job-status.outputs.job_status }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Save test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: ./.github/actions/save-weekly-summary-result
+        with:
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-dualstack-cluster-provisioning
+          job: v2-15
+
+  v2-14:
+    if: |
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14-head'))
+    name: ${{ github.event.inputs.rancher_version }}
+    runs-on: ubuntu-latest
+    environment: upgrade-prime-staging
+    env:
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
+      HOSTNAME_PREFIX: "ds-up-214"
+      REPORTING_ENABLED: >-
+        ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -443,7 +906,9 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_14_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_14_HEAD)
             }}
 
       - name: Set upgraded Rancher chart version
@@ -453,7 +918,9 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_14) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_14)
             }}
 
       - name: Set upgraded Rancher repo
@@ -462,7 +929,26 @@ jobs:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
           is-prime: true
+          release-prime-version: "2.14"
           env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_14 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_14 }}
+
+      - name: Set upgraded Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          is-prime: true
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
+          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
 
       - name: Create config.yaml
         run: |
@@ -476,7 +962,6 @@ jobs:
             cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
-            generateV3Token: true
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
@@ -488,7 +973,7 @@ jobs:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
             awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
+              ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -500,29 +985,31 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
+              awsUser: "${{ vars.DUAL_STACK_AWS_USER }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_DUALSTACK_TYPE }}"
               targetType: "${{ vars.TARGET_TYPE }}"
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
+              osUser: "${{ vars.DUAL_STACK_OS_USER }}"
+              osGroup: "${{ vars.DUAL_STACK_OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_14 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
@@ -532,9 +1019,73 @@ jobs:
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            networking:
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
+              stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
+            advanced:
+              machineGlobalConfig:
+                flannel-ipv6-masq: true
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+
+          awsEC2Configs:
+            region: "${{ vars.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
+                awsUser: "${{ vars.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -558,24 +1109,26 @@ jobs:
           terraform_version: "${{ vars.TERRAFORM_VERSION }}"
           terraform_wrapper: false
 
-      - name: Run Post Release Upgrade Test Suite
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/dualstack/main.go
+
+      - name: Run Dualstack Provisioning tests
         env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_CUSTOM_FIELD_FILTER: Hostbusters
           QASE_SCHEMA_PREFIX: hostbusters
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
+        uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          package: ${{ env.PACKAGE }}
           reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
+          tags: dualstack
+          run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/sanity/aws
+        working-directory: tfp-automation/modules/dualstack/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -590,6 +1143,20 @@ jobs:
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
           region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
@@ -611,24 +1178,28 @@ jobs:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Save test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: ./.github/actions/save-weekly-summary-result
+        with:
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-dualstack-cluster-provisioning
+          job: v2-14
   
   v2-13:
-    needs: [create-qase-run]
     if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && !contains(inputs.rancher_version, '-head')
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: prime
+    environment: upgrade-prime-staging
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_13 }}"
-      HOSTNAME_PREFIX: "pr-up-213"
+      HOSTNAME_PREFIX: "ds-up-213"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -713,7 +1284,9 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_13_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_13_HEAD)
             }}
 
       - name: Set upgraded Rancher chart version
@@ -723,7 +1296,9 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_13) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_13)
             }}
 
       - name: Set upgraded Rancher repo
@@ -732,7 +1307,26 @@ jobs:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
           is-prime: true
+          release-prime-version: "2.13"
           env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
+
+      - name: Set upgraded Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          is-prime: true
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
+          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
 
       - name: Create config.yaml
         run: |
@@ -746,7 +1340,6 @@ jobs:
             cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
-            generateV3Token: true
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
@@ -758,7 +1351,7 @@ jobs:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
             awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
+              ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -770,29 +1363,31 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
+              awsUser: "${{ vars.DUAL_STACK_AWS_USER }}"
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
               ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_DUALSTACK_TYPE }}"
               targetType: "${{ vars.TARGET_TYPE }}"
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
+              osUser: "${{ vars.DUAL_STACK_OS_USER }}"
+              osGroup: "${{ vars.DUAL_STACK_OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_13 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
@@ -802,548 +1397,73 @@ jobs:
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/go-build.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Run Post Release Upgrade Test Suite
-        env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
-        with:
-          package: ${{ env.PACKAGE }}
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
-
-      - name: Cleanup Infrastructure
-        if: always()
-        working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve > /dev/null 2>&1
-
-      - name: Refresh AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: AWS Custodian Infrastructure Cleanup
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set job status output
-        if: always()
-        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
-        id: set-job-status
-
-      - name: Reporting Results to Slack
-        if: always() && env.REPORTING_ENABLED == 'true'
-        uses: ./.github/actions/report-to-slack
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          job-status: ${{ steps.set-job-status.outputs.job_status }}
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  v2-12:
-    needs: [create-qase-run]
-    if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12')) && !contains(inputs.rancher_version, '-head')
-    name: ${{ github.event.inputs.rancher_version }}
-    runs-on: ubuntu-latest
-    environment: prime
-    env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_12 }}"
-      HOSTNAME_PREFIX: "pr-up-212"
-      REPORTING_ENABLED: >-
-        ${{
-          github.event_name == 'workflow_call' ||
-          github.actor == 'github-actions[bot]' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
-        }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          submodules: recursive
-
-      - name: Checkout tfp-automation repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: rancher/tfp-automation
-          path: tfp-automation
-
-      - name: Set up local rancher2 Terraform provider
-        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
-        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
-        with:
-          version: "latest"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: "Fetch and Set DockerHub Credentials"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
-
-      - name: Mask Dockerhub Credentials
-        run: |
-          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
-          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Set up certificates
-        id: setup-certs
-        uses: ./.github/actions/setup-certs
-        with:
-          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
-          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
-          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
-          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
-            }}
-
-      - name: Set upgraded Rancher chart version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_CHART_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
-            }}
-
-      - name: Set upgraded Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          is-prime: true
-          env-var-name: UPGRADED_RANCHER_REPO
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-            cleanup: true
-          terraform:
-            cni: "${{ vars.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            generateV3Token: true
-            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
-            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
-            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ vars.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_12 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_12 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_12 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_12 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/go-build.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Run Post Release Upgrade Test Suite
-        env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
-        with:
-          package: ${{ env.PACKAGE }}
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
-
-      - name: Cleanup Infrastructure
-        if: always()
-        working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve > /dev/null 2>&1
-
-      - name: Refresh AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: AWS Custodian Infrastructure Cleanup
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set job status output
-        if: always()
-        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
-        id: set-job-status
-
-      - name: Reporting Results to Slack
-        if: always() && env.REPORTING_ENABLED == 'true'
-        uses: ./.github/actions/report-to-slack
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          job-status: ${{ steps.set-job-status.outputs.job_status }}
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  v2-11:
-    needs: [create-qase-run]
-    if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.1')) && !contains(inputs.rancher_version, '-head')
-    name: ${{ github.event.inputs.rancher_version }}
-    runs-on: ubuntu-latest
-    environment: prime
-    env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
-      HOSTNAME_PREFIX: "pr-up-211"
-      REPORTING_ENABLED: >-
-        ${{
-          github.event_name == 'workflow_call' ||
-          github.actor == 'github-actions[bot]' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
-        }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          submodules: recursive
-
-      - name: Checkout tfp-automation repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: rancher/tfp-automation
-          path: tfp-automation
-
-      - name: Set up local rancher2 Terraform provider
-        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
-        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
-        with:
-          version: "latest"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: "Fetch and Set DockerHub Credentials"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
-
-      - name: Mask Dockerhub Credentials
-        run: |
-          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
-          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Set up certificates
-        id: setup-certs
-        uses: ./.github/actions/setup-certs
-        with:
-          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
-          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
-          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
-          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
-            }}
-
-      - name: Set upgraded Rancher chart version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_CHART_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
-            }}
-
-      - name: Set upgraded Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          is-prime: true
-          env-var-name: UPGRADED_RANCHER_REPO
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-            cleanup: true
-          terraform:
             cni: "${{ vars.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
-            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
-            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ vars.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_11 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_11 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_11 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            networking:
+              clusterCIDR: "${{ vars.DUALSTACK_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.DUALSTACK_SERVICE_CIDR }}"
+              stackPreference: "${{ vars.STACK_PREFERENCE_DUAL }}"
+            advanced:
+              machineGlobalConfig:
+                flannel-ipv6-masq: true
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_DUALSTACK_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              subnetId: "${{ secrets.AWS_SUBNET_ID }}"
+
+          awsEC2Configs:
+            region: "${{ vars.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_DUALSTACK_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
+                awsUser: "${{ vars.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1367,24 +1487,26 @@ jobs:
           terraform_version: "${{ vars.TERRAFORM_VERSION }}"
           terraform_wrapper: false
 
-      - name: Run Post Release Upgrade Test Suite
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/dualstack/main.go
+
+      - name: Run Dualstack Provisioning tests
         env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_CUSTOM_FIELD_FILTER: Hostbusters
           QASE_SCHEMA_PREFIX: hostbusters
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
+        uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          package: ${{ env.PACKAGE }}
           reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
+          tags: dualstack
+          run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/sanity/aws
+        working-directory: tfp-automation/modules/dualstack/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -1399,6 +1521,20 @@ jobs:
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
           region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
@@ -1421,26 +1557,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  close-qase-run:
-    needs: [create-qase-run, v2-15, v2-14, v2-13, v2-12, v2-11]
-    if: always() && (
-        ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
-        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
-        ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-alpha') &&
-        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-rc') &&
-        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-head'))
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Save test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          submodules: recursive
-
-      - name: Close Qase test run
-        uses: ./.github/actions/close-qase-test-run
-        with:
-          qase_run_id: ${{ needs.create-qase-run.outputs.run_id }}
-          qase_project_id: ${{ secrets.HB_QASE_PROJECT_ID }}
-          qase_token: ${{ secrets.QASE_TOKEN }}
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-dualstack-cluster-provisioning
+          job: v2-13

--- a/.github/workflows/rancher-upgrade-ipv6-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-ipv6-cluster-provisioning.yml
@@ -1,13 +1,20 @@
 ---
-name: Hostbusters Post Release Upgrade Sanity
+name: Upgraded IPv6 Rancher Cluster Provisioning
 
 on:
+  schedule:
+    - cron: "0 8 * * 2"
   workflow_dispatch:
     inputs:
       rancher_version:
         description: "Rancher tag version"
       rancher_chart_version:
         description: "Rancher chart version"
+      run_all_versions:
+        description: "Run all supported versions if manually triggered"
+        required: false
+        default: false
+        type: boolean
       reporting:
         description: "Enable reporting to Qase and Slack"
         required: false
@@ -44,54 +51,22 @@ env:
       (github.event_name == 'schedule' && 'rke2') || 'rke2' 
     }}
   LOCALS_PROVIDER_VERSION: "${{ vars.LOCALS_PROVIDER_VERSION }}"
-  PACKAGE: "postrelease"
-  TAG: "postrelease"
-  TEST_SUITE: "^TestPostReleaseUpgradeTestSuite$"
-  TIMEOUT: "1h"
 
-jobs: 
-  create-qase-run:
+jobs:
+  v2-16:
     if: |
-      ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
-      ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-head'))
-    runs-on: ubuntu-latest
-    outputs:
-      run_id: ${{ steps.create-qase-run.outputs.id }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          submodules: recursive
-      
-      - name: Create Qase test run
-        id: create-qase-run
-        uses: ./.github/actions/create-qase-test-run
-        with:
-          test_run_name: "[${{ github.event.inputs.rancher_version || inputs.rancher_version }}] Post Rancher Release Upgrade Validations"
-          qase_project_id: ${{ secrets.HB_QASE_PROJECT_ID }}
-          qase_token: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-  
-  v2-15:
-    needs: [create-qase-run]
-    if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.15')) && !contains(inputs.rancher_version, '-head')
+      github.event_name == 'schedule' ||
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: latest
+    environment: upgrade-community-head
     env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
-      HOSTNAME_PREFIX: "pr-up-215"
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_16 }}"
+      HOSTNAME_PREFIX: "ipv6-up-216"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -176,7 +151,9 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_16_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_16_HEAD)
             }}
 
       - name: Set upgraded Rancher chart version
@@ -186,7 +163,9 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
             }}
 
       - name: Set upgraded Rancher repo
@@ -194,7 +173,27 @@ jobs:
         with:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          is-prime: false
+          release-community-version: "2.16"
           env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_16 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_16 }}
+
+      - name: Set upgraded Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          is-prime: false
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
+          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
 
       - name: Create config.yaml
         run: |
@@ -219,7 +218,7 @@ jobs:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
             awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
+              ami: "${{ secrets.AWS_IPV6_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -231,28 +230,32 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
+              awsUser: "${{ vars.IPV6_AWS_USER }}"
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
+              enablePrimaryIPv6: true
+              httpProtocolIPv6: "enabled"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
+              ipAddressType: "${{ vars.IPV6_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_DUALSTACK_TYPE }}"
+              targetType: "${{ vars.TARGET_IPV6_TYPE }}"
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
+              osUser: "${{ vars.IPV6_OS_USER }}"
+              osGroup: "${{ vars.IPV6_OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
@@ -262,9 +265,73 @@ jobs:
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            networking:
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
+              stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
+            advanced:
+              machineGlobalConfig:
+                flannel-ipv6-masq: true
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              subnetId: "${{ secrets.AWS_IPV6_SUBNET_ID }}"
+
+          awsEC2Configs:
+            region: "${{ vars.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
+                awsUser: "${{ vars.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -288,24 +355,26 @@ jobs:
           terraform_version: "${{ vars.TERRAFORM_VERSION }}"
           terraform_wrapper: false
 
-      - name: Run Post Release Upgrade Test Suite
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/ipv6/main.go
+
+      - name: Run IPv6 Provisioning tests
         env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_CUSTOM_FIELD_FILTER: Hostbusters
           QASE_SCHEMA_PREFIX: hostbusters
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
+        uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          package: ${{ env.PACKAGE }}
           reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
+          tags: ipv6
+          run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/sanity/aws
+        working-directory: tfp-automation/modules/ipv6/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -320,6 +389,20 @@ jobs:
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
           region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
@@ -342,23 +425,407 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  v2-14:
-    needs: [create-qase-run]
+      - name: Save test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: ./.github/actions/save-weekly-summary-result
+        with:
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-ipv6-cluster-provisioning
+          job: v2-16
+  
+  v2-15:
     if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.14')) && !contains(inputs.rancher_version, '-head')
+      github.event_name == 'schedule' ||
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.15-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: prime
+    environment: upgrade-community-head
     env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
-      HOSTNAME_PREFIX: "pr-up-214"
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_15 }}"
+      HOSTNAME_PREFIX: "ipv6-up-215"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
+          github.event_name == 'workflow_call' ||
+          github.actor == 'github-actions[bot]' ||
+          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
+        }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          submodules: recursive
+
+      - name: Checkout tfp-automation repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
+        with:
+          repository: rancher/tfp-automation
+          path: tfp-automation
+
+      - name: Set up local rancher2 Terraform provider
+        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
+        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
+        with:
+          version: "latest"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Get AWS credentials from Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
+        with:
+          secret-ids: |
+            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
+            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: "Fetch and Set DockerHub Credentials"
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
+
+      - name: Mask Dockerhub Credentials
+        run: |
+          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
+          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
+
+      - name: Whitelist Runner IP
+        uses: ./.github/actions/whitelist-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set up SSH Keys
+        uses: ./.github/actions/setup-ssh-keys
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
+          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
+          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
+
+      - name: Set up certificates
+        id: setup-certs
+        uses: ./.github/actions/setup-certs
+        with:
+          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
+          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
+          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
+          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
+
+      - name: Uniquify hostname prefix
+        uses: ./.github/actions/uniquify-hostname
+
+      - name: Set upgraded Rancher version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_15_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_15_HEAD)
+            }}
+
+      - name: Set upgraded Rancher chart version
+        uses: ./.github/actions/set-env-var
+        with:
+          key: UPGRADED_RANCHER_CHART_VERSION
+          value: |
+            ${{ 
+              github.event.inputs.rancher_chart_version || 
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_15) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_15)
+            }}
+
+      - name: Set upgraded Rancher repo
+        uses: ./.github/actions/set-rancher-repo
+        with:
+          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
+          is-prime: false
+          release-community-version: "2.15"
+          env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_15 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_15 }}
+
+      - name: Set upgraded Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          is-prime: false
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
+          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
+
+      - name: Create config.yaml
+        run: |
+          cat > config.yaml <<EOF
+          rancher:
+            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+            insecure: true
+            cleanup: true
+          terraform:
+            cni: "${{ vars.CNI }}"
+            defaultClusterRoleForProjectMembers: "true"
+            enableNetworkPolicy: false
+            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
+            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
+            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
+            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            awsCredentials:
+              awsAccessKey: "$AWS_ACCESS_KEY"
+              awsSecretKey: "$AWS_SECRET_KEY"
+            awsConfig:
+              ami: "${{ secrets.AWS_IPV6_AMI }}"
+              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
+              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              region: "${{ vars.AWS_REGION }}"
+              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
+              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
+              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
+              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
+              awsUser: "${{ vars.IPV6_AWS_USER }}"
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
+              enablePrimaryIPv6: true
+              httpProtocolIPv6: "enabled"
+              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
+              timeout: "${{ vars.TIMEOUT }}"
+              ipAddressType: "${{ vars.IPV6_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_DUALSTACK_TYPE }}"
+              targetType: "${{ vars.TARGET_IPV6_TYPE }}"
+            standalone:
+              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
+              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
+              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_15 }}"
+              k3sVersion: "${{ vars.K3S_VERSION_2_15 }}${{ vars.K3S_VERSION_SUFFIX }}"
+              osUser: "${{ vars.IPV6_OS_USER }}"
+              osGroup: "${{ vars.IPV6_OS_GROUP }}"
+              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
+              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
+              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
+              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_15 }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
+              repo: "${{ secrets.RANCHER_REPO }}"
+              rke2Version: "${{ vars.RKE2_VERSION_2_15 }}"
+              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
+              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
+              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
+              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
+          terratest:
+            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
+            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
+
+          clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
+            provider: "${{ vars.PROVIDER_AMAZON }}"
+            nodeProvider: "ec2"
+            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            networking:
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
+              stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
+            advanced:
+              machineGlobalConfig:
+                flannel-ipv6-masq: true
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              subnetId: "${{ secrets.AWS_IPV6_SUBNET_ID }}"
+
+          awsEC2Configs:
+            region: "${{ vars.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
+                awsUser: "${{ vars.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
+          EOF
+
+      - name: Export CATTLE_TEST_CONFIG
+        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Set up Go environment
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
+        with:
+          go-version-file: "./go.mod"
+
+      - name: Build Packages
+        run: ./.github/scripts/go-build.sh
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
+        with:
+          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
+          terraform_wrapper: false
+
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/ipv6/main.go
+
+      - name: Run IPv6 Provisioning tests
+        env:
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
+          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
+          QASE_CUSTOM_FIELD_FILTER: Hostbusters
+          QASE_SCHEMA_PREFIX: hostbusters
+          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
+        uses: ./.github/actions/run-hostbusters-provisioning
+        with:
+          reporting: ${{ env.REPORTING_ENABLED }}
+          tags: ipv6
+          run_ace: "false"
+          run_template: "false"
+
+      - name: Cleanup Infrastructure
+        if: always()
+        working-directory: tfp-automation/modules/ipv6/aws
+        run: terraform destroy -auto-approve > /dev/null 2>&1
+
+      - name: Refresh AWS credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
+        with:
+          role-to-assume: ${{ secrets.IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: AWS Custodian Infrastructure Cleanup
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Revoke Runner IP
+        if: always()
+        uses: ./.github/actions/revoke-runner-ip
+        with:
+          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID }}
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: Set job status output
+        if: always()
+        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
+        id: set-job-status
+
+      - name: Reporting Results to Slack
+        if: always() && env.REPORTING_ENABLED == 'true'
+        uses: ./.github/actions/report-to-slack
+        with:
+          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          job-status: ${{ steps.set-job-status.outputs.job_status }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Save test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: ./.github/actions/save-weekly-summary-result
+        with:
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-ipv6-cluster-provisioning
+          job: v2-15
+
+  v2-14:
+    if: |
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.14-head'))
+    name: ${{ github.event.inputs.rancher_version }}
+    runs-on: ubuntu-latest
+    environment: upgrade-prime-staging
+    env:
+      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_14 }}"
+      HOSTNAME_PREFIX: "ipv6-up-214"
+      REPORTING_ENABLED: >-
+        ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -443,7 +910,9 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_14_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_14_HEAD)
             }}
 
       - name: Set upgraded Rancher chart version
@@ -453,7 +922,9 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_14) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_14)
             }}
 
       - name: Set upgraded Rancher repo
@@ -462,7 +933,26 @@ jobs:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
           is-prime: true
+          release-prime-version: "2.14"
           env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_14 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_14 }}
+
+      - name: Set upgraded Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          is-prime: true
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
+          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
 
       - name: Create config.yaml
         run: |
@@ -476,7 +966,6 @@ jobs:
             cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
-            generateV3Token: true
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
@@ -488,7 +977,7 @@ jobs:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
             awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
+              ami: "${{ secrets.AWS_IPV6_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -500,29 +989,33 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
+              awsUser: "${{ vars.IPV6_AWS_USER }}"
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
+              enablePrimaryIPv6: true
+              httpProtocolIPv6: "enabled"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
+              ipAddressType: "${{ vars.IPV6_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_DUALSTACK_TYPE }}"
+              targetType: "${{ vars.TARGET_IPV6_TYPE }}"
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_14 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_14 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
+              osUser: "${{ vars.IPV6_OS_USER }}"
+              osGroup: "${{ vars.IPV6_OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_14 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_14 }}"
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
@@ -532,9 +1025,73 @@ jobs:
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
+            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
+            cni: "${{ vars.CNI }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            networking:
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
+              stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
+            advanced:
+              machineGlobalConfig:
+                flannel-ipv6-masq: true
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              subnetId: "${{ secrets.AWS_IPV6_SUBNET_ID }}"
+
+          awsEC2Configs:
+            region: "${{ vars.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
+                awsUser: "${{ vars.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -558,24 +1115,26 @@ jobs:
           terraform_version: "${{ vars.TERRAFORM_VERSION }}"
           terraform_wrapper: false
 
-      - name: Run Post Release Upgrade Test Suite
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/ipv6/main.go
+
+      - name: Run IPv6 Provisioning tests
         env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_CUSTOM_FIELD_FILTER: Hostbusters
           QASE_SCHEMA_PREFIX: hostbusters
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
+        uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          package: ${{ env.PACKAGE }}
           reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
+          tags: ipv6
+          run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/sanity/aws
+        working-directory: tfp-automation/modules/ipv6/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -590,6 +1149,20 @@ jobs:
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
           region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
@@ -611,24 +1184,28 @@ jobs:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Save test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: ./.github/actions/save-weekly-summary-result
+        with:
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-ipv6-cluster-provisioning
+          job: v2-14
   
   v2-13:
-    needs: [create-qase-run]
     if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.13')) && !contains(inputs.rancher_version, '-head')
+      github.event.inputs.run_all_versions == 'true' ||
+      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.13-head'))
     name: ${{ github.event.inputs.rancher_version }}
     runs-on: ubuntu-latest
-    environment: prime
+    environment: upgrade-prime-staging
     env:
       RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_13 }}"
-      HOSTNAME_PREFIX: "pr-up-213"
+      HOSTNAME_PREFIX: "ipv6-up-213"
       REPORTING_ENABLED: >-
         ${{
+          github.event_name == 'schedule' ||
           github.event_name == 'workflow_call' ||
           github.actor == 'github-actions[bot]' ||
           (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
@@ -713,7 +1290,9 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version) || 
+              (github.event_name == 'schedule' && vars.RANCHER_VERSION_2_13_HEAD) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RANCHER_VERSION_2_13_HEAD)
             }}
 
       - name: Set upgraded Rancher chart version
@@ -723,7 +1302,9 @@ jobs:
           value: |
             ${{ 
               github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
+              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version) ||
+              (github.event_name == 'schedule' && vars.RELEASED_RANCHER_CHART_VERSION_2_13) ||
+              (github.event.inputs.run_all_versions == 'true' && vars.RELEASED_RANCHER_CHART_VERSION_2_13)
             }}
 
       - name: Set upgraded Rancher repo
@@ -732,7 +1313,26 @@ jobs:
           rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
           fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
           is-prime: true
+          release-prime-version: "2.13"
           env-var-name: UPGRADED_RANCHER_REPO
+
+      - name: Get Qase ID
+        id: get-qase-id
+        uses: ./.github/actions/get-qase-id
+        with:
+          triggered_tag: ${{ github.event.inputs.rancher_version }}
+          qase_release_id: ${{ vars.HB_QASE_RELEASE_TEST_RUN_ID_2_13 }}
+          qase_recurring_id: ${{ vars.HB_QASE_RECURRING_TEST_RUN_ID_2_13 }}
+
+      - name: Set upgraded Rancher chart url
+        uses: ./.github/actions/set-rancher-chart-url
+        with:
+          rancher-repo: ${{ env.UPGRADED_RANCHER_REPO }}
+          is-prime: true
+          community-chart-url: ${{ vars.COMMUNITY_HELM_CHART_URL }}
+          staging-chart-url: ${{ secrets.STAGING_RANCHER_HELM_CHART_URL }}
+          fallback-chart-url: ${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}
+          env-var-name: UPGRADED_RANCHER_HELM_CHART_URL
 
       - name: Create config.yaml
         run: |
@@ -746,7 +1346,6 @@ jobs:
             cni: "${{ vars.CNI }}"
             defaultClusterRoleForProjectMembers: "true"
             enableNetworkPolicy: false
-            generateV3Token: true
             localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
             provider: "${{ vars.PROVIDER_AMAZON }}"
             downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
@@ -758,7 +1357,7 @@ jobs:
               awsAccessKey: "$AWS_ACCESS_KEY"
               awsSecretKey: "$AWS_SECRET_KEY"
             awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
+              ami: "${{ secrets.AWS_IPV6_AMI }}"
               awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
               awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
               awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
@@ -770,29 +1369,33 @@ jobs:
               awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
               awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
               awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
+              awsUser: "${{ vars.IPV6_AWS_USER }}"
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
+              enablePrimaryIPv6: true
+              httpProtocolIPv6: "enabled"
               sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
               timeout: "${{ vars.TIMEOUT }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
+              ipAddressType: "${{ vars.IPV6_ADDRESS_TYPE }}"
+              loadBalancerType: "${{ vars.LOAD_BALANCER_DUALSTACK_TYPE }}"
+              targetType: "${{ vars.TARGET_IPV6_TYPE }}"
             standalone:
               bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
               certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
               chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_13 }}"
               k3sVersion: "${{ vars.K3S_VERSION_2_13 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
+              osUser: "${{ vars.IPV6_OS_USER }}"
+              osGroup: "${{ vars.IPV6_OS_GROUP }}"
               rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
               rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
               rancherImage: "${{ secrets.RANCHER_IMAGE }}"
               rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_13 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
+              registryPassword: "${{ env.DOCKERHUB_PASSWORD }}"
+              registryUsername: "${{ env.DOCKERHUB_USERNAME }}"
               repo: "${{ secrets.RANCHER_REPO }}"
               rke2Version: "${{ vars.RKE2_VERSION_2_13 }}"
               upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
+              upgradedRancherChartRepository: "${{ env.UPGRADED_RANCHER_HELM_CHART_URL }}"
               upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
               upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
               upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
@@ -802,548 +1405,73 @@ jobs:
             standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
 
           clusterConfig:
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/go-build.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Run Post Release Upgrade Test Suite
-        env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
-        with:
-          package: ${{ env.PACKAGE }}
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
-
-      - name: Cleanup Infrastructure
-        if: always()
-        working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve > /dev/null 2>&1
-
-      - name: Refresh AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: AWS Custodian Infrastructure Cleanup
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set job status output
-        if: always()
-        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
-        id: set-job-status
-
-      - name: Reporting Results to Slack
-        if: always() && env.REPORTING_ENABLED == 'true'
-        uses: ./.github/actions/report-to-slack
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          job-status: ${{ steps.set-job-status.outputs.job_status }}
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  v2-12:
-    needs: [create-qase-run]
-    if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.12')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.12')) && !contains(inputs.rancher_version, '-head')
-    name: ${{ github.event.inputs.rancher_version }}
-    runs-on: ubuntu-latest
-    environment: prime
-    env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_12 }}"
-      HOSTNAME_PREFIX: "pr-up-212"
-      REPORTING_ENABLED: >-
-        ${{
-          github.event_name == 'workflow_call' ||
-          github.actor == 'github-actions[bot]' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
-        }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          submodules: recursive
-
-      - name: Checkout tfp-automation repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: rancher/tfp-automation
-          path: tfp-automation
-
-      - name: Set up local rancher2 Terraform provider
-        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
-        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
-        with:
-          version: "latest"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: "Fetch and Set DockerHub Credentials"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
-
-      - name: Mask Dockerhub Credentials
-        run: |
-          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
-          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Set up certificates
-        id: setup-certs
-        uses: ./.github/actions/setup-certs
-        with:
-          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
-          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
-          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
-          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
-            }}
-
-      - name: Set upgraded Rancher chart version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_CHART_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
-            }}
-
-      - name: Set upgraded Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          is-prime: true
-          env-var-name: UPGRADED_RANCHER_REPO
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-            cleanup: true
-          terraform:
-            cni: "${{ vars.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            generateV3Token: true
-            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
-            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
-            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
             resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ vars.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_12 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_12 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_12 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_12 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            nodeProvider: "ec2"
-            pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
-          EOF
-
-      - name: Export CATTLE_TEST_CONFIG
-        run: echo "CATTLE_TEST_CONFIG=${{ github.workspace }}/config.yaml" >> $GITHUB_ENV
-        shell: bash
-
-      - name: Set up Go environment
-        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 #v6
-        with:
-          go-version-file: "./go.mod"
-
-      - name: Build Packages
-        run: ./.github/scripts/go-build.sh
-
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@c4a0df2e75a225d979a444342dd3db752b53619f
-
-      - name: Set up Terraform
-        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 #v4
-        with:
-          terraform_version: "${{ vars.TERRAFORM_VERSION }}"
-          terraform_wrapper: false
-
-      - name: Run Post Release Upgrade Test Suite
-        env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
-          QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
-          QASE_CUSTOM_FIELD_FILTER: Hostbusters
-          QASE_SCHEMA_PREFIX: hostbusters
-          QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
-        with:
-          package: ${{ env.PACKAGE }}
-          reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
-
-      - name: Cleanup Infrastructure
-        if: always()
-        working-directory: tfp-automation/modules/sanity/aws
-        run: terraform destroy -auto-approve > /dev/null 2>&1
-
-      - name: Refresh AWS credentials
-        if: always()
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: AWS Custodian Infrastructure Cleanup
-        if: always()
-        uses: ./.github/actions/aws-cleanup
-        with:
-          prefix: "${{ env.HOSTNAME_PREFIX }}"
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Revoke Runner IP
-        if: always()
-        uses: ./.github/actions/revoke-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set job status output
-        if: always()
-        run: echo "job_status=${{ job.status }}" >> $GITHUB_OUTPUT
-        id: set-job-status
-
-      - name: Reporting Results to Slack
-        if: always() && env.REPORTING_ENABLED == 'true'
-        uses: ./.github/actions/report-to-slack
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          job-status: ${{ steps.set-job-status.outputs.job_status }}
-          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  v2-11:
-    needs: [create-qase-run]
-    if: |
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && !contains(github.event.inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_dispatch' && startsWith(github.event.inputs.rancher_version, 'v2.11')) && !contains(github.event.inputs.rancher_version, '-head') ||
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11')) && !contains(inputs.rancher_version, '-alpha') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.11')) && !contains(inputs.rancher_version, '-rc') &&
-      (github.event_name == 'workflow_call' && startsWith(inputs.rancher_version, 'v2.1')) && !contains(inputs.rancher_version, '-head')
-    name: ${{ github.event.inputs.rancher_version }}
-    runs-on: ubuntu-latest
-    environment: prime
-    env:
-      RANCHER2_PROVIDER_VERSION: "${{ vars.RANCHER2_PROVIDER_VERSION_2_11 }}"
-      HOSTNAME_PREFIX: "pr-up-211"
-      REPORTING_ENABLED: >-
-        ${{
-          github.event_name == 'workflow_call' ||
-          github.actor == 'github-actions[bot]' ||
-          (github.event_name == 'workflow_dispatch' && github.event.inputs.reporting == 'true' )
-        }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          submodules: recursive
-
-      - name: Checkout tfp-automation repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6
-        with:
-          repository: rancher/tfp-automation
-          path: tfp-automation
-
-      - name: Set up local rancher2 Terraform provider
-        if: contains(env.RANCHER2_PROVIDER_VERSION, '-rc')
-        run: chmod +x ./tfp-automation/scripts/setup-provider.sh && ./tfp-automation/scripts/setup-provider.sh rancher2 v${{ env.RANCHER2_PROVIDER_VERSION }}
-
-      - name: Setup kubectl
-        uses: azure/setup-kubectl@15650b3ad78fff148532a140b8a4c821796b2d7b #v5
-        with:
-          version: "latest"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 #v6
-        with:
-          role-to-assume: ${{ secrets.IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
-
-      - name: Get AWS credentials from Secrets Manager
-        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa #v3
-        with:
-          secret-ids: |
-            AWS_ACCESS_KEY, ${{ secrets.AWS_ACCESS_KEY_ID }}
-            AWS_SECRET_KEY, ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: "Fetch and Set DockerHub Credentials"
-        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 #v3
-        with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials username | DOCKERHUB_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/org-token/credentials password | DOCKERHUB_PASSWORD
-
-      - name: Mask Dockerhub Credentials
-        run: |
-          echo "::add-mask::${{ env.DOCKERHUB_USERNAME }}"
-          echo "::add-mask::${{ env.DOCKERHUB_PASSWORD }}"
-
-      - name: Whitelist Runner IP
-        uses: ./.github/actions/whitelist-runner-ip
-        with:
-          prefix-list-id: ${{ secrets.AWS_MANAGED_PREFIX_LIST_ID_PRIME }}
-          region: "${{ vars.AWS_REGION }}"
-
-      - name: Set up SSH Keys
-        uses: ./.github/actions/setup-ssh-keys
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-          ssh-private-key-name: ${{ secrets.SSH_PRIVATE_KEY_NAME }}
-          windows-ssh-private-key: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY }}
-          windows-ssh-private-key-name: ${{ secrets.WINDOWS_SSH_PRIVATE_KEY_NAME }}
-
-      - name: Set up certificates
-        id: setup-certs
-        uses: ./.github/actions/setup-certs
-        with:
-          private-full-chain: ${{ secrets.PRIVATE_FULL_CHAIN }}
-          private-full-chain-name: ${{ vars.PRIVATE_FULL_CHAIN_NAME }}
-          private-cert-key: ${{ secrets.PRIVATE_CERT_KEY }}
-          private-cert-key-name: ${{ vars.PRIVATE_CERT_KEY_NAME }}
-
-      - name: Uniquify hostname prefix
-        uses: ./.github/actions/uniquify-hostname
-
-      - name: Set upgraded Rancher version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_version)
-            }}
-
-      - name: Set upgraded Rancher chart version
-        uses: ./.github/actions/set-env-var
-        with:
-          key: UPGRADED_RANCHER_CHART_VERSION
-          value: |
-            ${{ 
-              github.event.inputs.rancher_chart_version || 
-              (github.event_name == 'workflow_dispatch' && github.event.inputs.rancher_chart_version)
-            }}
-
-      - name: Set upgraded Rancher repo
-        uses: ./.github/actions/set-rancher-repo
-        with:
-          rancher-version: ${{ env.UPGRADED_RANCHER_VERSION }}
-          fallback-repo: ${{ secrets.UPGRADED_RANCHER_REPO }}
-          is-prime: true
-          env-var-name: UPGRADED_RANCHER_REPO
-
-      - name: Create config.yaml
-        run: |
-          cat > config.yaml <<EOF
-          rancher:
-            host: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-            adminPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-            insecure: true
-            cleanup: true
-          terraform:
             cni: "${{ vars.CNI }}"
-            defaultClusterRoleForProjectMembers: "true"
-            enableNetworkPolicy: false
-            localCluster: "${{ env.LOCAL_CLUSTER_TYPE }}"
-            provider: "${{ vars.PROVIDER_AMAZON }}"
-            downstreamClusterProvider: "${{ vars.PROVIDER_AMAZON }}"
-            privateKeyPath: "${{ secrets.TFP_SSH_PRIVATE_KEY_PATH }}"
-            privateFullChainPath: "${{ steps.setup-certs.outputs.private-full-chain-tfp-path }}"
-            privateCertKeyPath: "${{ steps.setup-certs.outputs.private-cert-key-tfp-path }}"
-            resourcePrefix: "${{ env.HOSTNAME_PREFIX }}"
-            awsCredentials:
-              awsAccessKey: "$AWS_ACCESS_KEY"
-              awsSecretKey: "$AWS_SECRET_KEY"
-            awsConfig:
-              ami: "${{ secrets.AWS_AMI }}"
-              awsKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}"
-              awsInstanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
-              awsVolumeType: "${{ vars.AWS_VOLUME_TYPE }}"
-              region: "${{ vars.AWS_REGION }}"
-              awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS_PRIME }}]
-              awsSecurityGroupNames: [${{ secrets.AWS_SECURITY_GROUP_NAMES_PRIME }}]
-              awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
-              awsVpcID: "${{ secrets.AWS_VPC_ID }}"
-              awsZoneLetter: "${{ vars.AWS_ZONE_LETTER }}"
-              awsRootSize: ${{ vars.AWS_ROOT_SIZE }}
-              awsRoute53Zone: "${{ secrets.AWS_ROUTE_53_ZONE }}"
-              awsUser: "${{ vars.AWS_USER }}"
-              sshConnectionType: "${{ vars.SSH_CONNECTION_TYPE }}" 
-              timeout: "${{ vars.TIMEOUT }}"
-              ipAddressType: "${{ vars.IP_ADDRESS_TYPE }}"
-              loadBalancerType: "${{ vars.LOAD_BALANCER_TYPE }}"
-              targetType: "${{ vars.TARGET_TYPE }}"
-            standalone:
-              bootstrapPassword: "${{ secrets.RANCHER_ADMIN_PASSWORD }}"
-              certManagerVersion: "${{ vars.CERT_MANAGER_VERSION }}"
-              chartVersion: "${{ vars.RELEASED_RANCHER_CHART_VERSION_2_11 }}"
-              k3sVersion: "${{ vars.K3S_VERSION_2_11 }}${{ vars.K3S_VERSION_SUFFIX }}"
-              osUser: "${{ vars.OS_USER }}"
-              osGroup: "${{ vars.OS_GROUP }}"
-              rancherChartRepository: "${{ secrets.RANCHER_HELM_CHART_URL }}"
-              rancherHostname: "${{ env.HOSTNAME_PREFIX }}.${{ secrets.AWS_ROUTE_53_ZONE }}"
-              rancherImage: "${{ secrets.RANCHER_IMAGE }}"
-              rancherTagVersion: "${{ vars.RELEASED_RANCHER_VERSION_2_11 }}"
-              registryUsername: "${{ secrets.PRIVATE_REGISTRY_USERNAME }}"
-              registryPassword: "${{ secrets.PRIVATE_REGISTRY_PASSWORD }}"
-              repo: "${{ secrets.RANCHER_REPO }}"
-              rke2Version: "${{ vars.RKE2_VERSION_2_11 }}"
-              upgradedRancherAgentImage: "${{ secrets.UPGRADED_RANCHER_AGENT_IMAGE }}"
-              upgradedRancherChartRepository: "${{ secrets.UPGRADED_RANCHER_HELM_CHART_URL }}"
-              upgradedRancherChartVersion: "${{ env.UPGRADED_RANCHER_CHART_VERSION }}"
-              upgradedRancherImage: "${{ secrets.UPGRADED_RANCHER_IMAGE }}"
-              upgradedRancherRepo: "${{ env.UPGRADED_RANCHER_REPO }}"
-              upgradedRancherTagVersion: "${{ env.UPGRADED_RANCHER_VERSION }}"
-          terratest:
-            pathToRepo: "${{ secrets.PATH_TO_REPO }}"
-            standaloneLogging: ${{ vars.TERRAFORM_LOGGING }}
-
-          clusterConfig:
             provider: "${{ vars.PROVIDER_AMAZON }}"
             nodeProvider: "ec2"
             pathToRepo: "${{ secrets.PATH_TO_TESTS_REPO }}"
+            networking:
+              clusterCIDR: "${{ vars.IPV6_CLUSTER_CIDR }}"
+              serviceCIDR: "${{ vars.IPV6_SERVICE_CIDR }}"
+              stackPreference: "${{ vars.STACK_PREFERENCE_IPV6 }}"
+            advanced:
+              machineGlobalConfig:
+                flannel-ipv6-masq: true
+            registries:
+              rke2Password: "${{ env.DOCKERHUB_PASSWORD }}"
+              rke2Username: "${{ env.DOCKERHUB_USERNAME }}"
+              rke2Registries:
+                mirrors:
+                  "docker.io":
+                    endpoint: ["https://${{ secrets.QA_PRIVATE_REGISTRY_NAME }}"]
+                configs:
+                  "${{ secrets.QA_PRIVATE_REGISTRY_NAME }}":
+                    "auth":
+                      username: "${{ env.DOCKERHUB_USERNAME }}"
+                      password: "${{ env.DOCKERHUB_PASSWORD }}"
+                    insecureSkipVerify: true
+
+          logging:
+            level: "${{ vars.LOGGING_LEVEL }}"
+          
+          awsCredentials:
+            secretKey: "$AWS_SECRET_KEY"
+            accessKey: "$AWS_ACCESS_KEY"
+            defaultRegion: "${{ vars.AWS_REGION }}"
+
+          awsMachineConfigs:
+            region: "${{ vars.AWS_REGION }}"
+            awsMachineConfig:
+            - roles: ["etcd", "controlplane", "worker"]
+              ami: "${{ secrets.AWS_IPV6_AMI }}"
+              instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+              sshUser: "${{ vars.AWS_USER }}"
+              vpcId: "${{ secrets.AWS_VPC_ID }}"
+              volumeType: "${{ vars.AWS_VOLUME_TYPE }}"
+              zone: "${{ vars.IPV6_AWS_ZONE_LETTER }}"
+              retries: "5"
+              rootSize: "${{ vars.AWS_ROOT_SIZE }}"
+              securityGroup: [${{ secrets.AWS_SECURITY_GROUP_NAMES }}]
+              subnetId: "${{ secrets.AWS_IPV6_SUBNET_ID }}"
+
+          awsEC2Configs:
+            region: "${{ vars.AWS_REGION }}"
+            awsSecretAccessKey: "$AWS_SECRET_KEY"
+            awsAccessKeyID: "$AWS_ACCESS_KEY"
+            awsEC2Config:
+              - awsRegionAZ: "${{ vars.AWS_REGION }}${{ vars.AWS_ZONE_LETTER }}"
+                awsAMI: "${{ secrets.AWS_IPV6_AMI }}"
+                instanceType: "${{ vars.AWS_INSTANCE_TYPE }}"
+                awsSecurityGroups: [${{ secrets.AWS_SECURITY_GROUPS }}]
+                awsSubnetID: "${{ secrets.AWS_SUBNET_ID }}"
+                awsSSHKeyName: "${{ secrets.SSH_PRIVATE_KEY_NAME }}.pem"
+                awsCICDInstanceTag: "rancher-validation"
+                awsIAMProfile: "${{ secrets.AWS_IAM_PROFILE }}"
+                awsUser: "${{ vars.AWS_USER }}"
+                volumeSize: ${{ vars.AWS_ROOT_SIZE }}
+                roles: ["etcd", "controlplane", "worker"]
+          sshPath: 
+            sshPath: "${{ secrets.SSH_PRIVATE_KEY_PATH }}"
           EOF
 
       - name: Export CATTLE_TEST_CONFIG
@@ -1367,24 +1495,26 @@ jobs:
           terraform_version: "${{ vars.TERRAFORM_VERSION }}"
           terraform_wrapper: false
 
-      - name: Run Post Release Upgrade Test Suite
+      - name: Creating Rancher server
+        run: go run /home/runner/work/tests/tests/validation/recurring/infrastructure/upgraderancher/ipv6/main.go
+
+      - name: Run IPv6 Provisioning tests
         env:
-          QASE_TEST_RUN_ID: ${{ needs.create-qase-run.outputs.run_id }}
+          QASE_TEST_RUN_ID: ${{ steps.get-qase-id.outputs.id }}
           QASE_AUTOMATION_TOKEN: ${{ secrets.QASE_AUTOMATION_TOKEN }}
           QASE_CUSTOM_FIELD_FILTER: Hostbusters
           QASE_SCHEMA_PREFIX: hostbusters
           QASE_PROJECT_ID: ${{ secrets.HB_QASE_PROJECT_ID }}
-        uses: ./.github/actions/run-test-suite
+        uses: ./.github/actions/run-hostbusters-provisioning
         with:
-          package: ${{ env.PACKAGE }}
           reporting: ${{ env.REPORTING_ENABLED }}
-          tag: ${{ env.TAG }}
-          test-suite: ${{ env.TEST_SUITE }}
-          timeout: ${{ env.TIMEOUT }}
+          tags: ipv6
+          run_ace: "false"
+          run_template: "false"
 
       - name: Cleanup Infrastructure
         if: always()
-        working-directory: tfp-automation/modules/sanity/aws
+        working-directory: tfp-automation/modules/ipv6/aws
         run: terraform destroy -auto-approve > /dev/null 2>&1
 
       - name: Refresh AWS credentials
@@ -1399,6 +1529,20 @@ jobs:
         uses: ./.github/actions/aws-cleanup
         with:
           prefix: "${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Node driver
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "auto-${{ env.HOSTNAME_PREFIX }}"
+          region: "${{ vars.AWS_REGION }}"
+
+      - name: AWS Custodian Downstream Cleanup - Custom
+        if: always()
+        uses: ./.github/actions/aws-cleanup
+        with:
+          prefix: "rancher-validation${{ env.HOSTNAME_PREFIX }}"
           region: "${{ vars.AWS_REGION }}"
 
       - name: Revoke Runner IP
@@ -1421,26 +1565,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  close-qase-run:
-    needs: [create-qase-run, v2-15, v2-14, v2-13, v2-12, v2-11]
-    if: always() && (
-        ((github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-alpha') &&
-        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-rc') &&
-        (github.event_name == 'workflow_dispatch' && (startsWith(github.event.inputs.rancher_version, 'v2.15') || startsWith(github.event.inputs.rancher_version, 'v2.14') || startsWith(github.event.inputs.rancher_version, 'v2.13') || startsWith(github.event.inputs.rancher_version, 'v2.12') || startsWith(github.event.inputs.rancher_version, 'v2.11'))) && !contains(github.event.inputs.rancher_version, '-head')) ||
-        ((github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-alpha') &&
-        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-rc') &&
-        (github.event_name == 'workflow_call' && (startsWith(inputs.rancher_version, 'v2.15') || startsWith(inputs.rancher_version, 'v2.14') || startsWith(inputs.rancher_version, 'v2.13') || startsWith(inputs.rancher_version, 'v2.12') || startsWith(inputs.rancher_version, 'v2.11'))) && !contains(inputs.rancher_version, '-head'))
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Save test result weekly summary
+        if: always() && github.event_name == 'schedule'
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          submodules: recursive
-
-      - name: Close Qase test run
-        uses: ./.github/actions/close-qase-test-run
-        with:
-          qase_run_id: ${{ needs.create-qase-run.outputs.run_id }}
-          qase_project_id: ${{ secrets.HB_QASE_PROJECT_ID }}
-          qase_token: ${{ secrets.QASE_TOKEN }}
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-ipv6-cluster-provisioning
+          job: v2-13

--- a/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
+++ b/.github/workflows/rancher-upgrade-proxy-cluster-provisioning.yml
@@ -445,18 +445,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-16\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-16-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-proxy-cluster-provisioning
+          job: v2-16
   
   v2-15:
     if: |
@@ -850,18 +845,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-15\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-15-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-proxy-cluster-provisioning
+          job: v2-15
   
   v2-14:
     if: |
@@ -1256,18 +1246,13 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-14\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-14-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-proxy-cluster-provisioning
+          job: v2-14
 
   v2-13:
     if: |
@@ -1661,15 +1646,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.UPGRADED_RANCHER_VERSION }}\", \"workflow\": \"rancher-upgrade-proxy-cluster-provisioning-test\", \"job\": \"v2-13\" }" > test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}
-          path: test-result-rancher-upgrade-proxy-cluster-provisioning-test-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: rancher-upgrade-proxy-cluster-provisioning
+          job: v2-13

--- a/.github/workflows/turtles-feature-off-cluster-provisioning.yml
+++ b/.github/workflows/turtles-feature-off-cluster-provisioning.yml
@@ -426,15 +426,10 @@ jobs:
           job-status: ${{ steps.set-job-status.outputs.job_status }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Save test result as artifact for weekly summary
+      - name: Save test result weekly summary
         if: always() && github.event_name == 'schedule'
-        run: |
-          echo "{\"date\": \"$(date -u "+%B %d, %Y at %I:%M %p")\", \"status\": \"${{ job.status }}\", \"rancher_version\": \"${{ env.RANCHER_VERSION }}\", \"workflow\": \"cluster-provisioning\", \"job\": \"v2-13\" }" > test-result-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
-        shell: bash
-
-      - name: Upload test result weekly summary
-        if: always() && github.event_name == 'schedule'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7
+        uses: ./.github/actions/save-weekly-summary-result
         with:
-          name: test-result-cluster-provisioning-v2-13-${{ github.run_id }}
-          path: test-result-cluster-provisioning-v2-13-${{ github.run_id }}-${{ github.run_attempt }}.json
+          rancher_version: ${{ env.UPGRADED_RANCHER_VERSION }}
+          workflow: turtles-feature-off-cluster-provisioning
+          job: v2-13

--- a/actions/kdm/verify.go
+++ b/actions/kdm/verify.go
@@ -1,0 +1,113 @@
+package kdm
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type Release struct {
+	Version string `json:"version"`
+}
+
+type DistroMetadata struct {
+	Releases []Release `json:"releases"`
+}
+
+type Metadata struct {
+	RKE2 DistroMetadata `json:"rke2"`
+	K3S  DistroMetadata `json:"k3s"`
+}
+
+// VerifyKDMUrl validates the KDM URL and returns Kubernetes versions.
+func VerifyKDMUrl(url, rancherVersion string) (map[string][]string, error) {
+	if strings.Contains(rancherVersion, "-alpha") || strings.Contains(rancherVersion, "-head") {
+		if !strings.Contains(url, "dev-v") {
+			return nil, fmt.Errorf("expected KDM URL to point to dev branch, url: %s", url)
+		}
+	} else {
+		if !strings.Contains(url, "release-v") {
+			return nil, fmt.Errorf("expected KDM URL to point to release branch, url: %s", url)
+		}
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading KDM response body: %w", err)
+	}
+
+	if len(body) == 0 {
+		return nil, fmt.Errorf("KDM response body is empty")
+	}
+
+	var meta Metadata
+	err = json.Unmarshal(body, &meta)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal KDM JSON: %w", err)
+	}
+
+	versions := make(map[string][]string)
+	for _, rel := range meta.RKE2.Releases {
+		if rel.Version != "" {
+			versions["rke2"] = append(versions["rke2"], rel.Version)
+		}
+	}
+
+	for _, rel := range meta.K3S.Releases {
+		if rel.Version != "" {
+			versions["k3s"] = append(versions["k3s"], rel.Version)
+		}
+	}
+
+	return versions, nil
+}
+
+// VerifyKDMVersions checks that the available Rancher Kubernetes versions are listed in the KDM version list
+func VerifyKDMVersions(kdmVersions map[string][]string, dropdownVersions []string, distro string) error {
+	var kdmList []string
+
+	switch {
+	case strings.Contains(distro, "rke2"):
+		kdmList = kdmVersions["rke2"]
+	case strings.Contains(distro, "k3s"):
+		kdmList = kdmVersions["k3s"]
+	default:
+		panic(fmt.Sprintf("Unsupported distro: %s", distro))
+	}
+
+	if len(kdmList) == 0 {
+		return fmt.Errorf("KDM version list for %s should not be empty", distro)
+	}
+
+	if len(dropdownVersions) == 0 {
+		return fmt.Errorf("Dropdown version list for %s should not be empty", distro)
+	}
+
+	for _, version := range dropdownVersions {
+		found := false
+		for _, kdmVersion := range kdmList {
+			if version == kdmVersion {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("%s dropdown version %s not found in KDM versions: %v", distro, version, kdmList)
+		}
+	}
+
+	return nil
+}

--- a/validation/kdm/defaults/defaults.yaml
+++ b/validation/kdm/defaults/defaults.yaml
@@ -1,0 +1,52 @@
+#Required for all tests
+rancher:
+  host: "<required>"
+  adminToken: "<required>"
+  insecure: true
+  cleanup: true
+
+#Required for all tests except template
+clusterConfig:
+  machinePools:
+  - machinePoolConfig:
+      etcd: true
+      controlplane: false
+      worker: false
+      quantity: 1
+  - machinePoolConfig:
+      etcd: false
+      controlplane: true
+      worker: false
+      quantity: 1
+  - machinePoolConfig:
+      etcd: false
+      controlplane: false
+      worker: true
+      quantity: 1
+  kubernetesVersion: ""
+  cni: "calico"
+  provider: "aws"
+  nodeProvider: "ec2"
+  hardened: false
+  compliance: false
+  psact: ""
+
+#Required for all tests except template
+awsCredentials:
+  secretKey: "<required>"
+  accessKey: "<required>"
+  defaultRegion: "us-east-2" 
+
+#Required for tests that utilize node driver clusters
+awsMachineConfigs:
+  region: "us-east-2"
+  awsMachineConfig:
+  - roles: ["etcd","controlplane","worker"]
+    ami: "<required>"
+    instanceType: "<required>"
+    volumeType: "<required>"
+    rootSize: "<required>"
+    sshUser: "<required>"
+    vpcId: "<required>"
+    zone: "a"
+    retries: "5"

--- a/validation/kdm/k3s/README.md
+++ b/validation/kdm/k3s/README.md
@@ -1,0 +1,53 @@
+# K3S KDM Configs
+
+## Table of Contents
+1. [Prerequisites](../README.md)
+2. [Tests Cases](#Test-Cases)
+3. [Configurations](#Configurations)
+4. [Configuration Defaults](#defaults)
+5. [Logging Levels](#Logging)
+6. [Back to general certificates](../README.md)
+
+## Test Cases
+All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
+
+### KDM Tests
+
+#### Description:
+The certificate test verifies that a cluster can rotate certificates.
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config) (with IPv6 settings)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `K3S_KDM`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/kdm/k3s --junitfile results.xml --jsonfile results.json -- -tags=kdm -run TestKDM -timeout=2h -v`
+
+## Configurations
+
+### Provisioning cluster
+This test will create a cluster if one is not provided, see to configure a node driver OR custom cluster depending on the certificate test [k3s provisioning](../../provisioning/k3s/README.md)
+
+## Defaults
+This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to: 
+1. Reduce the number of fields the user needs to provide in the cattle_config file. 
+2. Reduce the amount of yaml data that needs to be stored in our pipelines.
+3. Make it easier to run tests
+
+Any data the user provides will override these defaults which are stored here: [defaults](defaults/defaults.yaml). 
+
+## Logging
+This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 
+
+```yaml
+logging:
+   level: "trace" #trace debug, info, warning, error
+```
+
+## Additional
+1. If the tests passes immediately without warning, try adding the `-count=1` or run `go clean -cache`. This will avoid previous results from interfering with the new test run.
+2. All of the tests utilize parallelism when running for more finite control of how things are run in parallel use the -p and -parallel.

--- a/validation/kdm/k3s/kdm_test.go
+++ b/validation/kdm/k3s/kdm_test.go
@@ -1,0 +1,90 @@
+//go:build kdm
+
+package kdm
+
+import (
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/cloudcredentials"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	kdmTest "github.com/rancher/tests/validation/kdm"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKDM(t *testing.T) {
+	t.Parallel()
+
+	k := kdmTest.Setup(t, defaults.K3S)
+
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
+
+	tests := []struct {
+		name         string
+		machinePools []provisioninginput.MachinePools
+		client       *rancher.Client
+	}{
+		{"K3S_KDM", nodeRolesStandard, k.StandardUserClient},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Running cleanup (%s)", tt.name)
+			k.Session.Cleanup()
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clusterConfig := new(clusters.ClusterConfig)
+			operations.LoadObjectFromMap(defaults.ClusterConfigKey, k.CattleConfig, clusterConfig)
+			clusterConfig.MachinePools = tt.machinePools
+
+			require.NotNil(t, clusterConfig.Provider)
+
+			provider := provisioning.CreateProvider(clusterConfig.Provider)
+			credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
+			machineConfigSpec := provider.LoadMachineConfigFunc(k.CattleConfig)
+
+			logrus.Infof("Provisioning cluster")
+			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			err = pods.VerifyClusterPods(tt.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(tt.client, cluster.Name)
+			require.NoError(t, err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(k.Client, k.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/kdm/k3s/schemas/hostbusters_schemas.yaml
+++ b/validation/kdm/k3s/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,23 @@
+- suite: Go Automation/KDM/K3S
+  projects: [RRT, RM]
+  cases:
+  - description: Provisions a K3s node driver cluster
+    title: K3S_KDM
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Provision a K3s node driver cluster
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/kdm/rke2/README.md
+++ b/validation/kdm/rke2/README.md
@@ -1,0 +1,53 @@
+# RKE2 KDM Configs
+
+## Table of Contents
+1. [Prerequisites](../README.md)
+2. [Tests Cases](#Test-Cases)
+3. [Configurations](#Configurations)
+4. [Configuration Defaults](#defaults)
+5. [Logging Levels](#Logging)
+6. [Back to general certificates](../README.md)
+
+## Test Cases
+All of the test cases in this package are listed below, keep in mind that all configuration for these tests have built in defaults [Configuration Defaults](#defaults). These tests will provision a cluster if one is not provided via the rancher.ClusterName field.
+
+### KDM Tests
+
+#### Description:
+The certificate test verifies that a cluster can rotate certificates.
+
+#### Required Configurations:
+1. [Cloud Credential](#cloud-credential-config)
+2. [Cluster Config](#cluster-config) (with IPv6 settings)
+3. [Machine Config](#machine-config)
+
+#### Table Tests:
+1. `K3S_KDM`
+
+#### Run Commands:
+1. `gotestsum --format standard-verbose --packages=github.com/rancher/tests/validation/kdm/rke2 --junitfile results.xml --jsonfile results.json -- -tags=kdm -run TestKDM -timeout=2h -v`
+
+## Configurations
+
+### Provisioning cluster
+This test will create a cluster if one is not provided, see to configure a node driver OR custom cluster depending on the certificate test [rke2 provisioning](../../provisioning/k3s/README.md)
+
+## Defaults
+This package contains a defaults folder which contains default test configuration data for non-sensitive fields. The goal of this data is to: 
+1. Reduce the number of fields the user needs to provide in the cattle_config file. 
+2. Reduce the amount of yaml data that needs to be stored in our pipelines.
+3. Make it easier to run tests
+
+Any data the user provides will override these defaults which are stored here: [defaults](defaults/defaults.yaml). 
+
+## Logging
+This package supports several logging levels. You can set the logging levels via the cattle config and all levels above the provided level will be logged while all logs below that logging level will be omitted. 
+
+```yaml
+logging:
+   level: "trace" #trace debug, info, warning, error
+```
+
+## Additional
+1. If the tests passes immediately without warning, try adding the `-count=1` or run `go clean -cache`. This will avoid previous results from interfering with the new test run.
+2. All of the tests utilize parallelism when running for more finite control of how things are run in parallel use the -p and -parallel.

--- a/validation/kdm/rke2/kdm_test.go
+++ b/validation/kdm/rke2/kdm_test.go
@@ -1,0 +1,90 @@
+//go:build kdm
+
+package kdm
+
+import (
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/extensions/cloudcredentials"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/provisioninginput"
+	"github.com/rancher/tests/actions/qase"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
+	kdmTest "github.com/rancher/tests/validation/kdm"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKDM(t *testing.T) {
+	t.Parallel()
+
+	k := kdmTest.Setup(t, defaults.RKE2)
+
+	nodeRolesStandard := []provisioninginput.MachinePools{provisioninginput.EtcdMachinePool, provisioninginput.ControlPlaneMachinePool, provisioninginput.WorkerMachinePool}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
+
+	tests := []struct {
+		name         string
+		machinePools []provisioninginput.MachinePools
+		client       *rancher.Client
+	}{
+		{"RKE2_KDM", nodeRolesStandard, k.StandardUserClient},
+	}
+
+	for _, tt := range tests {
+		t.Cleanup(func() {
+			logrus.Infof("Running cleanup (%s)", tt.name)
+			k.Session.Cleanup()
+		})
+
+		var err error
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			clusterConfig := new(clusters.ClusterConfig)
+			operations.LoadObjectFromMap(defaults.ClusterConfigKey, k.CattleConfig, clusterConfig)
+			clusterConfig.MachinePools = tt.machinePools
+
+			require.NotNil(t, clusterConfig.Provider)
+
+			provider := provisioning.CreateProvider(clusterConfig.Provider)
+			credentialSpec := cloudcredentials.LoadCloudCredential(string(provider.Name))
+			machineConfigSpec := provider.LoadMachineConfigFunc(k.CattleConfig)
+
+			logrus.Infof("Provisioning cluster")
+			cluster, err := provisioning.CreateProvisioningCluster(tt.client, provider, credentialSpec, clusterConfig, machineConfigSpec, nil)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying the cluster is ready (%s)", cluster.Name)
+			err = provisioning.VerifyClusterReady(tt.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+			err = deployment.VerifyClusterDeployments(tt.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+			err = pods.VerifyClusterPods(tt.client, cluster)
+			require.NoError(t, err)
+
+			logrus.Infof("Verifying service account token secret (%s)", cluster.Name)
+			err = clusters.VerifyServiceAccountTokenSecret(tt.client, cluster.Name)
+			require.NoError(t, err)
+		})
+
+		params := provisioning.GetProvisioningSchemaParams(k.Client, k.CattleConfig)
+		err = qase.UpdateSchemaParameters(tt.name, params)
+		if err != nil {
+			logrus.Warningf("Failed to upload schema parameters %s", err)
+		}
+	}
+}

--- a/validation/kdm/rke2/schemas/hostbusters_schemas.yaml
+++ b/validation/kdm/rke2/schemas/hostbusters_schemas.yaml
@@ -1,0 +1,23 @@
+- suite: Go Automation/KDM/RKE2
+  projects: [RRT, RM]
+  cases:
+  - description: Provisions an RKE2 node driver cluster
+    title: RKE2_KDM
+    priority: 4
+    type: 8
+    is_flaky: 0
+    automation: 2
+    steps:
+    - action: Provision an RKE2 node driver cluster
+      expectedresult: ""
+      data: ""
+      position: 1
+      attachments: []
+    - action: Verify cluster state
+      expectedresult: ""
+      data: ""
+      position: 2
+      attachments: []
+    custom_field:
+      "14": Validation
+      "18": Hostbusters

--- a/validation/kdm/setup.go
+++ b/validation/kdm/setup.go
@@ -1,0 +1,109 @@
+package kdm
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/extensions/clusters/kubernetesversions"
+	"github.com/rancher/shepherd/pkg/config"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	"github.com/rancher/shepherd/pkg/session"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/kdm"
+	"github.com/rancher/tests/actions/logging"
+	standard "github.com/rancher/tests/validation/provisioning/resources/standarduser"
+	tfpConfig "github.com/rancher/tfp-automation/config"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type kdmTest struct {
+	suite.Suite
+	Session            *session.Session
+	Client             *rancher.Client
+	StandardUserClient *rancher.Client
+	CattleConfig       map[string]any
+	ClusterConfig      *clusters.ClusterConfig
+	rancherConfig      *rancher.Config
+	Cluster            *v1.SteveAPIObject
+}
+
+func Setup(t *testing.T, clusterType string) *kdmTest {
+	k := &kdmTest{}
+
+	testSession := session.NewSession()
+	k.Session = testSession
+
+	client, err := rancher.NewClient("", testSession)
+	require.NoError(t, err)
+
+	k.Client = client
+
+	standardUserClient, _, _, err := standard.CreateStandardUser(k.Client)
+	require.NoError(t, err)
+
+	k.StandardUserClient = standardUserClient
+
+	k.CattleConfig = config.LoadConfigFromFile(os.Getenv(config.ConfigEnvironmentKey))
+	_, _, _, standaloneConfig := tfpConfig.LoadTFPConfigs(k.CattleConfig)
+
+	k.CattleConfig, err = defaults.LoadPackageDefaults(k.CattleConfig, "")
+	require.NoError(t, err)
+
+	setting, err := client.Management.Setting.ByID("rke-metadata-config")
+	require.NoError(t, err)
+
+	rawKDM := setting.Value
+
+	if strings.HasPrefix(rawKDM, "{") {
+		var m map[string]string
+
+		err := json.Unmarshal([]byte(rawKDM), &m)
+		require.NoError(t, err)
+
+		rawKDM = m["url"]
+	}
+
+	kdmURL := rawKDM
+
+	kdmVersions, err := kdm.VerifyKDMUrl(kdmURL, standaloneConfig.RancherTagVersion)
+	require.NoError(t, err)
+
+	rke2Versions, err := kubernetesversions.ListRKE2AllVersions(k.Client)
+	require.NoError(t, err)
+
+	k3sVersions, err := kubernetesversions.ListK3SAllVersions(k.Client)
+	require.NoError(t, err)
+
+	err = kdm.VerifyKDMVersions(kdmVersions, rke2Versions, defaults.RKE2)
+	require.NoError(t, err)
+
+	err = kdm.VerifyKDMVersions(kdmVersions, k3sVersions, defaults.K3S)
+	require.NoError(t, err)
+
+	loggingConfig := new(logging.Logging)
+	operations.LoadObjectFromMap(logging.LoggingKey, k.CattleConfig, loggingConfig)
+
+	err = logging.SetLogger(loggingConfig)
+	require.NoError(t, err)
+
+	k.CattleConfig, err = defaults.SetK8sDefault(k.Client, clusterType, k.CattleConfig)
+	require.NoError(t, err)
+
+	clusterConfig := new(clusters.ClusterConfig)
+	operations.LoadObjectFromMap(defaults.ClusterConfigKey, k.CattleConfig, clusterConfig)
+
+	k.ClusterConfig = clusterConfig
+
+	rancherConfig := new(rancher.Config)
+	operations.LoadObjectFromMap(defaults.RancherConfigKey, k.CattleConfig, rancherConfig)
+
+	k.rancherConfig = rancherConfig
+
+	return k
+}

--- a/validation/recurring/infrastructure/upgraderancher/clusters/preupgradeclusters.go
+++ b/validation/recurring/infrastructure/upgraderancher/clusters/preupgradeclusters.go
@@ -1,0 +1,114 @@
+package clusters
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/rancher/shepherd/clients/ec2"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/pkg/config/operations"
+	"github.com/rancher/tests/actions/clusters"
+	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/provisioning"
+	"github.com/rancher/tests/actions/provisioninginput"
+	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
+	tfpConfig "github.com/rancher/tfp-automation/config"
+	tfpCustom "github.com/rancher/tfp-automation/tests/infrastructure/downstream/custom"
+	tfpImported "github.com/rancher/tfp-automation/tests/infrastructure/downstream/imported"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// ProvisionClustersPreUpgrade is a helper function to provision clusters before upgrading Rancher.
+func ProvisionClustersPreUpgrade(t *testing.T, client *rancher.Client, cattleConfig map[string]any) {
+	clusterConfig := new(clusters.ClusterConfig)
+	operations.LoadObjectFromMap(defaults.ClusterConfigKey, cattleConfig, clusterConfig)
+
+	provider := provisioning.CreateProvider(clusterConfig.Provider)
+	machineConfigSpec := provider.LoadMachineConfigFunc(cattleConfig)
+
+	awsEC2Configs := new(ec2.AWSEC2Configs)
+	operations.LoadObjectFromMap(ec2.ConfigurationFileKey, cattleConfig, awsEC2Configs)
+
+	nodeRolesStandard := []provisioninginput.MachinePools{
+		provisioninginput.EtcdMachinePool,
+		provisioninginput.ControlPlaneMachinePool,
+		provisioninginput.WorkerMachinePool,
+	}
+
+	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
+	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
+	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
+
+	rancher, terraform, terratest, _ := tfpConfig.LoadTFPConfigs(cattleConfig)
+
+	clusterConfig.MachinePools = nodeRolesStandard
+
+	customNodepoolsRKE2 := []tfpConfig.Nodepool{{Quantity: 1, Etcd: true}, {Quantity: 1, Controlplane: true}, {Quantity: 1, Worker: true}}
+	customNodepoolsK3S := []tfpConfig.Nodepool{{Quantity: 1, Etcd: true}, {Quantity: 1, Controlplane: true}, {Quantity: 1, Worker: true}}
+	importedNodepools := []tfpConfig.Nodepool{{Quantity: 3, Etcd: true}, {Quantity: 2, Controlplane: true}, {Quantity: 3, Worker: true}}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var errs []error
+
+	addErr := func(err error) {
+		mu.Lock()
+		errs = append(errs, err)
+		mu.Unlock()
+	}
+
+	for _, clusterType := range []string{defaults.RKE2, defaults.K3S} {
+		clusterType := clusterType
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			logrus.Infof("Provisioning %s node driver cluster", clusterType)
+			_, err := resources.ProvisionRKE2K3SCluster(t, client, clusterType, provider, *clusterConfig, machineConfigSpec, nil, true, false)
+			if err != nil {
+				addErr(fmt.Errorf("%s node driver: %w", clusterType, err))
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			terraformCustom := *terraform
+			terratestCustom := *terratest
+
+			if clusterType == defaults.RKE2 {
+				terratestCustom.Nodepools = customNodepoolsRKE2
+			} else {
+				terratestCustom.Nodepools = customNodepoolsK3S
+			}
+
+			logrus.Infof("Provisioning %s custom cluster", clusterType)
+			_, _, _, customCluster := tfpCustom.CreateCustomCluster(t, client, rancher, &terraformCustom, &terratestCustom, clusterType, "validation/provisioning/"+clusterType, false)
+			if err := provisioning.VerifyClusterReady(client, customCluster); err != nil {
+				addErr(fmt.Errorf("%s custom: %w", clusterType, err))
+			}
+		}()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			terraformImported := *terraform
+			terratestImported := *terratest
+			terratestImported.Nodepools = importedNodepools
+
+			logrus.Infof("Provisioning %s imported cluster", clusterType)
+			_, _, _, importedCluster := tfpImported.CreateImportedCluster(t, client, rancher, &terraformImported, &terratestImported, clusterType, "validation/provisioning/"+clusterType)
+			if err := provisioning.VerifyClusterReadyV3(client, importedCluster.Name); err != nil {
+				addErr(fmt.Errorf("%s imported: %w", clusterType, err))
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+}

--- a/validation/recurring/infrastructure/upgraderancher/dualstack/main.go
+++ b/validation/recurring/infrastructure/upgraderancher/dualstack/main.go
@@ -6,16 +6,21 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/pkg/config"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
 	infraConfig "github.com/rancher/tests/validation/recurring/infrastructure/config"
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	setupdualstack "github.com/rancher/tfp-automation/tests/infrastructure/ranchers/setup/dualstack"
 	upgradedualstack "github.com/rancher/tfp-automation/tests/infrastructure/ranchers/upgrade/dualstack"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
 func main() {
@@ -34,9 +39,29 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("Failed to load package defaults: %v", err)
 	}
+
 	testSession := session.NewSession()
 
 	client, serverNodeOne, _, _, cattleConfig := setupdualstack.SetupDualStackRancher(t, testSession, keypath.DualStackKeyPath, cattleConfig)
+
+	cattleConfig, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, client.RancherConfig.AdminToken, cattleConfig)
+	if err != nil {
+		logrus.Fatalf("Failed to replace admin token: %v", err)
+	}
+
+	infraConfig.WriteConfigToFile(os.Getenv(config.ConfigEnvironmentKey), cattleConfig)
+
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
+
 	client, _, _, _ = upgradedualstack.UpgradeDualStackRancher(t, client, serverNodeOne, testSession, cattleConfig)
 
 	cattleConfig, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, client.RancherConfig.AdminToken, cattleConfig)
@@ -45,4 +70,12 @@ func main() {
 	}
 
 	infraConfig.WriteConfigToFile(os.Getenv(config.ConfigEnvironmentKey), cattleConfig)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
 }

--- a/validation/recurring/infrastructure/upgraderancher/ipv6/main.go
+++ b/validation/recurring/infrastructure/upgraderancher/ipv6/main.go
@@ -6,16 +6,21 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/pkg/config"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
 	infraConfig "github.com/rancher/tests/validation/recurring/infrastructure/config"
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	setupipv6 "github.com/rancher/tfp-automation/tests/infrastructure/ranchers/setup/ipv6"
 	upgradeipv6 "github.com/rancher/tfp-automation/tests/infrastructure/ranchers/upgrade/ipv6"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
 func main() {
@@ -37,6 +42,27 @@ func main() {
 	testSession := session.NewSession()
 
 	client, serverNodeOne, _, _, cattleConfig := setupipv6.SetupIPv6Rancher(t, testSession, keypath.IPv6KeyPath, cattleConfig)
+
+	cattleConfig, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, client.RancherConfig.AdminToken, cattleConfig)
+	if err != nil {
+		logrus.Fatalf("Failed to replace admin token: %v", err)
+	}
+
+	infraConfig.WriteConfigToFile(os.Getenv(config.ConfigEnvironmentKey), cattleConfig)
+
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
+
+	infraConfig.WriteConfigToFile(os.Getenv(config.ConfigEnvironmentKey), cattleConfig)
+
 	client, _, _, _ = upgradeipv6.UpgradeIPv6Rancher(t, client, serverNodeOne, testSession, cattleConfig)
 
 	cattleConfig, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, client.RancherConfig.AdminToken, cattleConfig)
@@ -45,4 +71,12 @@ func main() {
 	}
 
 	infraConfig.WriteConfigToFile(os.Getenv(config.ConfigEnvironmentKey), cattleConfig)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
 }

--- a/validation/recurring/infrastructure/upgraderancher/proxy/main.go
+++ b/validation/recurring/infrastructure/upgraderancher/proxy/main.go
@@ -6,16 +6,21 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/rancher/shepherd/extensions/defaults/namespaces"
+	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/pkg/config"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
 	"github.com/rancher/tests/actions/config/defaults"
+	"github.com/rancher/tests/actions/workloads/deployment"
+	"github.com/rancher/tests/actions/workloads/pods"
 	infraConfig "github.com/rancher/tests/validation/recurring/infrastructure/config"
 	"github.com/rancher/tfp-automation/defaults/keypath"
 	setupproxy "github.com/rancher/tfp-automation/tests/infrastructure/ranchers/setup/proxy"
 	upgradeproxy "github.com/rancher/tfp-automation/tests/infrastructure/ranchers/upgrade/proxy"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
 )
 
 func main() {
@@ -37,6 +42,25 @@ func main() {
 	testSession := session.NewSession()
 
 	client, proxyBastion, proxyPrivateIP, _, _, cattleConfig := setupproxy.SetupProxyRancher(t, testSession, keypath.ProxyKeyPath, cattleConfig)
+
+	cattleConfig, err = operations.ReplaceValue([]string{"rancher", "adminToken"}, client.RancherConfig.AdminToken, cattleConfig)
+	if err != nil {
+		logrus.Fatalf("Failed to replace admin token: %v", err)
+	}
+
+	infraConfig.WriteConfigToFile(os.Getenv(config.ConfigEnvironmentKey), cattleConfig)
+
+	cluster, err := client.Steve.SteveType(stevetypes.Provisioning).ByID(namespaces.FleetLocal + "/local")
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
+
 	client, _, _, _ = upgradeproxy.UpgradeProxyRancher(t, client, proxyPrivateIP, proxyBastion, testSession, cattleConfig)
 
 	cattleConfig, err = operations.ReplaceValue([]string{"terraform", "proxy", "proxyBastion"}, proxyBastion, cattleConfig)
@@ -53,4 +77,12 @@ func main() {
 	}
 
 	infraConfig.WriteConfigToFile(os.Getenv(config.ConfigEnvironmentKey), cattleConfig)
+
+	logrus.Infof("Verifying cluster deployments (%s)", cluster.Name)
+	err = deployment.VerifyClusterDeployments(client, cluster)
+	require.NoError(t, err)
+
+	logrus.Infof("Verifying cluster pods (%s)", cluster.Name)
+	err = pods.VerifyClusterPods(client, cluster)
+	require.NoError(t, err)
 }

--- a/validation/recurring/infrastructure/upgraderancher/standard/main.go
+++ b/validation/recurring/infrastructure/upgraderancher/standard/main.go
@@ -1,34 +1,26 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
-	"sync"
 	"testing"
 
 	"github.com/rancher/shepherd/clients/ec2"
-	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/defaults/namespaces"
 	"github.com/rancher/shepherd/extensions/defaults/stevetypes"
 	"github.com/rancher/shepherd/pkg/config"
 	shepherdConfig "github.com/rancher/shepherd/pkg/config"
 	"github.com/rancher/shepherd/pkg/config/operations"
 	"github.com/rancher/shepherd/pkg/session"
-	"github.com/rancher/tests/actions/clusters"
 	"github.com/rancher/tests/actions/config/defaults"
-	"github.com/rancher/tests/actions/provisioning"
-	"github.com/rancher/tests/actions/provisioninginput"
 	"github.com/rancher/tests/actions/workloads/deployment"
 	"github.com/rancher/tests/actions/workloads/pods"
-	resources "github.com/rancher/tests/validation/provisioning/resources/provisioncluster"
 	infraConfig "github.com/rancher/tests/validation/recurring/infrastructure/config"
+	"github.com/rancher/tests/validation/recurring/infrastructure/upgraderancher/clusters"
 	"github.com/rancher/tests/validation/recurring/infrastructure/upgraderancher/localcluster"
 	tfpConfig "github.com/rancher/tfp-automation/config"
 	"github.com/rancher/tfp-automation/defaults/keypath"
-	tfpCustom "github.com/rancher/tfp-automation/tests/infrastructure/downstream/custom"
-	tfpImported "github.com/rancher/tfp-automation/tests/infrastructure/downstream/imported"
 	setupstandard "github.com/rancher/tfp-automation/tests/infrastructure/ranchers/setup/standard"
 	upgradestandard "github.com/rancher/tfp-automation/tests/infrastructure/ranchers/upgrade/standard"
 	"github.com/sirupsen/logrus"
@@ -77,7 +69,7 @@ func main() {
 	// If awsEC2Configs is present in the cattleConfig, provision clusters before upgrading Rancher.
 	// If it is not present, skip provisioning clusters and proceed with upgrading Rancher.
 	if _, ok := cattleConfig[ec2.ConfigurationFileKey]; ok {
-		provisionClustersPreUpgrade(t, client, cattleConfig)
+		clusters.ProvisionClustersPreUpgrade(t, client, cattleConfig)
 	}
 
 	client, _, _, _ = upgradestandard.UpgradeRancher(t, client, serverNodeOne, testSession, cattleConfig)
@@ -101,98 +93,6 @@ func main() {
 
 	if standalone.UpgradeLocalCluster {
 		err = localcluster.UpgradeLocalCluster(client, terraform)
-		require.NoError(t, err)
-	}
-}
-
-func provisionClustersPreUpgrade(t *testing.T, client *rancher.Client, cattleConfig map[string]any) {
-	clusterConfig := new(clusters.ClusterConfig)
-	operations.LoadObjectFromMap(defaults.ClusterConfigKey, cattleConfig, clusterConfig)
-
-	provider := provisioning.CreateProvider(clusterConfig.Provider)
-	machineConfigSpec := provider.LoadMachineConfigFunc(cattleConfig)
-
-	awsEC2Configs := new(ec2.AWSEC2Configs)
-	operations.LoadObjectFromMap(ec2.ConfigurationFileKey, cattleConfig, awsEC2Configs)
-
-	nodeRolesStandard := []provisioninginput.MachinePools{
-		provisioninginput.EtcdMachinePool,
-		provisioninginput.ControlPlaneMachinePool,
-		provisioninginput.WorkerMachinePool,
-	}
-
-	nodeRolesStandard[0].MachinePoolConfig.Quantity = 3
-	nodeRolesStandard[1].MachinePoolConfig.Quantity = 2
-	nodeRolesStandard[2].MachinePoolConfig.Quantity = 3
-
-	rancher, terraform, terratest, _ := tfpConfig.LoadTFPConfigs(cattleConfig)
-
-	clusterConfig.MachinePools = nodeRolesStandard
-
-	customNodepoolsRKE2 := []tfpConfig.Nodepool{{Quantity: 1, Etcd: true}, {Quantity: 1, Controlplane: true}, {Quantity: 1, Worker: true}, {Quantity: 1, Windows: true}}
-	customNodepoolsK3S := []tfpConfig.Nodepool{{Quantity: 1, Etcd: true}, {Quantity: 1, Controlplane: true}, {Quantity: 1, Worker: true}}
-	importedNodepools := []tfpConfig.Nodepool{{Quantity: 3, Etcd: true}, {Quantity: 2, Controlplane: true}, {Quantity: 3, Worker: true}}
-
-	var wg sync.WaitGroup
-	var mu sync.Mutex
-	var errs []error
-
-	addErr := func(err error) {
-		mu.Lock()
-		errs = append(errs, err)
-		mu.Unlock()
-	}
-
-	for _, clusterType := range []string{defaults.RKE2, defaults.K3S} {
-		clusterType := clusterType
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			logrus.Infof("Provisioning %s node driver cluster", clusterType)
-			_, err := resources.ProvisionRKE2K3SCluster(t, client, clusterType, provider, *clusterConfig, machineConfigSpec, nil, true, false)
-			if err != nil {
-				addErr(fmt.Errorf("%s node driver: %w", clusterType, err))
-			}
-		}()
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			terraformCustom := *terraform
-			terratestCustom := *terratest
-
-			if clusterType == defaults.RKE2 {
-				terratestCustom.Nodepools = customNodepoolsRKE2
-			} else {
-				terratestCustom.Nodepools = customNodepoolsK3S
-			}
-
-			logrus.Infof("Provisioning %s custom cluster", clusterType)
-			_, _, _, customCluster := tfpCustom.CreateCustomCluster(t, client, rancher, &terraformCustom, &terratestCustom, clusterType, "validation/provisioning/"+clusterType, false)
-			if err := provisioning.VerifyClusterReady(client, customCluster); err != nil {
-				addErr(fmt.Errorf("%s custom: %w", clusterType, err))
-			}
-		}()
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			terraformImported := *terraform
-			terratestImported := *terratest
-			terratestImported.Nodepools = importedNodepools
-
-			logrus.Infof("Provisioning %s imported cluster", clusterType)
-			_, _, _, importedCluster := tfpImported.CreateImportedCluster(t, client, rancher, &terraformImported, &terratestImported, clusterType, "validation/provisioning/"+clusterType)
-			if err := provisioning.VerifyClusterReadyV3(client, importedCluster.Name); err != nil {
-				addErr(fmt.Errorf("%s imported: %w", clusterType, err))
-			}
-		}()
-	}
-
-	wg.Wait()
-
-	for _, err := range errs {
 		require.NoError(t, err)
 	}
 }


### PR DESCRIPTION
This PR migrates the KDM, MCM feature-disabled, dual-stack, and IPv6 upgrade workflows from `rancher/tfp-automation` to `rancher/tests`.
The change consolidates these upgrade workflows into the `rancher/tests` repository so they can be maintained and executed alongside the rest of the test suite.